### PR TITLE
feat: support negated patterns in `workspaces` field

### DIFF
--- a/packages/zpm/src/project.rs
+++ b/packages/zpm/src/project.rs
@@ -651,14 +651,15 @@ impl Workspace {
                 let glob_patterns
                     = current_patterns.into_iter()
                         .map(|pattern| {
-                            let (pattern, is_positive) = if pattern.starts_with('!') {
-                                (&pattern[1..], false)
-                            } else {
-                                (pattern.as_ref(), true)
-                            };
+                            let (pattern, is_positive)
+                                = if pattern.starts_with('!') {
+                                    (&pattern[1..], false)
+                                } else {
+                                    (pattern.as_ref(), true)
+                                };
 
-                            let pattern_path = base_path
-                                .with_join_str(pattern);
+                            let pattern_path
+                                = base_path.with_join_str(pattern);
 
                             GlobBuilder::new(pattern_path.as_str())
                                     .literal_separator(true)


### PR DESCRIPTION
This PR implements support for negated glob patterns as part of the `workspaces` field of manifests.

I implemented this manually, as literally none of the Rust glob libraries support matching a set of globs containing negated patterns:
- `globset` supports sets of globs but doesn't support `!` to negate a pattern
- `wax` doesn't support `!` to negate patterns
- `fast-glob` and `glob-match` support negated patterns but not sets of globs...

It would probably be a good idea to compare the performance of all of these libraries in the future (inside zpm) and pick one (we currently use both `globset` and `wax`) to create our own fancier globs and globsets (but it's not high on the priority list right now).