### PR TITLE
Implements 'yarn switch update'

### DIFF
--- a/packages/zpm-switch/src/commands/mod.rs
+++ b/packages/zpm-switch/src/commands/mod.rs
@@ -18,6 +18,7 @@ program_async!(SwitchExecCli, [
     switch::link::LinkCommand,
     switch::postinstall::PostinstallCommand,
     switch::unlink::UnlinkCommand,
+    switch::update::UpdateCommand,
     switch::version::VersionCommand,
     switch::which::WhichCommand,
     proxy::ProxyCommand,

--- a/packages/zpm-switch/src/commands/switch/mod.rs
+++ b/packages/zpm-switch/src/commands/switch/mod.rs
@@ -6,5 +6,6 @@ pub mod links_list;
 pub mod link;
 pub mod postinstall;
 pub mod unlink;
+pub mod update;
 pub mod version;
 pub mod which;

--- a/packages/zpm-switch/src/commands/switch/update.rs
+++ b/packages/zpm-switch/src/commands/switch/update.rs
@@ -1,0 +1,37 @@
+use std::process::Command;
+
+use clipanion::cli;
+use zpm_utils::Path;
+
+use crate::{errors::Error, http::fetch};
+
+#[cli::command]
+#[cli::path("switch", "update")]
+#[cli::category("Switch commands")]
+#[cli::description("Update the Yarn Switch binary to the latest version")]
+#[derive(Debug)]
+pub struct UpdateCommand {
+}
+
+impl UpdateCommand {
+    pub async fn execute(&self) -> Result<(), Error> {
+        let install_script_url
+            = "https://repo.yarnpkg.com/install";
+
+        let install_script
+            = fetch(install_script_url).await?;
+
+        let install_script_path
+            = Path::temp_root_dir()?
+                .with_join_str("yarn-install-script.sh");
+
+        install_script_path
+            .fs_write(install_script)?;
+
+        Command::new("bash")
+            .arg(install_script_path.to_path_buf())
+            .status()?;
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
This PR adds a new `yarn switch update` command that, when run, download the install script and run it through `bash`. It's essentially an alias for `curl https://repo.yarnpkg.com/install | bash` that's easier to remember.