### PR TITLE
feat: implement `dlx -q,--quiet`

### DIFF
--- a/packages/zpm/src/commands/init.rs
+++ b/packages/zpm/src/commands/init.rs
@@ -70,7 +70,7 @@ impl InitWithTemplate {
         let dlx_project
             = dlx::setup_project().await?;
         let dlx_project
-            = dlx::install_dependencies(&dlx_project.project_cwd, vec![template.clone()]).await?;
+            = dlx::install_dependencies(&dlx_project.project_cwd, vec![template.clone()], false).await?;
         let bin
             = dlx::find_binary(&dlx_project, template.ident.name(), true)?;
 


### PR DESCRIPTION
This PR implements support for Yarn's `dlx -q,--quiet` flag, which makes dlx hide the install output.