### PR TITLE
Implements caching at the http text layer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -401,7 +401,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -410,7 +410,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -590,6 +590,20 @@ dependencies = [
  "darling_core",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "dashmap"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -1025,6 +1039,12 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
@@ -3607,7 +3627,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4101,6 +4121,7 @@ dependencies = [
  "clipanion",
  "colored 3.0.0",
  "convert_case 0.8.0",
+ "dashmap",
  "dialoguer",
  "env_logger",
  "fancy-regex",

--- a/packages/zpm/Cargo.toml
+++ b/packages/zpm/Cargo.toml
@@ -48,3 +48,4 @@ hickory-resolver = "0.25.2"
 indexmap = {version = "2.11.0", features = ["serde"]}
 sha2 = "0.10.8"
 hex = "0.4.3"
+dashmap = "6.1.0"

--- a/packages/zpm/src/install.rs
+++ b/packages/zpm/src/install.rs
@@ -1,5 +1,6 @@
 use std::{collections::{BTreeMap, BTreeSet}, hash::Hash, marker::PhantomData, sync::LazyLock};
 
+use dashmap::DashMap;
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use zpm_config::PackageExtension;
 use zpm_primitives::{Descriptor, Ident, Locator, PatchRange, PeerRange, Range, RegistrySemverRange, RegistryTagRange, SemverDescriptor, SemverPeerRange};
@@ -21,6 +22,7 @@ pub struct InstallContext<'a> {
     pub check_checksums: bool,
     pub check_resolutions: bool,
     pub enforced_resolutions: BTreeMap<Descriptor, Locator>,
+    pub npm_metadata_cache: Option<&'a DashMap<Ident, String>>,
     pub refresh_lockfile: bool,
     pub mode: Option<InstallMode>,
 }
@@ -34,6 +36,7 @@ impl<'a> Default for InstallContext<'a> {
             check_checksums: false,
             check_resolutions: false,
             enforced_resolutions: BTreeMap::new(),
+            npm_metadata_cache: None,
             refresh_lockfile: false,
             mode: None,
         }
@@ -48,6 +51,11 @@ impl<'a> InstallContext<'a> {
 
     pub fn with_project(mut self, project: Option<&'a Project>) -> Self {
         self.project = project;
+        self
+    }
+
+    pub fn with_npm_metadata_cache(mut self, npm_metadata_cache: Option<&'a DashMap<Ident, String>>) -> Self {
+        self.npm_metadata_cache = npm_metadata_cache;
         self
     }
 

--- a/packages/zpm/src/project.rs
+++ b/packages/zpm/src/project.rs
@@ -1,5 +1,6 @@
 use std::{collections::{BTreeMap, HashSet}, io::ErrorKind, sync::Arc, time::UNIX_EPOCH};
 
+use dashmap::DashMap;
 use globset::{GlobBuilder, GlobSetBuilder};
 use zpm_config::{Configuration, ConfigurationContext};
 use zpm_macro_enum::zpm_enum;
@@ -625,9 +626,13 @@ impl Project {
                 }
             }
 
+            let npm_metadata_cache
+                = DashMap::new();
+
             let install_context = InstallContext::default()
                 .with_package_cache(Some(&package_cache))
                 .with_project(Some(self))
+                .with_npm_metadata_cache(Some(&npm_metadata_cache))
                 .set_check_checksums(options.check_checksums)
                 .set_enforced_resolutions(options.enforced_resolutions)
                 .set_refresh_lockfile(options.refresh_lockfile)


### PR DESCRIPTION
Alternative to #81 to compare performances of multiple approaches (because #81 seemed slower than base, which I suspect might be because it tries to parse *everything*, instead of skipping over versions that don't matter). This time instead of storing the full parsed metadata we just store the text itself. This should at least let us skip network calls.