### PR TITLE
Implements 'yarn switch cache --check'

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,13 +25,19 @@ git clone https://github.com/yarnpkg/berry.git
 cargo build --release -p zpm-switch -p zpm
 ```
 
-4. (optional) Configure Yarn Switch to use your local binary when working on this repository.
+4. Configure the `local` symlink to point to the binaries you just built.
+
+```bash
+ln -s target/release local
+```
+
+5. (optional) Configure Yarn Switch to use your local binary when working on this repository.
 
 ```bash
 yarn switch link target/release/yarn-bin
 ```
 
-5. Run the tests.
+6. Run the tests.
 
 ```bash
 yarn berry test:integration

--- a/contributing/general-commands.md
+++ b/contributing/general-commands.md
@@ -2,11 +2,21 @@
 
 ## Compiling the project
 
-I've been working with the release binary even in development, and tests are configured to use it as well so we can have performances similar to what users would experience. Note that the release builds are configured to contain debug information, even if optimized.
+Building the project is done through Cargo:
 
 ```bash
 cargo build -p zpm -r
 ```
+
+Building with the release profile (ie the `-r` flag) is advised as debug builds are significantly slower. You also have access to `release-lto` and `release-lto-nodebug` profiles, although they are slower to build and are not recommended for development.
+
+Regardless what you pick, make sure to link the binary by creating a `local` symlink:
+
+```bash
+ln -s target/release local
+```
+
+Other parts of the infra such as the tests use this symlink to find the binaries to spawn.
 
 ## Running integration tests
 

