### PR TITLE
Fixes scripts surrounded by parentheses

### DIFF
--- a/packages/zpm-utils/src/lib.rs
+++ b/packages/zpm-utils/src/lib.rs
@@ -11,6 +11,7 @@ mod pretty;
 mod process;
 mod serialization_builtins;
 mod serialization;
+mod shell;
 mod system;
 mod url;
 
@@ -28,5 +29,6 @@ pub use crate::pretty::*;
 pub use crate::process::*;
 pub use crate::serialization_builtins::*;
 pub use crate::serialization::*;
+pub use crate::shell::*;
 pub use crate::system::*;
 pub use crate::url::*;

--- a/packages/zpm-utils/src/shell.rs
+++ b/packages/zpm-utils/src/shell.rs
@@ -1,0 +1,3 @@
+pub fn shell_escape(s: &str) -> String {
+    format!("'{}'", s.replace("'", "'\"'\"'"))
+}

--- a/packages/zpm/src/script.rs
+++ b/packages/zpm/src/script.rs
@@ -3,7 +3,7 @@ use std::{collections::BTreeMap, ffi::OsStr, fs::Permissions, io::Read, os::unix
 use bincode::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 use zpm_primitives::Locator;
-use zpm_utils::{to_shell_line, FromFileString, Hash64, Path, ToFileString};
+use zpm_utils::{shell_escape, to_shell_line, FromFileString, Hash64, Path, ToFileString};
 use itertools::Itertools;
 use regex::Regex;
 use tokio::process::Command;
@@ -598,12 +598,19 @@ impl ScriptEnvironment {
     }
 
     pub async fn run_script<I, S>(&mut self, script: &str, args: I) -> Result<ScriptResult, Error> where I: IntoIterator<Item = S>, S: AsRef<OsStr> + ToString {
+        let mut final_script
+            = script.to_string();
+
+        for arg in args {
+            final_script.push(' ');
+            final_script.push_str(&shell_escape(arg.to_string().as_str()));
+        }
+
         let mut bash_args = vec![];
 
         bash_args.push("-c".to_string());
-        bash_args.push(format!("{} \"$@\"", script));
+        bash_args.push(final_script);
         bash_args.push("yarn-script".to_string());
-        bash_args.extend(args.into_iter().map(|arg| arg.to_string()));
 
         self.run_exec("bash", bash_args).await
     }


### PR DESCRIPTION
The current implementation was appending `"$@"` to the end of the executed script and was passing extra arguments through bash (to avoid having to escape them). Unfortunately this cannot work for every script, as things like `(echo)` would end up as syntax errors due to the parentheses.

Instead we now revert to escaping the user shell arguments using single quotes.