### PR TITLE
fix(dlx): use `formatter.set` instead of `update`

### DIFF
--- a/packages/zpm/src/commands/dlx.rs
+++ b/packages/zpm/src/commands/dlx.rs
@@ -121,8 +121,8 @@ async fn install_dependencies(workspace_path: &Path, descriptors: Vec<Descriptor
         = JsonFormatter::from(&manifest_content)?;
 
     for descriptor in descriptors.into_iter() {
-        formatter.update(
-            vec!["dependencies".to_string(), descriptor.ident.to_file_string()], 
+        formatter.set(
+            vec!["dependencies".to_string(), descriptor.ident.to_file_string()],
             JsonValue::String(descriptor.range.to_file_string()),
         )?;
     }


### PR DESCRIPTION
`dlx` is currently broken because it creates an empty `package.json` (`{}`) and then calls `formatter.update` on it, which does nothing as it uses `create_if_missing: false`.

Fixed it by using `formatter.set` instead of `formatter.update`.