### PR TITLE
Cleans up the unused paths from the unplugged directory

### DIFF
--- a/packages/zpm/src/commands/init.rs
+++ b/packages/zpm/src/commands/init.rs
@@ -252,10 +252,6 @@ pub async fn init_project(init_cwd: &Path, params: InitParams) -> Result<Project
 
         if !gitignore_path.fs_exists() {
             let gitignore_content = vec![
-                ".yarn/ignore/*\n",
-                "\n",
-                "# Whether you use PnP or not, the node_modules folder is often used to store\n",
-                "# build artifacts that should be gitignored\n",
                 "node_modules\n",
             ];
 

--- a/packages/zpm/src/project.rs
+++ b/packages/zpm/src/project.rs
@@ -194,6 +194,10 @@ impl Project {
         self.project_cwd.with_join_str(".yarn/ignore")
     }
 
+    pub fn unplugged_path(&self) -> Path {
+        self.ignore_path().with_join_str("unplugged")
+    }
+
     pub fn install_state_path(&self) -> Path {
         self.ignore_path().with_join_str("install")
     }


### PR DESCRIPTION
Two fixes:

- The unplugged directory was happily keeping things that were no longer needed. For instance if you had `sharp` installed and removed it, it would linger in the unplugged folder.

- The cross-packages symlinks introduced in #72 were accidentally taking into account packages that didn't get fetch due to not being compatible with the system, causing them to appear despite being empty.