### PR TITLE
Fixes yarn info when using packageExtensions

### DIFF
--- a/packages/zpm-primitives/src/descriptor.rs
+++ b/packages/zpm-primitives/src/descriptor.rs
@@ -66,6 +66,14 @@ impl Descriptor {
         }
     }
 
+    pub fn physical_descriptor(&self) -> Descriptor {
+        if let Range::Virtual(params) = &self.range {
+            Descriptor::new_bound(self.ident.clone(), params.inner.physical_range().clone(), self.parent.clone())
+        } else {
+            self.clone()
+        }
+    }
+
     pub fn resolve_with(&self, reference: Reference) -> Locator {
         let parent = match reference.must_bind() {
             true => self.parent.clone().map(Arc::new),

--- a/packages/zpm-primitives/src/range.rs
+++ b/packages/zpm-primitives/src/range.rs
@@ -141,6 +141,14 @@ impl Range {
         }
     }
 
+    pub fn physical_range(&self) -> &Range {
+        if let Range::Virtual(params) = self {
+            params.inner.physical_range()
+        } else {
+            self
+        }
+    }
+
     pub fn to_semver_range(&self) -> Option<zpm_semver::Range> {
         match self {
             Range::AnonymousSemver(params) => {


### PR DESCRIPTION
When using `packageExtensions`, new dependencies / peer dependencies will be injected into the package that weren't there before. Because `yarn info` was retrieving data from both `normalized_resolutions` (which didn't contain those information) and `locator_resolutions` (which did), some assumptions didn't hold.

This was initially done because packages with peer dependencies aren't part of `locator_resolutions` on their own, having been virtualized (ie only their virtualized entries remain). But I addressed that another, by using one of the virtuals in place of its original parent when necessary (we just prune the virtual dependencies from the output, which gives us the same result).