### PR TITLE
Fixes hash calculation

### DIFF
--- a/packages/zpm/src/hash.rs
+++ b/packages/zpm/src/hash.rs
@@ -38,7 +38,7 @@ pub trait CollectHash {
     fn collect_hash(self) -> Sha256;
 }
 
-impl<I: Iterator<Item = Sha256>> CollectHash for I {
+impl<'a, I: Iterator<Item = &'a Sha256>> CollectHash for I {
     fn collect_hash(self) -> Sha256 {
         let mut hasher
             = Blake2b80::new();


### PR DESCRIPTION
I made a mistake in #56: the hash should be computed not based on the request build dependencies, but based on its full dependency tree branch (ie we should rebuild A when B changes, even if B doesn't have a postinstall itself).

Fixing that here.