### PR TITLE
Fixes the build manager

### DIFF
--- a/packages/zpm/src/algos.rs
+++ b/packages/zpm/src/algos.rs
@@ -1,0 +1,167 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+/// Strongly Connected Components using the Tarjan–Pearce (space-efficient) variant.
+/// Input: adjacency list for vertices 0..n-1
+/// Output: Vec of components, each a Vec<usize>, in reverse topological order.
+pub fn scc_tarjan_pearce_core(adj: &[Vec<usize>]) -> Vec<Vec<usize>> {
+    let n = adj.len();
+    if n == 0 {
+        return Vec::new();
+    }
+
+    // rindex[v] = 0           => unvisited
+    // rindex[v] in [1..index) => DFS "rindex" = index of v's current local root (active)
+    // rindex[v] >= c_min      => vertex has been assigned to a component with id rindex[v]
+    let mut rindex
+        = vec![0usize; n];
+
+    // Stack of vertices that are candidates for the current SCC.
+    let mut stack
+        = Vec::with_capacity(n);
+
+    // DFS visit counter (starts at 1 in Pearce’s Alg. 3).
+    let mut index
+        = 1usize;
+
+    // Component id (starts at n-1 and decrements) – ensures index < c always holds.
+    let mut c
+        = n - 1;
+
+    // Result components, collected when a root is closed.
+    let mut comps
+        = Vec::new();
+
+    // Recursive DFS as in Pearce’s Algorithm 3 (PEA_FIND_SCC2).
+    fn visit(
+        v: usize,
+        adj: &[Vec<usize>],
+        rindex: &mut [usize],
+        stack: &mut Vec<usize>,
+        index: &mut usize,
+        c: &mut usize,
+        comps: &mut Vec<Vec<usize>>,
+    ) {
+        let mut is_root = true;
+
+        // Enter v: set its initial rindex to current index and advance.
+        rindex[v] = *index;
+        *index += 1;
+
+        // Explore all out-edges (v -> w).
+        for &w in &adj[v] {
+            if rindex[w] == 0 {
+                // Tree edge to an unvisited node.
+                visit(w, adj, rindex, stack, index, c, comps);
+            }
+
+            // If w is not yet assigned to a component, its rindex is < current c,
+            // so a smaller rindex[w] indicates a better (earlier) local root.
+            if rindex[w] < rindex[v] {
+                rindex[v] = rindex[w];
+                is_root = false;
+            }
+        }
+
+        if is_root {
+            // v is the root of its SCC: finalize all vertices whose rindex >= rindex[v]
+            // (including v itself) — they form one component.
+            *index -= 1;
+
+            let mut comp = Vec::new();
+
+            while let Some(&top) = stack.last() {
+                if rindex[v] <= rindex[top] {
+                    let w
+                        = stack.pop().unwrap();
+
+                    rindex[w] = *c; // assign component id
+                    *index -= 1;    // Pearce decrements index for each assignment
+
+                    comp.push(w);
+                } else {
+                    break;
+                }
+            }
+
+            // Assign v itself.
+            rindex[v] = *c;
+            comp.push(v);
+
+            // Decrement component id for the next SCC.
+            *c = c.saturating_sub(1);
+
+            // We produced the SCC for root v.
+            comps.push(comp);
+        } else {
+            // Not a root — stay on the candidate stack.
+            stack.push(v);
+        }
+    }
+
+    for v in 0..n {
+        if rindex[v] == 0 {
+            visit(v, adj, &mut rindex, &mut stack, &mut index, &mut c, &mut comps);
+        }
+    }
+
+    comps
+}
+
+pub fn scc_tarjan_pearce<T>(graph: &BTreeMap<T, BTreeSet<T>>) -> Vec<Vec<T>> where T: Eq + Ord + Clone {
+    // 1) Assign dense indices to *all* vertices (keys and neighbors).
+    let mut id_of
+        = BTreeMap::new();
+    let mut key_of
+        = Vec::new();
+
+    let intern = |x: T, id_of: &mut BTreeMap<T, usize>, key_of: &mut Vec<T>| -> usize {
+        if let Some(&i) = id_of.get(&x) {
+            i
+        } else {
+            let i
+                = key_of.len();
+
+            key_of.push(x.clone());
+            id_of.insert(x, i);
+
+            i
+        }
+    };
+
+    // Include keys.
+    for k in graph.keys() {
+        intern(k.clone(), &mut id_of, &mut key_of);
+    }
+
+    // Include neighbors that might not appear as keys.
+    for nbrs in graph.values() {
+        for v in nbrs {
+            intern(v.clone(), &mut id_of, &mut key_of);
+        }
+    }
+
+    // 2) Build the indexed adjacency list.
+    let n
+        = key_of.len();
+    let mut adj_idx
+        = vec![Vec::new(); n];
+
+    for (u, nbrs) in graph.iter() {
+        let ui
+            = id_of[u];
+
+        for v in nbrs {
+            let vi = id_of[v];
+            adj_idx[ui].push(vi);
+        }
+    }
+
+    // 3) Run core SCC on indices and map components back to T.
+    let comps_idx
+        = scc_tarjan_pearce_core(&adj_idx);
+
+    comps_idx
+        .into_iter()
+        .map(|c| c.into_iter().map(|i| key_of[i].clone()).collect())
+        .collect()
+}

