### PR TITLE
Cleans up the env tracking

### DIFF
--- a/packages/zpm/src/script.rs
+++ b/packages/zpm/src/script.rs
@@ -507,13 +507,18 @@ impl ScriptEnvironment {
             = self.install_binaries().unwrap();
 
         let env_path = self.env.get("PATH")
-            .and_then(|opt| opt.clone())
-            .or_else(|| std::env::var("PATH").ok())
+            .cloned()
+            .unwrap_or_else(|| std::env::var("PATH").ok())
             .unwrap_or_default();
 
         let next_env_path = match env_path.is_empty() {
-            true => bin_dir.to_file_string(),
-            false => format!("{}:{}", bin_dir.to_file_string(), env_path),
+            true => {
+                bin_dir.to_file_string()
+            },
+
+            false => {
+                format!("{}:{}", bin_dir.to_file_string(), env_path)
+            },
         };
 
         cmd.env("PATH", next_env_path);


### PR DESCRIPTION
Tracking the updated environment variables and deleted environment variables in different fields was unnecessary and caused the code to be hard to read. I updated that to instead use an `Option<String>` as value, where `None` means the value should be deleted.