### PR TITLE
fix: make `globalFolder` a user config

### DIFF
--- a/packages/zpm/src/project.rs
+++ b/packages/zpm/src/project.rs
@@ -275,7 +275,7 @@ impl Project {
     }
 
     pub fn package_cache(&self) -> Result<CompositeCache, Error> {
-        let global_cache_path = self.config.project.global_folder.value
+        let global_cache_path = self.config.user.global_folder.value
             .with_join_str("cache");
 
         let local_cache_path

--- a/packages/zpm/src/settings.rs
+++ b/packages/zpm/src/settings.rs
@@ -92,6 +92,9 @@ pub struct UserConfig {
     #[default(|_| !zpm_ci::is_ci().is_some())]
     pub enable_progress_bars: BoolField,
 
+    #[default(Path::home_dir().unwrap().unwrap().with_join_str(".yarn/zpm"))]
+    pub global_folder: PathField,
+
     #[default(3)]
     pub http_retry: UintField,
 
@@ -149,9 +152,6 @@ pub struct ProjectConfig {
 
     #[default(true)]
     pub enable_transparent_workspaces: BoolField,
-
-    #[default(Path::home_dir().unwrap().unwrap().with_join_str(".yarn/zpm"))]
-    pub global_folder: PathField,
 
     #[default("cache".to_string())]
     pub local_cache_folder_name: StringField,


### PR DESCRIPTION
zpm currently makes `globalFolder` a project config instead of a user config.

However, I believe that most users of `globalFolder` are configuring it once inside of their home config, rather than per-project - especially as the purpose of `globalFolder` is to cache artifacts shared between all projects.

e.g. I have a setting in my `~/.yarnrc.yml` to change my `globalFolder` to the drive where I have my projects, in order to take advantage of Yarn Modern's copy-on-write global cache to local cache copies.

There are likely some people who are using this per-project as well, most likely for benchmarking or testing, like we are doing in our benchmark script from the berry repo.
This use case can still be solved by setting the `YARN_GLOBAL_FOLDER` env variable.