### PR TITLE
Fixes "resolutions" field traversal order

### DIFF
--- a/packages/zpm/src/install.rs
+++ b/packages/zpm/src/install.rs
@@ -690,10 +690,14 @@ impl<'a> InstallManager<'a> {
 
 fn normalize_resolution(context: &InstallContext<'_>, descriptor: &mut Descriptor, resolution: &Resolution, apply_overrides: bool) -> () {
     if apply_overrides {
-        let possible_resolution_overrides = context.project
-            .and_then(|project| project.resolution_overrides(&descriptor.ident));
+        let candidate_resolutions = context.project
+            .expect("The project is required to normalize resolutions, as it may be impacted by the project's overrides")
+            .root_workspace()
+            .manifest
+            .resolutions
+            .get_by_ident(&descriptor.ident);
 
-        let resolution_override = possible_resolution_overrides
+        let resolution_override = candidate_resolutions
             .and_then(|overrides| {
                 overrides.iter().find_map(|(rule, range)| {
                     rule.apply(&resolution.locator, &resolution.version, descriptor, range)

--- a/packages/zpm/src/manifest/mod.rs
+++ b/packages/zpm/src/manifest/mod.rs
@@ -8,10 +8,10 @@ use bin::BinField;
 use bincode::{Decode, Encode};
 use exports::ExportsField;
 use imports::ImportsField;
-use resolutions::ResolutionSelector;
+use resolutions::ResolutionsField;
 use serde::{Deserialize, Serialize};
 
-use crate::{primitives::{descriptor::{descriptor_map_deserializer, descriptor_map_serializer}, Descriptor, Ident, PeerRange, Range}, system};
+use crate::{primitives::{descriptor::{descriptor_map_deserializer, descriptor_map_serializer}, Descriptor, Ident, PeerRange}, system};
 
 pub mod bin;
 pub mod browser;
@@ -171,8 +171,8 @@ pub struct Manifest {
     pub scripts: BTreeMap<String, String>,
 
     #[serde(default)]
-    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
-    pub resolutions: BTreeMap<ResolutionSelector, Range>,
+    #[serde(skip_serializing_if = "ResolutionsField::is_empty")]
+    pub resolutions: ResolutionsField,
 }
 
 impl Manifest {

--- a/packages/zpm/src/project.rs
+++ b/packages/zpm/src/project.rs
@@ -31,7 +31,6 @@ pub struct Project {
     pub workspaces: Vec<Workspace>,
     pub workspaces_by_ident: BTreeMap<Ident, usize>,
     pub workspaces_by_rel_path: BTreeMap<Path, usize>,
-    pub resolution_overrides: BTreeMap<Ident, Vec<(ResolutionSelector, Range)>>,
 
     pub last_changed_at: u128,
     pub install_state: Option<InstallState>,
@@ -92,15 +91,6 @@ impl Project {
         let (mut workspaces, last_changed_at) = root_workspace
             .workspaces().await?;
 
-        let mut resolutions_overrides: BTreeMap<Ident, Vec<(ResolutionSelector, Range)>>
-            = BTreeMap::new();
-
-        for (resolution, range) in &root_workspace.manifest.resolutions {
-            resolutions_overrides.entry(resolution.target_ident().clone())
-               .or_default()
-               .push((resolution.clone(), range.clone()));
-        }
-
         // Add root workspace to the beginning
         workspaces.insert(0, root_workspace);
 
@@ -124,7 +114,6 @@ impl Project {
             workspaces,
             workspaces_by_ident,
             workspaces_by_rel_path,
-            resolution_overrides: resolutions_overrides,
 
             last_changed_at,
             install_state: None,
@@ -188,10 +177,6 @@ impl Project {
         }
 
         Ok(sonic_rs::from_str(&src)?)
-    }
-
-    pub fn resolution_overrides(&self, ident: &Ident) -> Option<&Vec<(ResolutionSelector, Range)>> {
-        self.resolution_overrides.get(ident)
     }
 
     #[track_time]


### PR DESCRIPTION
Yarn Berry traverses the `resolutions` field in insertion order and [stops on the first match](https://github.com/yarnpkg/berry/blob/master/packages/yarnpkg-core/sources/CorePlugin.ts#L11-L52). Because the code here used BTreeMap, the traversal order was different and could lead to different overrides being picked in the event multiple ones were conflicting.

I fixed that by replacing the BTreeMap with a struct that implements a custom serialize / deserialize function. This also let me remove the code in `Project` that was performing some by-descriptor-ident indexing, as it's now moved into the custom struct.