### PR TITLE
Discards errors when updating the mtime flag

### DIFF
--- a/packages/zpm-switch/src/cache.rs
+++ b/packages/zpm-switch/src/cache.rs
@@ -122,8 +122,10 @@ pub async fn ensure<R: Future<Output = Result<(), Error>>, F: FnOnce(Path) -> R>
             let ready_path = cache_path
                 .with_join_str(".ready");
 
-            ready_path
-                .fs_set_modified(std::time::SystemTime::now())?;
+            // Not a big deal if this fails, which may happen on filesystems
+            // with limited permissions (read-only ones)
+            let _ = ready_path
+                .fs_set_modified(std::time::SystemTime::now());
 
             Ok(cache_path)
         },


### PR DESCRIPTION
We currently update the mtime from the `.ready` file for every command we run, which lets us know when's the last time the binary was useful (which can be useful for cache eviction).

Unfortunately, it doesn't work on read-only filesystems. It's not a big deal (most are docker containers anyway), so we can just ignore those errors.