--- a/packages/zpm-switch/src/commands/mod.rs
+++ b/packages/zpm-switch/src/commands/mod.rs
@@ -10,6 +10,7 @@ pub mod proxy;
 pub mod switch;
 
 program_async!(SwitchExecCli, [
+    switch::cache_check::CacheCheckCommand,
     switch::cache_clear::CacheClearCommand,
     switch::cache_list::CacheListCommand,
     switch::explicit::ExplicitCommand,

--- a/packages/zpm-switch/src/commands/switch/cache_check.rs
+++ b/packages/zpm-switch/src/commands/switch/cache_check.rs
@@ -1,0 +1,34 @@
+use clipanion::cli;
+use zpm_utils::{get_system_string};
+
+use crate::{cache, errors::Error};
+
+#[cli::command]
+#[cli::path("switch", "cache")]
+#[cli::category("Cache management")]
+#[cli::description("Check if the specified versions are available in the cache")]
+#[derive(Debug)]
+pub struct CacheCheckCommand {
+    #[cli::option("--check")]
+    _check: bool,
+
+    versions: Vec<zpm_semver::Version>,
+}
+
+impl CacheCheckCommand {
+    pub async fn execute(&self) -> Result<(), Error> {
+        for version in &self.versions {
+            let cache_key = cache::CacheKey {
+                cache_version: cache::CACHE_VERSION,
+                version: version.clone(),
+                platform: get_system_string().to_string(),
+            };
+
+            if !cache::check(&cache_key)? {
+                return Err(Error::CacheNotFound(version.clone()));
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/packages/zpm-switch/src/commands/switch/mod.rs
+++ b/packages/zpm-switch/src/commands/switch/mod.rs
@@ -1,3 +1,4 @@
+pub mod cache_check;
 pub mod cache_clear;
 pub mod cache_list;
 pub mod explicit;

--- a/packages/zpm-switch/src/errors.rs
+++ b/packages/zpm-switch/src/errors.rs
@@ -29,6 +29,9 @@ pub enum Error {
     #[error("Unknown binary name: {0}")]
     UnknownBinaryName(String),
 
+    #[error("Cache not found: {version}", version = .0.to_print_string())]
+    CacheNotFound(zpm_semver::Version),
+
     #[error("Failed to get current executable path")]
     FailedToGetExecutablePath,
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -396,14 +396,14 @@
       }
     },
     "@types/lodash@npm:^4.17.17": {
-      "checksum": "02ef05a5b867ffdfef893cdd789a6eb5d94ceae415d0a197b23854fa534f3108f4766f644e0dddb88e4e54cede5c3cebb741ab5a13671da3485520fe8f8759fb",
+      "checksum": "94909551bd183fc22807512fe920d0345ac18c6d26e830c1718b69dc8f449f310f501e9561a2c0c90ca3a70374d55035a193562e185a7b3362ec9b3a51261486",
       "resolution": {
         "resolution": "@types/lodash@npm:4.17.20",
         "version": "4.17.20"
       }
     },
     "@types/node@npm:^22.15.20": {
-      "checksum": "0c693bfbf375ec6408653b68f580a1753563143d8d9facd6564215bd523376c674dd8a1c7b0dcbaa472f64134886129db23711358a82dcdcd283c4202efe8722",
+      "checksum": "56ae174ff572a4eb84acd30aa0d8cd3872e4e5f13dcc6522b666ff954c4e2a5c934a1f3f21dbdc2e4cada272d36047667078c4d7b974a2fba14ffaa90191f4b4",
       "resolution": {
         "resolution": "@types/node@npm:22.18.1",
         "version": "22.18.1",
@@ -413,7 +413,7 @@
       }
     },
     "@types/node@npm:^24.0.10": {
-      "checksum": "35f68602bede6c23b30f3a1d341dfe3b3c8f6a0c2dc4826d74c2e2c58df9708868d7e5806e28f343d8554c0684c1b34fcccfd89dde6c999eca0c3458fea7d41d",
+      "checksum": "c4109a319387861517f203b433f9c3ff5acffa8e6ea18650c101b2654b2de102142b487b857f05290905e84683d069eac9de54cd11f99022ebce5af463170057",
       "resolution": {
         "resolution": "@types/node@npm:24.3.1",
         "version": "24.3.1",
@@ -423,7 +423,7 @@
       }
     },
     "@yarnpkg/types@npm:^4.0.1": {
-      "checksum": "778be8abfc730f54cce12850187690546e2bc87c095abf0cda57df0bcc0950c2ca9fbb62b1c024e8f3bea1db48718503133a81dbdc76349b95b4f37761d10b74",
+      "checksum": "804820b6b4c4e632a19c17c781ca7e205ae08a395942101478810cc360d23ff31390d50c730ac8338ae2eb0128e90af8e51c6dd76d28505a8e12a02ed91ce425",
       "resolution": {
         "resolution": "@yarnpkg/types@npm:4.0.1",
         "version": "4.0.1",
@@ -433,7 +433,7 @@
       }
     },
     "clipanion@npm:^4.0.0-rc.4": {
-      "checksum": "9175b23c2beb4ecb1cee163da2d3e9448c7f45e15bbffa5fcd95c84dabb42f3d828ef24dc11e1c555287876e7a2aed166274444c958dcd73c7c634027cb239bc",
+      "checksum": "4b5daa0fcb77686fc86c95f6b97d146585d3a73b0a7a4eb0f79579972645483fa4a532ac3335cc73435fcd850512e58fbf398e25684780d9efd9fb1d1cd2792e",
       "resolution": {
         "resolution": "clipanion@npm:4.0.0-rc.4",
         "version": "4.0.0-rc.4",
@@ -446,7 +446,7 @@
       }
     },
     "esbuild@npm:^0.25.5": {
-      "checksum": "925109bd32a7c2f920ffe062cb1dae4d9c9b9b3eaea79e27fc0ae2429db03c3ad758f233e00881b02830522982c8617a668a89b096e6333d338d839d90579756",
+      "checksum": "22c710e11e04e4cfb81ee8b413b38dcdaf6f1b253ef99c7897df2a2578132d76dc380cfd3c9ada32f2b31e1be499c57fd558d7684fb56df26ef9508cd7c43cc7",
       "resolution": {
         "resolution": "esbuild@npm:0.25.9",
         "version": "0.25.9",
@@ -518,7 +518,7 @@
       }
     },
     "lodash@npm:^4.17.21": {
-      "checksum": "9c92ff31a61e1bb60f9c6629c19d5f4db12d60abd0b975b429e8349c947d98c9b343b49a58b74c7ad5bdb3afd0fc0bfdb82968b70fade7388716ea3c82153042",
+      "checksum": "aa57c52a153e28367a6bb1173b04460f291b57e7c8761a5aa9918a8773e56608cb220cfe79bd26fa4bff21648a9ce6849018bb00c0bf213371a3766409bb3706",
       "resolution": {
         "resolution": "lodash@npm:4.17.21",
         "version": "4.17.21"
@@ -544,42 +544,42 @@
       }
     },
     "tslib@npm:^2.4.0": {
-      "checksum": "7e5be2c22c37f0762021f1f1523e3390841bf35d3c26b88ba811e1f4d0caa4af99448ab50b2c5003c629798151e8301ee9b4f5af15afc68013bb5e9364f416b6",
+      "checksum": "cf84b5a3e3542d9b3307c03e5b8d7f8eb03ca432d28b1297a82bfbc162ba73f5995ba353916a05b248580dbd0f61bf086176c0a5877f99b9f0a842d1cf51cc1a",
       "resolution": {
         "resolution": "tslib@npm:2.8.1",
         "version": "2.8.1"
       }
     },
     "typanion@npm:^3.8.0": {
-      "checksum": "06f82ac43db85fb3a60b5b027dcf958ad04b7b0350f40f42fbbe11da8d36c5c50ab1f089e7410cab0dcb9a6d0ea65dbec5b3b616687dd95028b5ea2bec14d9b6",
+      "checksum": "5b1d3b80514318cc0b4a756fe6370f110d03025c81093938ecdb7bc698cf3809af4b72655a8b0842fea52ea79169052219334721afd6079f86d089a1408e0aea",
       "resolution": {
         "resolution": "typanion@npm:3.14.0",
         "version": "3.14.0"
       }
     },
     "typescript@npm:^5.8.3": {
-      "checksum": "e14739a0c31f779c8ec73cee5ca1fb75dcb36f04458faa3e20ae787d11ebb13e0d34c1d3d77b687b4a4f09761d6a9d7bc1d2da7926dd65270ea42eb360a0071c",
+      "checksum": "d49d1e43f42eba75349106fc2cee2173f9bda26c41dab91251e96595123b42a5ebbad1cfa94222c3169bd9b60f9203aadbd261b8a06c1d8aec82083372c650b9",
       "resolution": {
         "resolution": "typescript@npm:5.9.2",
         "version": "5.9.2"
       }
     },
     "typescript@patch:typescript%40npm%3A%5E5.8.3#<builtin>": {
-      "checksum": "a8a4a2d4269edc7233e8f3863324d92884e32eccf831623649821afc7b340fd775c5157b8071b359172d51a2de4c22fca8dc36efbd9aa30d88580da90bc69f5a",
+      "checksum": "04e0920acfce8d9cdbb2256209c2d8d202081ed3864798967a8778dfd5d1fd62bcb27e759fbaadc9da873818bba42b21ffa1517a4632843ea95d2c9a490e709d",
       "resolution": {
         "resolution": "typescript@patch:typescript%40npm%3A5.9.2#<builtin>&checksum=112fa7c8f2b0a70cad690e274067371ec56b5b10b3563ccb108397127d71ae1ba42d51780238b6c7e517cc2b6710a106f89dd53ede004418a9a818b06656546a",
         "version": "5.9.2"
       }
     },
     "undici-types@npm:~6.21.0": {
-      "checksum": "d59dc444c5a1381e4a6e6865ff6e04a5e3d309c2b2d75ed088e2bab48dd2e6a18786ca5cb82b4f52b78285f97f61932f1a60cadc118a675f9d1410293bde4115",
+      "checksum": "6aff936b5792ef2c6dfc21a14f71defbaf921b380df507d085b58dd0308feacac6198978d99c962320b2fd9f97553e3abd55c30493b59c1d73fef74ee67e228e",
       "resolution": {
         "resolution": "undici-types@npm:6.21.0",
         "version": "6.21.0"
       }
     },
     "undici-types@npm:~7.10.0": {
-      "checksum": "e28419de70512c73a9a3dd6eda06642c48d27fb72de99a2ba2e8484ed4cb6fd184c55c5f150fb7f841c225dc9cb1fcf47b3dbce6af211509c9f5f14cce4f19d8",
+      "checksum": "43d870c42a8a0dbfc88da3255dd84cbec2e30deee04cc8f2ce803b05310f43494b8cb717917cab1340240d16fb77015c210015df9dad00047a74caff820d599c",
       "resolution": {
         "resolution": "undici-types@npm:7.10.0",
         "version": "7.10.0"


### PR DESCRIPTION
This PR implements a new `yarn switch cache --check x.y.z` command that fails if the specified versions aren't in the cache. It can be used on CI to avoid accidentally relying on the network.