### PR TITLE
Fixes extra fields skip

### DIFF
--- a/packages/zpm/src/commands/debug/iter_zip.rs
+++ b/packages/zpm/src/commands/debug/iter_zip.rs
@@ -1,0 +1,26 @@
+use clipanion::cli;
+use zpm_utils::Path;
+
+use crate::{error::Error};
+
+#[cli::command(proxy)]
+#[cli::path("debug", "iter-zip")]
+pub struct IterZip {
+    path: Path,
+}
+
+impl IterZip {
+    pub fn execute(&self) -> Result<(), Error> {
+        let buffer = self.path
+            .fs_read()?;
+
+        let entries
+            = zpm_formats::zip::entries_from_zip(&buffer)?;
+
+        for entry in entries {
+            println!("{}", entry.name);
+        }
+
+        Ok(())
+    }
+}

--- a/packages/zpm/src/commands/debug/mod.rs
+++ b/packages/zpm/src/commands/debug/mod.rs
@@ -5,5 +5,6 @@ pub mod check_range;
 pub mod check_reference;
 pub mod check_requirements;
 pub mod check_semver_version;
+pub mod iter_zip;
 pub mod print_hoisting;
 pub mod print_platform;

--- a/packages/zpm/src/commands/mod.rs
+++ b/packages/zpm/src/commands/mod.rs
@@ -38,6 +38,7 @@ program!(YarnCli, [
     debug::check_reference::CheckReference,
     debug::check_requirements::CheckRequirements,
     debug::check_semver_version::CheckSemverVersion,
+    debug::iter_zip::IterZip,
     debug::print_hoisting::PrintHoisting,
     debug::print_platform::PrintPlatform,
 


### PR DESCRIPTION
The zip traversal was accidentally omitting to walk over extra fields. This caused deflate errors for zip archives containing such fields (such as the ones generated by the release workflow).