### PR TITLE
Removes the PnP hooks from the environment before adding it back

### DIFF
--- a/packages/zpm/src/script.rs
+++ b/packages/zpm/src/script.rs
@@ -491,11 +491,11 @@ impl ScriptEnvironment {
 
         cmd.current_dir(self.cwd.to_path_buf());
 
+        cmd.envs(self.env.iter());
+
         for key in &self.deleted_env {
             cmd.env_remove(key);
         }
-
-        cmd.envs(self.env.iter());
 
         let bin_dir
             = self.install_binaries().unwrap();


### PR DESCRIPTION
If we don't remove the hook we run the risk of adding multiple hooks into the same runtime when a project starts a script located in another project, causing issues w/ the global cache.