### PR TITLE
Check yarn run script preference

### DIFF
--- a/packages/zpm/src/commands/run.rs
+++ b/packages/zpm/src/commands/run.rs
@@ -36,7 +36,8 @@ impl Run {
             project.package_cwd = Path::new();
         }
 
-        let maybe_script = project.find_script(&self.name);
+        let maybe_script
+            = project.find_script(&self.name);
 
         if let Ok((locator, script)) = maybe_script {
             Ok(ScriptEnvironment::new()?
@@ -47,7 +48,8 @@ impl Run {
                 .await
                 .into())
         } else if let Err(Error::ScriptNotFound(_)) = maybe_script {
-            let maybe_binary = project.find_binary(&self.name);
+            let maybe_binary
+                = project.find_binary(&self.name);
 
             if let Ok(binary) = maybe_binary {
                 Ok(ScriptEnvironment::new()?


### PR DESCRIPTION
Switch `yarn run` command to prefer scripts over binaries.

The previous implementation in `run.rs` incorrectly checked for binaries first, leading to unexpected behavior where a binary would execute even if a script with the same name existed. This change aligns `yarn run` with official Yarn documentation and user expectations.