### PR TITLE
Re-enables the test tracker

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,8 +3,6 @@ name: Build
 on:
   push:
     branches: [main]
-  pull_request:
-    branches: [main]
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
This PR moves the test tracker into a separate workflow so it doesn't impact the time to build the regular artifacts, allowing to turn it back on.