### PR TITLE
Adds support for workspace: dependencies in git dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -358,28 +358,31 @@ checksum = "aaa6b4b263a5d737e9bf6b7c09b72c41a5480aec4d7219af827f6564e950b6a5"
 [[package]]
 name = "clipanion"
 version = "0.8.1"
-source = "git+https://github.com/arcanis/clipanion-rs.git#85dba1d6998584e468889994ac9820a4bd254362"
+source = "git+https://github.com/arcanis/clipanion-rs.git#3fffad8efca4577f9131392be5ad0c05aa10a4c6"
 dependencies = [
  "clipanion-core",
  "clipanion-derive",
  "colored 2.2.0",
  "num-traits",
+ "serde_json",
 ]
 
 [[package]]
 name = "clipanion-core"
 version = "0.8.1"
-source = "git+https://github.com/arcanis/clipanion-rs.git#85dba1d6998584e468889994ac9820a4bd254362"
+source = "git+https://github.com/arcanis/clipanion-rs.git#3fffad8efca4577f9131392be5ad0c05aa10a4c6"
 dependencies = [
  "colored 2.2.0",
  "itertools 0.14.0",
+ "serde",
  "thiserror 2.0.16",
+ "ts-rs",
 ]
 
 [[package]]
 name = "clipanion-derive"
 version = "0.8.1"
-source = "git+https://github.com/arcanis/clipanion-rs.git#85dba1d6998584e468889994ac9820a4bd254362"
+source = "git+https://github.com/arcanis/clipanion-rs.git#3fffad8efca4577f9131392be5ad0c05aa10a4c6"
 dependencies = [
  "indoc",
  "proc-macro2",
@@ -401,7 +404,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -410,7 +413,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -758,7 +761,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2228,7 +2231,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2623,7 +2626,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2702,18 +2705,28 @@ checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2722,14 +2735,15 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.140"
+version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
 dependencies = [
  "itoa",
  "memchr",
  "ryu",
  "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -3021,7 +3035,16 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -3327,6 +3350,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "ts-rs"
+version = "10.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e640d9b0964e9d39df633548591090ab92f7a4567bc31d3891af23471a3365c6"
+dependencies = [
+ "lazy_static",
+ "thiserror 2.0.16",
+ "ts-rs-macros",
+]
+
+[[package]]
+name = "ts-rs-macros"
+version = "10.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e9d8656589772eeec2cf7a8264d9cda40fb28b9bc53118ceb9e8c07f8f38730"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "termcolor",
+]
+
+[[package]]
 name = "typeid"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3623,7 +3669,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/packages/zpm-git/src/reference.rs
+++ b/packages/zpm-git/src/reference.rs
@@ -2,13 +2,23 @@ use bincode::{Decode, Encode};
 
 use zpm_utils::{DataType, FromFileString, QueryString, QueryStringValue, ToFileString, ToHumanString, UnwrapInfallible};
 
-use crate::{range::PrepareParams, Error, GitSource};
+use crate::{range::PrepareParams, Error, GitRange, GitSource, GitTreeish};
 
 #[derive(Clone, Debug, Decode, Encode, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct GitReference {
     pub repo: GitSource,
     pub commit: String,
     pub prepare_params: PrepareParams,
+}
+
+impl GitReference {
+    pub fn to_git_range(&self) -> GitRange {
+        GitRange {
+            repo: self.repo.clone(),
+            treeish: GitTreeish::Commit(self.commit.clone()),
+            prepare_params: self.prepare_params.clone(),
+        }
+    }
 }
 
 impl FromFileString for GitReference {

--- a/packages/zpm-parsers/Cargo.toml
+++ b/packages/zpm-parsers/Cargo.toml
@@ -9,7 +9,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.9"
 regex = "1.10.2"
 thiserror = "1.0"
-serde_json = "1.0.140"
+serde_json = "1.0.145"
 erased-serde = "0.4.6"
 rstest = "0.26.1"
 pretty_assertions = "1.4.1"

--- a/packages/zpm-primitives/src/range.rs
+++ b/packages/zpm-primitives/src/range.rs
@@ -149,6 +149,10 @@ impl Range {
         }
     }
 
