### PR TITLE
Removes extra fields from the generated release archive

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Generate the archive files
         run: |
-          zip -j yarn-${{matrix.target}}.zip target/${{matrix.target}}/release-lto-nodebug/{yarn-bin,yarn,LICENSE.md}
+          zip -jX yarn-${{matrix.target}}.zip target/${{matrix.target}}/release-lto-nodebug/{yarn-bin,yarn,LICENSE.md}
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
#79 fixes extra field support in zip archives, but the rc.0 still has the bug. To avoid triggering it until people upgrade we can simply remove the extra fields from the generated zip archives.