--- a/packages/zpm/src/hash.rs
+++ b/packages/zpm/src/hash.rs
@@ -34,6 +34,23 @@ impl Sha256 {
     }
 }
 
+pub trait CollectHash {
+    fn collect_hash(self) -> Sha256;
+}
+
+impl<I: Iterator<Item = Sha256>> CollectHash for I {
+    fn collect_hash(self) -> Sha256 {
+        let mut hasher
+            = Blake2b80::new();
+
+        for hash in self {
+            hasher.update(hash.state.as_slice());
+        }
+
+        Sha256 {state: hasher.finalize().to_vec()}
+    }
+}
+
 impl FromFileString for Sha256 {
     type Error = Error;
 

--- a/packages/zpm/src/lib.rs
+++ b/packages/zpm/src/lib.rs
@@ -3,6 +3,7 @@
 use env_logger as _;
 
 pub mod algolia;
+pub mod algos;
 pub mod build;
 pub mod cache;
 pub mod commands;

--- a/packages/zpm/src/linker/helpers.rs
+++ b/packages/zpm/src/linker/helpers.rs
@@ -54,23 +54,23 @@ pub fn fs_remove_nm(nm_path: Path) -> Result<(), Error> {
             for entry in entries.flatten() {
                 let path
                     = Path::try_from(entry.path())?;
-        
+
                 let basename = path.basename()
                     .unwrap();
-        
+
                 if basename.starts_with(".") && basename != ".bin" && path.fs_is_dir() {
                     has_dot_entries = true;
                     continue;
                 }
-        
+
                 path.fs_rm()
                     .unwrap();
             }
-        
+
             if !has_dot_entries {
                 nm_path.fs_rm()?;
             }
-        
+
             Ok(())
         },
     }
