### PR TITLE
Installs Yarn Switch in all available shells

### DIFF
--- a/packages/zpm-switch/src/commands/switch/postinstall.rs
+++ b/packages/zpm-switch/src/commands/switch/postinstall.rs
@@ -79,7 +79,7 @@ impl PostinstallCommand {
             ShellProfile {
                 name: "Fish".to_string(),
                 force: self.check_has_binary("fish"),
-                rc_file: home.with_join_str(".fish/config.fish"),
+                rc_file: home.with_join_str(".config/fish/config.fish"),
                 rc_line: format!("source \"{}\"\n", home.with_join_str(".yarn/switch/env/fish").to_file_string()),
                 env_file: home.with_join_str(".yarn/switch/env/fish"),
                 env_line: format!("set -x PATH \"{}:$PATH\"", bin_dir.to_file_string()),


### PR DESCRIPTION
This diff makes sure Yarn Switch is installed in all available shells rather than just the one selected based on the $SHELL environment variable. This detection method is unreliable as it's not updated when switching from one shell to another.

I also updated the scripts to use different env files depending on the shell, as they sometimes have different syntaxes (in particular fish vs everything else), and trying to satisfy both was causing oddities (like `set +x` being accidentally enabled in zsh, causing a bunch of debug statements).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors postinstall to update Bash/Zsh/Fish profiles using per-shell env files, improve GHA PATH handling, and adjust Volta interference checks.
> 
> - **Postinstall workflow (`packages/zpm-switch/src/commands/switch/postinstall.rs`)**:
>   - **Multi-shell setup**: Replace `$SHELL`-based detection with explicit updates for `Bash`, `Zsh`, and `Fish`.
>     - Introduce `ShellProfile` struct (`name`, `force`, `rc_file`, `rc_line`, `env_file`, `env_line`).
>     - Write per-shell env files: `~/.yarn/switch/env/sh` (POSIX) and `~/.yarn/switch/env/fish` (Fish) with appropriate `PATH` syntax.
>     - Append sourcing lines to `~/.bashrc`, `~/.zshrc`, and `~/.config/fish/config.fish` when applicable.
>   - **File-writing helpers**: Add `check_has_binary`, `update_shell_profiles`, `write_env`, and `write_rc`; refactor `write_profile` to use them and improve warnings.
>   - **GitHub Actions**: Rename `check_github_path` -> `install_github_path`; append bin dir to `GITHUB_PATH` and skip profile edits in CI.
>   - **Volta check**: Update `check_volta_interference` to prioritize the installed bin dir in `PATH` during Node check; keep `apply_volta_workaround` unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 84ba731ce3f7f0ba6c029b37bca8a95a0c3c0203. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->