+    pub fn is_workspace(&self) -> bool {
+        matches!(self, Range::WorkspaceMagic(_) | Range::WorkspaceSemver(_) | Range::WorkspaceIdent(_) | Range::WorkspacePath(_))
+    }
+
     pub fn to_semver_range(&self) -> Option<zpm_semver::Range> {
         match self {
             Range::AnonymousSemver(params) => {

--- a/packages/zpm-utils/Cargo.toml
+++ b/packages/zpm-utils/Cargo.toml
@@ -14,7 +14,7 @@ ouroboros = "0.18.5"
 path-slash = "0.2.1"
 radix_trie = "0.2.1"
 serde_derive = { version = "1.0.163" }
-serde_json = "1.0.124"
+serde_json = "1.0.145"
 serde = { version = "1.0.163" }
 sonic-rs = "0.5.1"
 tokio = { version = "1.39.2", features = ["fs"] }

--- a/packages/zpm/Cargo.toml
+++ b/packages/zpm/Cargo.toml
@@ -11,7 +11,7 @@ base64 = "0.22.0"
 bytes = "1.7.1"
 bincode = {version = "2.0.0-rc.3", features = ["serde"] }
 chrono = "0.4.38"
-clipanion = { git = "https://github.com/arcanis/clipanion-rs.git" }
+clipanion = { git = "https://github.com/arcanis/clipanion-rs.git", features = ["serde"] }
 colored = "3.0.0"
 dialoguer = "0.11.0"
 fancy-regex = "0.13.0"
@@ -28,7 +28,7 @@ serde_yaml = "0.9.34"
 sonic-rs = "0.5.1"
 thiserror = "1.0.63"
 tokio = { version = "1.39.2", features = ["full"] }
-serde_json = "1.0.124"
+serde_json = "1.0.145"
 serde = { version = "1.0.207", features = ["derive"] }
 wax = { git = "https://github.com/arcanis/wax.git" }
 zpm-config = { path = "../zpm-config" }

--- a/packages/zpm/src/commands/pack.rs
+++ b/packages/zpm/src/commands/pack.rs
@@ -9,7 +9,7 @@ use zpm_utils::ToFileString;
 use crate::{
     error::Error,
     manifest::helpers::parse_manifest,
-    pack::{pack_list, pack_manifest},
+    pack::{pack_list, pack_manifest, PackManifestOptions},
     project::{Project, RunInstallOptions, Workspace},
     script::ScriptEnvironment,
 };
@@ -24,6 +24,9 @@ pub struct Pack {
 
     #[cli::option("--install-if-needed", default = false)]
     install_if_needed: bool,
+
+    #[cli::option("--preserve-workspaces", default = false)]
+    preserve_workspaces: bool,
 
     #[cli::option("--json", default = false)]
     json: bool,
@@ -92,7 +95,9 @@ impl Pack {
 
     async fn dry_run(&self, project: &Project, active_workspace: &Workspace) -> Result<(), Error> {
         let pack_manifest_content
-            = pack_manifest(project, active_workspace)?;
+            = pack_manifest(project, active_workspace, PackManifestOptions {
+                preserve_workspaces: self.preserve_workspaces,
+            })?;
 
         let pack_manifest
             = parse_manifest(&pack_manifest_content)?;
@@ -115,7 +120,9 @@ impl Pack {
 
     async fn gen_archive(&self, project: &Project, active_workspace: &Workspace) -> Result<(), Error> {
         let pack_manifest_content
-            = pack_manifest(project, active_workspace)?;
+            = pack_manifest(project, active_workspace, PackManifestOptions {
+                preserve_workspaces: self.preserve_workspaces,
+            })?;
 
         let pack_manifest
             = parse_manifest(&pack_manifest_content)?;

--- a/packages/zpm/src/prepare.rs
+++ b/packages/zpm/src/prepare.rs
@@ -217,15 +217,22 @@ async fn prepare_yarn_modern_project(folder_path: &Path, params: &PrepareParams)
             .await?
             .to_file_string();
 
+    let mut pack_args
+        = vec![];
+
+    if let Some(workspace) = &params.workspace {
+        pack_args.push("workspace");
+        pack_args.push(workspace.as_str());
+    }
+
+    pack_args.push("pack");
+    pack_args.push("--install-if-needed");
+
     let pack_path = folder_path
         .with_join_str("package.tgz");
 
-    let pack_args = match &params.workspace {
-        Some(workspace_name) =>
-            vec!["workspace", workspace_name.as_str(), "pack", "--install-if-needed", "--filename", pack_path.as_str()],
-        None =>
-            vec!["pack", "--install-if-needed", "--filename", pack_path.as_str()],
-    };
+    pack_args.push("--filename");
+    pack_args.push(pack_path.as_str());
 
     ScriptEnvironment::new()?
         .with_cwd(folder_path.clone())
@@ -285,6 +292,7 @@ async fn prepare_yarn_zpm_project(folder_path: &Path, params: &PrepareParams) ->
     }
 
     pack_args.push("pack");
+    pack_args.push("--preserve-workspaces");
     pack_args.push("--install-if-needed");
     pack_args.push("--out");
     pack_args.push(archive_path.as_str());


### PR DESCRIPTION
This diff makes it possible for Yarn to resolve `workspace:` dependencies from within Git repositories. To make that work it transparently turns all `workspace:` dependencies from git locators into git ranges during normalization. This only works for zpm repositories, because it relies on a new `yarn pack` flag: `--preserve-workspaces`.

A follow-up will be to make the implementation more efficient. The current logic is a little wasteful: it clones the repository once for each package it needs to install (plus it runs an install N times).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables resolving `workspace:` dependencies in git packages by rewriting them to git ranges during install, adds `pack --preserve-workspaces` with CLI/plumbing updates, and bumps serde/serde_json and related deps.
> 
> - **Install/Resolution**:
>   - Convert `workspace:` dependency ranges to `git` ranges when the parent package is a `git` locator (`install.rs`).
>   - Add `Range::is_workspace()` helper and use `Workspace*` variants to build `GitRange`s.
> - **Git**:
>   - Add `GitReference::to_git_range()` and use `GitTreeish::Commit` (`zpm-git/reference.rs`).
> - **Pack/CLI**:
>   - Add `--preserve-workspaces` to `yarn pack` (CLI option and forwarding).
>   - Change `pack_manifest(...)` to accept `PackManifestOptions { preserve_workspaces }` and only rewrite `workspace:` deps when not preserving.
>   - `prepare` passes `--preserve-workspaces` for ZPM and refactors pack args construction.
> - **Deps/Config**:
>   - Enable `clipanion` serde feature; update `serde`, `serde_json` (and lockfile), add `ts-rs`/`termcolor` transitive entries and adjust `windows-sys` versions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3e8c407cc1a97ddb3523702666c71caf75c0bf27. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->