@@ -114,13 +114,17 @@ pub fn fs_extract_archive(destination: &Path, package_data: &PackageData) -> Res
 }
 
 pub fn populate_build_entry_dependencies(package_build_entries: &BTreeMap<Locator, usize>, locator_resolutions: &BTreeMap<Locator, Resolution>, descriptor_to_locator: &BTreeMap<Descriptor, Locator>) -> Result<BTreeMap<usize, BTreeSet<usize>>, Error> {
-    let mut package_build_dependencies = BTreeMap::new();
+    let mut package_build_dependencies
+        = BTreeMap::new();
 
     for locator in package_build_entries.keys() {
-        let mut build_dependencies = BTreeSet::new();
+        let mut build_dependencies
+            = BTreeSet::new();
 
-        let mut queue = vec![locator.clone()];
-        let mut seen: BTreeSet<_> = BTreeSet::new();
+        let mut queue
+            = vec![locator.clone()];
+        let mut seen
+            = BTreeSet::new();
 
         seen.insert(locator.clone());
 

--- a/packages/zpm/src/linker/nm/hoist.rs
+++ b/packages/zpm/src/linker/nm/hoist.rs
@@ -3,155 +3,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use itertools::{Either, Itertools};
 use zpm_utils::ToHumanString;
 
-use crate::{install::InstallState, primitives::{Ident, Locator}, project::Project, ui};
-
-/// Strongly Connected Components using the Tarjan–Pearce (space-efficient) variant.
-/// Input: adjacency list for vertices 0..n-1
-/// Output: Vec of components, each a Vec<usize>, in reverse topological order.
-pub fn scc_tarjan_pearce_core(adj: &[Vec<usize>]) -> Vec<Vec<usize>> {
-    let n = adj.len();
-    if n == 0 {
-        return Vec::new();
-    }
-
-    // rindex[v] = 0           => unvisited
-    // rindex[v] in [1..index) => DFS "rindex" = index of v's current local root (active)
-    // rindex[v] >= c_min      => vertex has been assigned to a component with id rindex[v]
-    let mut rindex = vec![0usize; n];
-
-    // Stack of vertices that are candidates for the current SCC.
-    let mut stack: Vec<usize> = Vec::with_capacity(n);
-
-    // DFS visit counter (starts at 1 in Pearce’s Alg. 3).
-    let mut index: usize = 1;
-
-    // Component id (starts at n-1 and decrements) – ensures index < c always holds.
-    let mut c: usize = n - 1;
-
-    // Result components, collected when a root is closed.
-    let mut comps: Vec<Vec<usize>> = Vec::new();
-
-    // Recursive DFS as in Pearce’s Algorithm 3 (PEA_FIND_SCC2).
-    fn visit(
-        v: usize,
-        adj: &[Vec<usize>],
-        rindex: &mut [usize],
-        stack: &mut Vec<usize>,
-        index: &mut usize,
-        c: &mut usize,
-        comps: &mut Vec<Vec<usize>>,
-    ) {
-        let mut is_root = true;
-
-        // Enter v: set its initial rindex to current index and advance.
-        rindex[v] = *index;
-        *index += 1;
-
-        // Explore all out-edges (v -> w).
-        for &w in &adj[v] {
-            if rindex[w] == 0 {
-                // Tree edge to an unvisited node.
-                visit(w, adj, rindex, stack, index, c, comps);
-            }
-            // If w is not yet assigned to a component, its rindex is < current c,
-            // so a smaller rindex[w] indicates a better (earlier) local root.
-            if rindex[w] < rindex[v] {
-                rindex[v] = rindex[w];
-                is_root = false;
-            }
-        }
-
-        if is_root {
-            // v is the root of its SCC: finalize all vertices whose rindex >= rindex[v]
-            // (including v itself) — they form one component.
-            *index -= 1;
-
-            let mut comp = Vec::new();
-
-            while let Some(&top) = stack.last() {
-                if rindex[v] <= rindex[top] {
-                    let w = stack.pop().unwrap();
-                    rindex[w] = *c; // assign component id
-                    *index -= 1;    // Pearce decrements index for each assignment
-                    comp.push(w);
-                } else {
-                    break;
-                }
-            }
-
-            // Assign v itself.
-            rindex[v] = *c;
-            comp.push(v);
-
-            // Decrement component id for the next SCC.
-            *c = c.saturating_sub(1);
-
-            // We produced the SCC for root v.
-            comps.push(comp);
-        } else {
-            // Not a root — stay on the candidate stack.
-            stack.push(v);
-        }
-    }
-
-    for v in 0..n {
-        if rindex[v] == 0 {
-            visit(v, adj, &mut rindex, &mut stack, &mut index, &mut c, &mut comps);
-        }
-    }
-
-    comps
-}
-
-pub fn scc_tarjan_pearce<T>(graph: &BTreeMap<T, Vec<T>>) -> Vec<Vec<T>>
-where
-    T: Eq + Ord + Clone,
-{
-    // 1) Assign dense indices to *all* vertices (keys and neighbors).
-    let mut id_of: BTreeMap<T, usize> = BTreeMap::new();
-    let mut key_of: Vec<T> = Vec::new();
-
-    let intern = |x: T, id_of: &mut BTreeMap<T, usize>, key_of: &mut Vec<T>| -> usize {
-        if let Some(&i) = id_of.get(&x) {
-            i
-        } else {
-            let i = key_of.len();
-            key_of.push(x.clone());
-            id_of.insert(x, i);
-            i
-        }
-    };
-
-    // Include keys.
-    for k in graph.keys() {
-        intern(k.clone(), &mut id_of, &mut key_of);
-    }
-
-    // Include neighbors that might not appear as keys.
-    for nbrs in graph.values() {
-        for v in nbrs {
-            intern(v.clone(), &mut id_of, &mut key_of);
-        }
-    }
-
-    // 2) Build the indexed adjacency list.
-    let n = key_of.len();
-    let mut adj_idx: Vec<Vec<usize>> = vec![Vec::new(); n];
-    for (u, nbrs) in graph.iter() {
-        let ui = id_of[u];
-        for v in nbrs {
-            let vi = id_of[v];
-            adj_idx[ui].push(vi);
-        }
-    }
-
-    // 3) Run core SCC on indices and map components back to T.
-    let comps_idx = scc_tarjan_pearce_core(&adj_idx);
-    comps_idx
-        .into_iter()
-        .map(|c| c.into_iter().map(|i| key_of[i].clone()).collect())
-        .collect()
-}
+use crate::{algos, install::InstallState, primitives::{Ident, Locator}, project::Project, ui};
 
 #[derive(Debug, Clone)]
 pub struct InputNode {
@@ -638,7 +490,7 @@ impl<'a> Hoister<'a> {
                     = &self.work_tree.nodes[hoistable_idx];
 
                 let mut candidate_dependencies
-                    = vec![];
+                    = BTreeSet::new();
 
                 for dependency_locator in hoistable_node.dependencies.values() {
                     // This node already embed its own copy of its dependency, so we don't care about whatever
@@ -653,7 +505,7 @@ impl<'a> Hoister<'a> {
                         continue;
                     }
 
-                    candidate_dependencies.push(dependency_locator);
+                    candidate_dependencies.insert(dependency_locator);
                 }
 
                 hoisting_dependencies.insert(hoistable_locator, candidate_dependencies);
@@ -665,7 +517,7 @@ impl<'a> Hoister<'a> {
             // A depends on package B, and package B depends on package A.
 
             let sccs
-                = scc_tarjan_pearce(&hoisting_dependencies);
+                = algos::scc_tarjan_pearce(&hoisting_dependencies);
 
             let mut new_dependencies
                 = self.work_tree.nodes[node_idx].dependencies.clone();


### PR DESCRIPTION
I noticed a couple of bugs while looking at the [perf dashboard](https://p.datadoghq.eu/sb/d2wdprp9uki7gfks-badb2c0f08402af744326888f9535a82):

- The BuildState struct was using a default `Deserialize` implementation, but a custom `Serialize` one. This caused a mismatch because the file was serialized as `{"key": "value"}`, whereas the deserialization expected `{"entries": {"key": "value"}}`.

    - Since the deserialization attempted to be error-tolerant by just making a fallback to an empty state, the hashes were just silently not working. I removed the tolerance here to avoid hiding similar errors in the future. It should be added back in a safer way later on (by introducing a version number into the BuildState struct?).

- The BuildManager class didn't support cycles; when cycles happened, the manager was just skipping them (they weren't built at all). I fixed that by computing the SCCs from the build request graph, and just removing the SCC siblings from each package's dependency set.

    - So if you have something like A depending on B and C, and B depending on A and C, both A and B will be rebuilt if C changes (because C isn't part of the A/B SCC), but B won't be rebuilt if A changes (we pretend the cyclic dependency doesn't exist, as there's no other reasonable way to resolve the conflict, except erroring - which we can't do for backward compatibility).