### PR TITLE
Moves content flags into the install state

### DIFF
--- a/packages/zpm-utils/src/misc.rs
+++ b/packages/zpm-utils/src/misc.rs
@@ -28,6 +28,20 @@ impl<T> UnwrapInfallible for Result<T, Infallible> {
     }
 }
 
+pub trait ResultExt<T, E> {
+    fn discard_error(self, f: impl Fn(&E) -> bool) -> Result<Option<T>, E>;
+}
+
+impl<T, E> ResultExt<T, E> for Result<T, E> {
+    fn discard_error(self, f: impl Fn(&E) -> bool) -> Result<Option<T>, E> {
+        match self {
+            Ok(value) => Ok(Some(value)),
+            Err(err) if f(&err) => Ok(None),
+            Err(err) => Err(err),
+        }
+    }
+}
+
 pub trait IoResultExt<T, E> {
     fn discard_io_error(self, f: impl Fn(std::io::ErrorKind) -> bool) -> Result<Option<T>, E>;
     fn ok_missing(self) -> Result<Option<T>, E>;

--- a/packages/zpm/src/commands/install.rs
+++ b/packages/zpm/src/commands/install.rs
@@ -1,5 +1,6 @@
 use clipanion::cli;
 use zpm_config::Source;
+use zpm_utils::ResultExt;
 
 use crate::{error::Error, project::{self, InstallMode, RunInstallOptions}};
 
@@ -42,6 +43,9 @@ impl Install {
             project.config.settings.enable_immutable_cache.value = true;
             project.config.settings.enable_immutable_cache.source = Source::Cli;
         }
+
+        // Discard errors; worst case scenario we just recompute the whole state from scratch.
+        let _ = project.import_install_state();
 
         project.run_install(RunInstallOptions {
             check_checksums: self.check_checksums,

--- a/packages/zpm/src/content_flags.rs
+++ b/packages/zpm/src/content_flags.rs
@@ -4,14 +4,11 @@ use bincode::{Decode, Encode};
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use serde_with::{DefaultOnError, serde_as};
-use zpm_primitives::Locator;
+use zpm_primitives::{Ident, Locator, Reference};
 use zpm_utils::Path;
 
 use crate::{
-    build,
-    error::Error,
-    fetchers::PackageData,
-    system,
+    build, error::Error, fetchers::PackageData, manifest::bin::BinField, system
 };
 
 static UNPLUG_SCRIPTS: &[&str] = &["preinstall", "install", "postinstall"];
@@ -30,6 +27,12 @@ static UNPLUG_EXT_REGEX: LazyLock<Regex> = LazyLock::new(|| {
  */
 #[derive(Clone, Debug, Encode, Decode, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ContentFlags {
+    /**
+     * The binaries that should be made available to the package.
+     */
+    #[serde(default)]
+    pub binaries: BTreeMap<String, Path>,
+
     /**
      * The build scripts that should be run after the package got installed.
      */
@@ -53,6 +56,7 @@ pub struct ContentFlags {
 impl Default for ContentFlags {
     fn default() -> Self {
         Self {
+            binaries: BTreeMap::new(),
             build_commands: vec![],
             prefer_extracted: None,
             suggest_extracted: false,
@@ -65,7 +69,13 @@ impl Default for ContentFlags {
 #[serde(rename_all = "camelCase")]
 struct Manifest {
     #[serde(default)]
+    name: Option<Ident>,
+
+    #[serde(default)]
     r#type: Option<String>,
+
+    #[serde(default)]
+    bin: Option<BinField>,
 
     #[serde(default)]
     requirements: system::Requirements,
@@ -78,8 +88,28 @@ struct Manifest {
     scripts: BTreeMap<String, String>,
 }
 
+fn extract_binaries(name: Option<Ident>, bin: Option<BinField>) -> BTreeMap<String, Path> {
+    let Some(bin) = bin else {
+        return BTreeMap::new();
+    };
+
+    match bin {
+        BinField::String(path) => name
+            .map(|name| BTreeMap::from_iter([(name.name().to_string(), path.path)]))
+            .unwrap_or_default(),
+
+        BinField::Map(bins) => bins.into_iter()
+            .map(|(name, path)| (name.name().to_string(), path.path))
+            .collect(),
+    }
+}
+
 impl ContentFlags {
     pub fn extract(locator: &Locator, package_data: &PackageData) -> Result<Self, Error> {
+        if matches!(locator.reference, Reference::Link(_)) {
+            return Ok(Self::default());
+        }
+
         match package_data {
             PackageData::Local {package_directory, is_synthetic_package} if !is_synthetic_package => {
                 Self::extract_local(package_directory)
@@ -110,6 +140,7 @@ impl ContentFlags {
                 .collect::<Vec<_>>();
 
         Ok(ContentFlags {
+            binaries: extract_binaries(manifest.name, manifest.bin),
             build_commands,
             prefer_extracted: Some(false),
             suggest_extracted: false,
@@ -152,6 +183,7 @@ impl ContentFlags {
             = entries.iter().any(|entry| UNPLUG_EXT_REGEX.is_match(&entry.name));
 
         Ok(ContentFlags {
+            binaries: extract_binaries(meta_manifest.name, meta_manifest.bin),
             build_commands,
             prefer_extracted,
             suggest_extracted,

--- a/packages/zpm/src/git.rs
+++ b/packages/zpm/src/git.rs
@@ -16,8 +16,6 @@ use crate::{
     script::ScriptEnvironment,
 };
 
-static NEW_STYLE_GIT_SELECTOR: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"^[a-z]+=").unwrap());
-
 #[derive(Debug)]
 pub enum GitOperation {
     Merge,
@@ -184,6 +182,8 @@ async fn resolve_git_treeish_stricter(repo: &GitSource, treeish: GitTreeish, con
 
 fn make_git_env() -> BTreeMap<String, String> {
     let mut env = BTreeMap::new();
+
+    env.insert("GIT_TERMINAL_PROMPT".to_string(), "0".to_string());
 
     if let Err(std::env::VarError::NotPresent) = std::env::var("GIT_SSH_COMMAND") {
         let ssh = std::env::var("GIT_SSH").unwrap_or("ssh".to_string());

--- a/packages/zpm/src/install.rs
+++ b/packages/zpm/src/install.rs
@@ -12,7 +12,6 @@ use crate::{
     build, cache::CompositeCache, content_flags::ContentFlags, error::Error, fetchers::{fetch_locator, patch::has_builtin_patch, try_fetch_locator_sync, PackageData, SyncFetchAttempt}, graph::{GraphCache, GraphIn, GraphOut, GraphTasks}, linker, lockfile::{Lockfile, LockfileEntry, LockfileMetadata}, primitives_exts::RangeExt, project::{InstallMode, Project}, report::{async_section, with_context_result, ReportContext}, resolvers::{resolve_descriptor, resolve_locator, try_resolve_descriptor_sync, validate_resolution, Resolution, SyncResolutionAttempt}, system, tree_resolver::{ResolutionTree, TreeResolver}
 };
 
-
 #[derive(Clone)]
 pub struct InstallContext<'a> {
     pub package_cache: Option<&'a CompositeCache>,
@@ -449,6 +448,7 @@ impl<'a> GraphCache<InstallContext<'a>, InstallOp<'a>, InstallOpResult> for Inst
 #[derive(Clone, Debug, Encode, Decode, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub struct InstallState {
     pub last_installed_at: u128,
+    pub content_flags: BTreeMap<Locator, ContentFlags>,
     pub resolution_tree: ResolutionTree,
     pub descriptor_to_locator: BTreeMap<Descriptor, Locator>,
     pub normalized_resolutions: BTreeMap<Locator, Resolution>,
@@ -510,6 +510,7 @@ pub struct InstallManager<'a> {
     initial_lockfile: Lockfile,
     roots: Vec<Descriptor>,
     context: InstallContext<'a>,
+    previous_state: Option<&'a InstallState>,
     result: Install,
 }
 
@@ -525,12 +526,18 @@ impl<'a> InstallManager<'a> {
             initial_lockfile: Lockfile::new(),
             roots: vec![],
             context: InstallContext::default(),
+            previous_state: None,
             result: Install::default(),
         }
     }
 
     pub fn with_context(mut self, context: InstallContext<'a>) -> Self {
         self.context = context;
+        self
+    }
+
+    pub fn with_previous_state(mut self, previous_state: Option<&'a InstallState>) -> Self {
+        self.previous_state = previous_state;
         self
     }
 
@@ -586,7 +593,7 @@ impl<'a> InstallManager<'a> {
                 },
 
                 (InstallOp::Fetch {locator, ..}, InstallOpResult::Fetched(FetchResult {package_data, ..})) => {
-                    self.record_fetch(locator, package_data);
+                    self.record_fetch(locator, package_data)?;
                 },
 
                 _ => panic!("Unsupported install result ({:?})", entry),
@@ -627,9 +634,6 @@ impl<'a> InstallManager<'a> {
             })
             .collect::<Result<BTreeMap<_, _>, Error>>()?;
 
-        let are_metadata_up_to_date
-            = self.result.lockfile.metadata.version == self.initial_lockfile.metadata.version;
-
         for entry in self.result.lockfile.entries.values_mut() {
             let package_data = self.result.package_data
                 .get(&entry.resolution.locator)
@@ -640,12 +644,6 @@ impl<'a> InstallManager<'a> {
 
             let previous_checksum = previous_entry
                 .and_then(|s| s.checksum.as_ref());
-            let mut previous_flags = previous_entry
-                .map(|s| &s.flags);
-
-            if !are_metadata_up_to_date || entry.resolution.locator.reference.is_disk_reference() {
-                previous_flags = None;
-            }
 
             let mut checksum = package_data.checksum()
                 .or_else(|| previous_checksum.cloned())
@@ -683,20 +681,7 @@ impl<'a> InstallManager<'a> {
                 }
             }
 
-            let mut content_flags
-                = None;
-
-            if let Some(previous_flags) = previous_flags {
-                content_flags = Some(previous_flags.clone());
-            }
-
-            let content_flags = content_flags.map_or_else(
-                || ContentFlags::extract(&entry.resolution.locator, &package_data),
-                Ok,
-            )?;
-
             entry.checksum = checksum;
-            entry.flags = content_flags;
         }
 
         self.result.install_state.resolution_tree = TreeResolver::default()
@@ -722,7 +707,6 @@ impl<'a> InstallManager<'a> {
         self.result.lockfile.entries.insert(resolution.locator.clone(), LockfileEntry {
             checksum: None,
             resolution: original_resolution,
-            flags: ContentFlags::default(),
         });
 
         if resolution.requirements.is_conditional() {
@@ -737,7 +721,7 @@ impl<'a> InstallManager<'a> {
         }
 
         if let Some(package_data) = package_data {
-            self.record_fetch(resolution.locator, package_data);
+            self.record_fetch(resolution.locator, package_data)?;
         }
 
         Ok(())
@@ -747,8 +731,18 @@ impl<'a> InstallManager<'a> {
         self.result.install_state.descriptor_to_locator.insert(descriptor, locator);
     }
 
-    fn record_fetch(&mut self, locator: Locator, package_data: PackageData) {
-        self.result.package_data.insert(locator, package_data);
+    fn record_fetch(&mut self, locator: Locator, package_data: PackageData) -> Result<(), Error> {
+        let content_flags
+            = self.previous_state
+                .and_then(|previous_state| previous_state.content_flags.get(&locator))
+                .cloned()
+                .map_or_else(|| ContentFlags::extract(&locator, &package_data), Ok)?;
+
+        self.result.package_data.insert(locator.clone(), package_data);
+
+        self.result.install_state.content_flags.insert(locator, content_flags);
+
+        Ok(())
     }
 }
 

--- a/packages/zpm/src/linker/helpers.rs
+++ b/packages/zpm/src/linker/helpers.rs
@@ -191,10 +191,9 @@ pub fn get_package_internal_info(project: &Project, install: &Install, dependenc
     // should always be the same for the same package, so we keep them in
     // the install state so we don't have to recompute them at every install.
     //
-    let package_flags = &install.lockfile.entries
+    let package_flags = &install.install_state.content_flags
         .get(&locator.physical_locator())
-        .expect("Expected package flags to be set")
-        .flags;
+        .expect("Expected package flags to be set");
 
     // We don't take into account `is_compatible` here, as it may change
     // depending on the system and we don't want the paths encoded in the

--- a/packages/zpm/src/lockfile.rs
+++ b/packages/zpm/src/lockfile.rs
@@ -7,7 +7,6 @@ use zpm_primitives::{Descriptor, Locator};
 use zpm_utils::{FromFileString, Hash64, ToFileString};
 
 use crate::{
-    content_flags::ContentFlags,
     error::Error,
     resolvers::Resolution,
 };
@@ -18,9 +17,6 @@ const LOCKFILE_VERSION: u64 = 9;
 pub struct LockfileEntry {
     pub checksum: Option<Hash64>,
     pub resolution: Resolution,
-
-    #[serde(default, skip_serializing_if = "zpm_utils::is_default")]
-    pub flags: ContentFlags,
 }
 
 #[derive(Clone, Debug, Default, Encode, Decode, PartialEq, Eq)]
@@ -275,7 +271,6 @@ pub fn from_legacy_berry_lockfile(data: &str) -> Result<Lockfile, Error> {
                 optional_peer_dependencies: Default::default(),
                 missing_peer_dependencies: Default::default(),
             },
-            flags: Default::default(),
         });
     }
 

--- a/packages/zpm/src/project.rs
+++ b/packages/zpm/src/project.rs
@@ -4,7 +4,7 @@ use globset::{GlobBuilder, GlobSetBuilder};
 use zpm_config::{Configuration, ConfigurationContext};
 use zpm_macro_enum::zpm_enum;
 use zpm_primitives::{Descriptor, Ident, Locator, Reference, WorkspaceIdentReference, WorkspaceMagicRange, WorkspacePathReference};
-use zpm_utils::{impl_file_string_from_str, impl_file_string_serialization, Path, ToFileString};
+use zpm_utils::{impl_file_string_from_str, impl_file_string_serialization, Path, ToFileString, ToHumanString};
 use serde::Deserialize;
 use zpm_formats::zip::ZipSupport;
 
@@ -16,7 +16,7 @@ use crate::{
     http::HttpClient,
     install::{InstallContext, InstallManager, InstallState},
     lockfile::{from_legacy_berry_lockfile, Lockfile},
-    manifest::{bin::BinField, helpers::read_manifest_with_size, BinManifest, Manifest},
+    manifest::{helpers::read_manifest_with_size, Manifest},
     manifest_finder::CachedManifestFinder,
     report::{with_report_result, StreamReport, StreamReportConfig},
     script::{Binary, ScriptEnvironment},
@@ -438,34 +438,17 @@ impl Project {
         let install_state = self.install_state.as_ref()
             .ok_or(Error::InstallStateNotFound)?;
 
-        let location = install_state.locations_by_package.get(locator)
-            .expect("Expected locator to have a location");
+        let package_location = install_state.locations_by_package.get(locator)
+            .unwrap_or_else(|| panic!("Expected {} to have a package location", locator.to_print_string()));
 
-        let manifest_text = self.project_cwd
-            .with_join(location)
-            .with_join_str(MANIFEST_NAME)
-            .fs_read_text_with_zip()?;
+        let content_flags = install_state.content_flags.get(&locator.physical_locator())
+            .unwrap_or_else(|| panic!("Expected {} to have content flags", locator.to_print_string()));
 
-        let manifest
-            = sonic_rs::from_str::<BinManifest>(&manifest_text)
-                .map_err(|_| Error::ManifestParseError(location.clone()))?;
+        let binaries = content_flags.binaries.iter()
+            .map(|(name, path)| (name.clone(), Binary::new(self, package_location.with_join(&path))))
+            .collect();
 
-        Ok(match manifest.bin {
-            Some(BinField::String(bin)) => {
-                if let Some(name) = manifest.name {
-                    BTreeMap::from_iter([(name.name().to_string(), Binary::new(self, location.with_join(&bin.path)))])
-                } else {
-                    BTreeMap::new()
-                }
-            }
-
-            Some(BinField::Map(bins)) => bins
-                .into_iter()
-                .map(|(name, path)| (name.name().to_string(), Binary::new(self, location.with_join(&path.path))))
-                .collect(),
-
-            None => BTreeMap::new(),
-        })
+        Ok(binaries)
     }
 
     pub fn package_visible_binaries(&self, locator: &Locator) -> Result<BTreeMap<String, Binary>, Error> {
@@ -637,6 +620,7 @@ impl Project {
             InstallManager::new()
                 .with_context(install_context)
                 .with_lockfile(lockfile?)
+                .with_previous_state(self.install_state.as_ref())
                 .with_roots_iter(self.workspaces.iter().map(|w| w.descriptor()))
                 .resolve_and_fetch().await?
                 .finalize(self).await?;

--- a/packages/zpm/src/script.rs
+++ b/packages/zpm/src/script.rs
@@ -1,8 +1,9 @@
 use std::{collections::BTreeMap, ffi::OsStr, fs::Permissions, io::Read, os::unix::{fs::PermissionsExt, process::ExitStatusExt}, process::{ExitStatus, Output}, sync::LazyLock};
 
-use serde::Serialize;
+use bincode::{Decode, Encode};
+use serde::{Deserialize, Serialize};
 use zpm_primitives::Locator;
-use zpm_utils::{to_shell_line, FromFileString, Hash64, IoResultExt, Path, ToFileString};
+use zpm_utils::{to_shell_line, FromFileString, Hash64, Path, ToFileString};
 use itertools::Itertools;
 use regex::Regex;
 use tokio::process::Command;
@@ -84,13 +85,13 @@ fn get_self_path() -> Result<Path, Error> {
     Ok(self_path)
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Encode, Decode, Serialize, Deserialize)]
 pub enum BinaryKind {
     Default,
     Node,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Encode, Decode, Serialize, Deserialize)]
 pub struct Binary {
     pub path: Path,
     pub kind: BinaryKind,

--- a/yarn.lock
+++ b/yarn.lock
@@ -506,15 +506,6 @@
           "@esbuild/win32-ia32",
           "@esbuild/win32-x64"
         ]
-      },
-      "flags": {
-        "build_commands": [
-          {
-            "type": "Script",
-            "event": "postinstall",
-            "script": "node install.js"
-          }
-        ]
       }
     },
     "lodash@npm:^4.17.21": {
@@ -538,9 +529,6 @@
           "lodash": "^4.17.21",
           "typescript": "^5.8.3"
         }
-      },
-      "flags": {
-        "prefer_extracted": false
       }
     },
     "tslib@npm:^2.4.0": {
@@ -597,9 +585,6 @@
           "esbuild": "^0.25.5",
           "lodash": "^4.17.21"
         }
-      },
-      "flags": {
-        "prefer_extracted": false
       }
     }
   }


### PR DESCRIPTION
I noticed regressions in `yarn run` on large projects. After some investigation I found out this is caused by the need to deflate manifests from the archives. It probably started after we implemented zip compression. I considered two fixes:

- Never compress the package.json files
- Precompute the binaries during install

The first felt the wrong option because it'd have required the cache to make assumptions on the content of the archives it receives. The second option felt cleaner, and easier as we already have a mechanism to store extra metadata from a package: content flags.

Those flags were previously stored in the lockfile (so they could be reused between installs), I took the opportunity to move them into the install state (which can also be reused between installs, but is gitignore). This makes the lockfile closer from what we used to have in Berry.