### PR TITLE
chore: remove `packageManager` field from root manifest

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,4 @@
 {
-  "packageManager": "yarn@6.0.0-git.20250707.hash-63b6e054a3bea911be2077d3be7898bf139a0a34",
   "workspaces": [
     "packages/*"
   ],


### PR DESCRIPTION
https://github.com/yarnpkg/zpm/pull/26/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R2 added a `packageManager` field to the root manifest, which causes `zpm-switch` to try and resolve https://repo.yarnpkg.com/releases/6.0.0-git.20250707.hash-63b6e054a3bea911be2077d3be7898bf139a0a34/x86_64-unknown-linux-gnu (which doesn't exist) instead of picking the local zpm.

@arcanis Is that URL supposed to be valid?