### PR TITLE
fix: cross-device moves

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ cd zpm && ./yarn.sh berry test:integration
 ```
 
 > [!NOTE]
-> You can set the `BERRY_PATH` environment variable to a pre-existing clone of the `berry` repository to avoid cloning it again.
+> You can set the `BERRY_DIR` environment variable to a pre-existing clone of the `berry` repository to avoid cloning it again.
 
 ## Differences in architecture
 

--- a/packages/zpm-switch/src/install.rs
+++ b/packages/zpm-switch/src/install.rs
@@ -40,7 +40,7 @@ async fn cache<T: Serialize, R: Future<Output = Result<(), Error>>, F: FnOnce(Pa
             .fs_create_parent()?;
 
         temp_dir
-            .fs_rename(&cache_path)?;
+            .fs_move(&cache_path)?;
     }
 
     Ok(cache_path)

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,1 @@
+disable_all_formatting = true


### PR DESCRIPTION
`zpm-switch` is doing a `rename` that doesn't work across different filesystems.
In my case, it throws because it's trying to move a folder from `/tmp` to `/home/paul`, which are separate filesystems.

I implemented `fs_move` inside of `zpm-utils/path`, which first tries to rename and then falls back on doing a copy and removing the source.

Note: I also added a `rustfmt.toml` file to disable formatting (tho it would be nice if we could have it enabled :smiling_face_with_tear:) and I also changed `BERRY_PATH` -> `BERRY_DIR` in the README to match the variable used in the manifest.