### PR TITLE
feat: add `--mode` flag to `add`, `remove`, `up`

### DIFF
--- a/packages/zpm/src/commands/add.rs
+++ b/packages/zpm/src/commands/add.rs
@@ -5,7 +5,7 @@ use zpm_parsers::{JsonFormatter, Value};
 use zpm_semver::RangeKind;
 use zpm_utils::{FromFileString, ToFileString, ToHumanString};
 
-use crate::{algolia::query_algolia, error::Error, install::InstallContext, primitives::{loose_descriptor, range::AnonymousSemverRange, Descriptor, LooseDescriptor, Range}, project};
+use crate::{algolia::query_algolia, error::Error, install::InstallContext, primitives::{loose_descriptor, range::AnonymousSemverRange, Descriptor, LooseDescriptor, Range}, project::{self, InstallMode}};
 
 #[derive(Clone, Debug)]
 struct AddRequest {
@@ -131,6 +131,11 @@ pub struct Add {
 
     #[cli::option("--prefer-dev", default = false)]
     prefer_dev: bool,
+
+    // ---
+
+    #[cli::option("--mode")]
+    mode: Option<InstallMode>,
 
     // ---
 
@@ -272,6 +277,7 @@ impl Add {
             = project::Project::new(None).await?;
 
         project.run_install(project::RunInstallOptions {
+            mode: self.mode,
             ..Default::default()
         }).await?;
 

--- a/packages/zpm/src/commands/remove.rs
+++ b/packages/zpm/src/commands/remove.rs
@@ -1,11 +1,11 @@
-use std::{collections::HashSet, fs::Permissions, os::unix::fs::PermissionsExt};
+use std::collections::HashSet;
 
 use clipanion::cli;
 use wax::{Glob, Program};
 use zpm_parsers::JsonFormatter;
 use zpm_utils::ToFileString;
 
-use crate::{config::Config, error::Error, primitives::Ident, project::{Project, RunInstallOptions, Workspace}};
+use crate::{config::Config, error::Error, primitives::Ident, project::{InstallMode, Project, RunInstallOptions, Workspace}};
 
 #[cli::command]
 #[cli::path("remove")]
@@ -14,6 +14,11 @@ use crate::{config::Config, error::Error, primitives::Ident, project::{Project, 
 pub struct Remove {
     #[cli::option("-A,--all", default = false)]
     all: bool,
+
+    #[cli::option("--mode")]
+    mode: Option<InstallMode>,
+
+    // ---
 
     identifiers: Vec<Ident>,
 }
@@ -46,6 +51,7 @@ impl Remove {
             = Project::new(None).await?;
 
         project.run_install(RunInstallOptions {
+            mode: self.mode,
             ..Default::default()
         }).await?;
 

--- a/packages/zpm/src/commands/up.rs
+++ b/packages/zpm/src/commands/up.rs
@@ -1,11 +1,11 @@
-use std::{collections::BTreeSet, fs::Permissions, os::unix::fs::PermissionsExt};
+use std::collections::BTreeSet;
 
 use clipanion::cli;
 use zpm_parsers::{JsonFormatter, Value};
 use zpm_semver::RangeKind;
 use zpm_utils::ToFileString;
 
-use crate::{error::Error, install::InstallContext, primitives::{loose_descriptor, Ident, LooseDescriptor}, project::{self, RunInstallOptions, Workspace}};
+use crate::{error::Error, install::InstallContext, primitives::{loose_descriptor, Ident, LooseDescriptor}, project::{self, InstallMode, RunInstallOptions, Workspace}};
 
 #[cli::command]
 #[cli::path("up")]
@@ -23,6 +23,11 @@ pub struct Up {
 
     #[cli::option("-C,--caret", default = false)]
     caret: bool,
+
+    // ---
+
+    #[cli::option("--mode")]
+    mode: Option<InstallMode>,
 
     // ---
 
@@ -109,6 +114,7 @@ impl Up {
             = project::Project::new(None).await?;
 
         project.run_install(RunInstallOptions {
+            mode: self.mode,
             ..Default::default()
         }).await?;
 


### PR DESCRIPTION
This PR adds the `--mode` flag to the `add`, `remove`, and `up` commands.

(I didn't realize Yarn supported it in all these places when I implemented the flag in zpm. It's also supported in `dedupe`, but the command is not implemented in zpm yet.)