### PR TITLE
Switches to single quote serialization in the .pnp.cjs file

### DIFF
--- a/packages/zpm/src/http.rs
+++ b/packages/zpm/src/http.rs
@@ -11,16 +11,16 @@ pub struct HttpClient {
 
 impl HttpClient {
     pub fn new(config: &Config) -> Result<Arc<Self>, Error> {
-        // let sock_addrs = format!("registry.npmjs.org:443").to_socket_addrs()
-        //     .map_err(|err| Error::DnsResolutionError(Arc::new(err)))?
-        //     .collect::<Vec<_>>();
+        let sock_addrs = format!("registry.npmjs.org:443").to_socket_addrs()
+            .map_err(|err| Error::DnsResolutionError(Arc::new(err)))?
+            .collect::<Vec<_>>();
 
         let client = reqwest::Client::builder()
             // TODO: Can we avoid hardcoding the DNS resolution? If we don't I get
             // errors due to exhausting the amount of open files when running an
             // install with a lockfile but without cache. I suspect something is
             // not configured properly in the DNS resolver pool.
-            // .resolve_to_addrs("registry.npmjs.org", &sock_addrs)
+            .resolve_to_addrs("registry.npmjs.org", &sock_addrs)
 
             // Connection pooling settings
             .pool_max_idle_per_host(config.user.network_concurrency.value as usize)


### PR DESCRIPTION
The Berry codebase serializes the PnP payload using a single-quote string, to avoid wasting space with too many escape characters. This is reflected in the `pnp` crate which only supports extracting PnP payload [if they're single-quote-enclosed](https://github.com/yarnpkg/pnp-rs/blob/21b071ac22c0930750b15f15b476cfeb06892d56/src/lib.rs#L112).

This diff fixes that by using single quotes to wrap the string instead of double quotes. It also pretty-prints the JSON payload instead of encoding it as a single line; I think we should eventually make that configurable, but for now it makes debugging slightly easier.