### PR TITLE
feat: implement `install --mode=skip-build`

### DIFF
--- a/packages/zpm/src/commands/install.rs
+++ b/packages/zpm/src/commands/install.rs
@@ -1,6 +1,6 @@
 use clipanion::cli;
 
-use crate::{error::Error, project::{self, RunInstallOptions}};
+use crate::{error::Error, project::{self, InstallMode, RunInstallOptions}};
 
 #[cli::command(default)]
 #[cli::path("install")]
@@ -21,6 +21,9 @@ pub struct Install {
 
     #[cli::option("--refresh-lockfile", default = false)]
     refresh_lockfile: bool,
+
+    #[cli::option("--mode")]
+    mode: Option<InstallMode>,
 }
 
 impl Install {
@@ -41,6 +44,7 @@ impl Install {
             check_checksums: self.check_checksums,
             check_resolutions: self.check_resolutions,
             refresh_lockfile: self.refresh_lockfile,
+            mode: self.mode,
             ..Default::default()
         }).await?;
 

--- a/packages/zpm/src/error.rs
+++ b/packages/zpm/src/error.rs
@@ -322,6 +322,9 @@ pub enum Error {
     #[error("Task timeout")]
     TaskTimeout,
 
+    #[error("Invalid install mode ({0})")]
+    InvalidInstallMode(String),
+
     #[error("Internal error: Join failed ({0})")]
     JoinFailed(#[from] Arc<JoinError>),
 


### PR DESCRIPTION
This PR implements the `skip-build` mode of the `install` command via the `--mode=skip-build` flag.

Enabling it skips the build step of the install.