### PR TITLE
Updates the default value for pnpFallbackMode

### DIFF
--- a/packages/zpm/src/settings.rs
+++ b/packages/zpm/src/settings.rs
@@ -165,7 +165,7 @@ pub struct ProjectConfig {
     #[default(true)]
     pub pnp_enable_inlining: BoolField,
 
-    #[default(PnpFallbackMode::All)]
+    #[default(PnpFallbackMode::DependenciesOnly)]
     pub pnp_fallback_mode: EnumField<PnpFallbackMode>,
 
     #[default(vec![])]


### PR DESCRIPTION
The `pnpFallbackMode` currently defaults to `all` when it should instead default to `dependencies-only` (see in [Berry](https://github.com/yarnpkg/berry/blob/master/packages/plugin-pnp/sources/index.ts#L148)).