### PR TITLE
Fixes content flags extraction for link: dependencies

### DIFF
--- a/packages/zpm/src/content_flags.rs
+++ b/packages/zpm/src/content_flags.rs
@@ -75,7 +75,7 @@ struct Manifest {
 impl ContentFlags {
     pub fn extract(locator: &Locator, package_data: &PackageData) -> Result<Self, Error> {
         match package_data {
-            PackageData::Local {package_directory, discard_from_lookup} if !discard_from_lookup => {
+            PackageData::Local {package_directory, is_synthetic_package} if !is_synthetic_package => {
                 Self::extract_local(package_directory)
             },
 

--- a/packages/zpm/src/fetchers/link.rs
+++ b/packages/zpm/src/fetchers/link.rs
@@ -13,7 +13,7 @@ pub fn fetch_locator(_context: &InstallContext, _locator: &Locator, params: &ref
         resolution: None,
         package_data: PackageData::Local {
             package_directory,
-            discard_from_lookup: true,
+            is_synthetic_package: true,
         },
     })
 }

--- a/packages/zpm/src/fetchers/mod.rs
+++ b/packages/zpm/src/fetchers/mod.rs
@@ -26,7 +26,8 @@ pub enum PackageData {
         /** Directory that contains the package.json file */
         package_directory: Path,
 
-        discard_from_lookup: bool,
+        /** Whether the package is a synthetic package, ie an arbitrary folder that is used as a package */
+        is_synthetic_package: bool,
     },
 
     MissingZip {

--- a/packages/zpm/src/fetchers/portal.rs
+++ b/packages/zpm/src/fetchers/portal.rs
@@ -13,7 +13,7 @@ pub fn fetch_locator(_context: &InstallContext, _locator: &Locator, params: &ref
         resolution: None,
         package_data: PackageData::Local {
             package_directory,
-            discard_from_lookup: false,
+            is_synthetic_package: false,
         },
     })
 }

--- a/packages/zpm/src/fetchers/workspace.rs
+++ b/packages/zpm/src/fetchers/workspace.rs
@@ -11,7 +11,7 @@ pub fn fetch_locator_ident(context: &InstallContext, _locator: &Locator, params:
 
     Ok(FetchResult::new(PackageData::Local {
         package_directory: workspace.path.clone(),
-        discard_from_lookup: false,
+        is_synthetic_package: false,
     }))
 }
 
@@ -24,6 +24,6 @@ pub fn fetch_locator_path(context: &InstallContext, _locator: &Locator, params: 
 
     Ok(FetchResult::new(PackageData::Local {
         package_directory: workspace.path.clone(),
-        discard_from_lookup: false,
+        is_synthetic_package: false,
     }))
 }

--- a/packages/zpm/src/linker/pnp.rs
+++ b/packages/zpm/src/linker/pnp.rs
@@ -223,7 +223,7 @@ pub async fn link_project_pnp<'a>(project: &'a mut Project, install: &'a mut Ins
         }
 
         let discard_from_lookup = match physical_package_data {
-            PackageData::Local {discard_from_lookup, ..} => *discard_from_lookup,
+            PackageData::Local {is_synthetic_package, ..} => *is_synthetic_package,
             _ => false,
         };
 


### PR DESCRIPTION
Content flags are extracted by looking at the package.json from disk. But what happens when there's no such package.json, for example in the case of the `link:` protocol? To avoid crashes I disabled content flags extraction when the package is marked `discard_from_lookup`, which means the referenced directory doesn't point to a true folder.

I also renamed `discard_from_lookup` into `is_synthetic_package` in the Rust structs to better reflect the semantics of this field. It doesn't change the name in the PnP structs, as that would be a breaking change.