### PR TITLE
Reworks how data structures are cleaned up when resolving peer dependencies

### DIFF
--- a/packages/zpm/src/linker/pnp.rs
+++ b/packages/zpm/src/linker/pnp.rs
@@ -219,7 +219,7 @@ pub async fn link_project_pnp<'a>(project: &'a mut Project, install: &'a mut Ins
 
         let mut package_dependencies: BTreeMap<Ident, PnpDependencyTarget> = resolution.dependencies.iter().map(|(ident, descriptor)| {
             let dependency_resolution = tree.descriptor_to_locator.get(descriptor)
-                .expect("Failed to find dependency resolution");
+                .unwrap_or_else(|| panic!("Failed to find dependency resolution for {}", descriptor.to_print_string()));
 
             let dependency_target = if &dependency_resolution.ident == ident {
                 PnpDependencyTarget::Simple(PnpReference(dependency_resolution.clone()))


### PR DESCRIPTION
Yarn performs the resolution in two steps:

- During the first traversal we retrieve the package metadata from the registry and connect packages to one another
- During the second traversal we resolve all peer dependencies by creating [virtual packages](https://yarnpkg.com/advanced/lexicon#virtual-package) as needed

Since we're traversing the concrete dependency tree (unlike the first pass, in which we try to retrieve the metadata from the network as fast as possible without any consideration for the traversal order), we also takes advantage of this second pass to compute additional metadata. One of them is `optional_builds`, which lists the locators that are part of optional branches.

To compute that, we start with a list of all locators, and remove them as soon as we detect that a locator is part of a branch that's not optional. However the code forgot one edge case, which is packages with peer dependencies. Since they are virtualized, the recursion doesn't recurse into the original locator (which is inside `optional_builds`), but rather into the new virtualized locator. As a result the original locator is never removed from `optional_builds`.

This isn't an issue _per se_, except that we also never clean up the `locator_resolutions` table from packages which got virtualized. As a result, code iterating over `locator_resolutions` would also iterate over those no-longer-needed physical packages (no-longer-needed because we only care about their virtualized instances in the dependency tree), and would think they are optional (because they're still in `optional_builds`).

Yarn tries to keep packages zipped as much as possible. Only when we detect that a package cannot work do we automatically extract it on disk inside the `.yarn/unplugged` folder. To perform that detection we rely on heuristics. One of them is "is the package an optional dependency?" - the rational being that if the package is optional, it's probably that it will try to build native binaries _(as I'm writing this I feel like this logic seems a little wrong, as transitive dependencies will also be flagged optional; to check if it's consistent with how Berry works)_.

As a result we end up with many useless unplugged folders. They are not harmful as nothing will ever require anything from them, but they are useless.

This diff fixes the traversal to properly clean up the `locator_resolutions` and `optional_builds` data structures as we create new virtualized locators.
