### PR TITLE
Fixes a couple of issues

### DIFF
--- a/packages/zpm-formats/src/lib.rs
+++ b/packages/zpm-formats/src/lib.rs
@@ -14,7 +14,7 @@ pub mod zip;
 
 pub use error::Error;
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct Entry<'a> {
     pub name: String,
     pub mode: u32,

--- a/packages/zpm/src/commands/run.rs
+++ b/packages/zpm/src/commands/run.rs
@@ -47,7 +47,7 @@ impl Run {
                 .run_script(&script, &self.args)
                 .await
                 .into())
-        } else if let Err(Error::ScriptNotFound(_)) = maybe_script {
+        } else if matches!(maybe_script, Err(Error::ScriptNotFound(_)) | Err(Error::GlobalScriptNotFound(_))) {
             let maybe_binary
                 = project.find_binary(&self.name);
 

--- a/packages/zpm/src/install.rs
+++ b/packages/zpm/src/install.rs
@@ -719,6 +719,13 @@ fn normalize_resolution(context: &InstallContext<'_>, descriptor: &mut Descripto
         } else if descriptor.range.must_bind() {
             descriptor.parent = Some(resolution.locator.clone());
         }
+
+        if has_builtin_patch(&descriptor.ident) {
+            descriptor.range = range::PatchRange {
+                inner: Box::new(UrlEncoded::new(descriptor.clone())),
+                path: "<builtin>".to_string(),
+            }.into();
+        }
     }
 
     match &mut descriptor.range {
@@ -736,13 +743,6 @@ fn normalize_resolution(context: &InstallContext<'_>, descriptor: &mut Descripto
 
         _ => {},
     };
-
-    if has_builtin_patch(&descriptor.ident) {
-        descriptor.range = range::PatchRange {
-            inner: Box::new(UrlEncoded::new(descriptor.clone())),
-            path: "<builtin>".to_string(),
-        }.into();
-    }
 }
 
 const BUILTIN_EXTENSIONS_JSON: &str = include_str!("../data/builtin-extensions.json");


### PR DESCRIPTION
Three issues:

- We forgot to account for global scripts errors when performing the fallback binary lookup, so running `yarn foo:bar` would fail if there isn't a `foo:bar` script, even if there is a `foo:bar` binary.

- The builtin patches should be allowed to fail, in which case we should fallback to the original package content.

- Builtin dependencies should only be applied once, at the top of the dependency normalization process.