### PR TITLE
fix: Always use root package.json for patch packages

### DIFF
--- a/packages/zpm-formats/src/lib.rs
+++ b/packages/zpm-formats/src/lib.rs
@@ -77,6 +77,18 @@ pub struct Entry<'a> {
     pub compression: Option<Compression<'a>>,
 }
 
+impl<'a> Entry<'a> {
+    pub fn new(name: Path) -> Self {
+        Entry {
+            name,
+            mode: 0o644,
+            crc: 0,
+            data: Cow::Borrowed(b""),
+            compression: None,
+        }
+    }
+}
+
 pub fn entries_to_disk<'a>(entries: &[Entry<'a>], base: &Path) -> Result<(), Error> {
     for entry in entries {
         base.with_join(&entry.name)

--- a/packages/zpm/src/fetchers/patch.rs
+++ b/packages/zpm/src/fetchers/patch.rs
@@ -138,21 +138,8 @@ pub async fn fetch_locator<'a>(context: &InstallContext<'a>, locator: &Locator, 
         Ok(package_cache.bundle_entries(patched_entries)?)
     }).await?;
 
-    let first_entry
+    let package_json_entry
         = zpm_formats::zip::first_entry_from_zip(&cached_blob.data)?;
-
-    // Fallback: Handle old caches where the first entry might not be the root package.json
-    // This can happen if the cache was created before the fix in prepare_npm_entries
-    let package_json_entry = if first_entry.name.basename() == Some("package.json") {
-        first_entry
-    } else {
-        let entries = zpm_formats::zip::entries_from_zip(&cached_blob.data)?;
-        entries
-            .into_iter()
-            .filter(|entry| entry.name.basename() == Some("package.json"))
-            .min_by_key(|entry| entry.name.as_str().len())
-            .ok_or(Error::MissingPackageManifest)?
-    };
 
     let manifest: Manifest
         = JsonDocument::hydrate_from_slice(&package_json_entry.data)?;

--- a/packages/zpm/src/npm.rs
+++ b/packages/zpm/src/npm.rs
@@ -12,21 +12,29 @@ impl<'a, T> NpmEntryExt<'a> for T where T: Iterator<Item = Entry<'a>> {
     fn prepare_npm_entries(self, subdir: &Path) -> impl Iterator<Item = Entry<'a>> {
         self
             .into_iter()
-            .sorted_by(|a, b| {
-                let a_is_pkg = a.name.basename() == Some("package.json");
-                let b_is_pkg = b.name.basename() == Some("package.json");
 
-                match (a_is_pkg, b_is_pkg) {
-                    // Both are package.json: sort by path length (shortest first)
-                    (true, true) => a.name.as_str().len().cmp(&b.name.as_str().len()),
-                    // Only a is package.json: a comes first
-                    (true, false) => std::cmp::Ordering::Less,
-                    // Only b is package.json: b comes first
-                    (false, true) => std::cmp::Ordering::Greater,
-                    // Neither is package.json: sort alphabetically
-                    (false, false) => a.name.cmp(&b.name),
-                }
+            // We first sort by file name; we do this first because we
+            // can't return references from `sorted_by_cached_key`
+            .sorted_by(|a, b| {
+                a.name.cmp(&b.name)
             })
+
+            // Now that we've sorted by name, we perform a second sort to
+            // list values that are near the root first, and package.json
+            // files as well. Since `sorted_by_cached_key` is a stable sort
+            // we don't lose the by-name order for other entries.
+            .sorted_by_cached_key(|entry| {
+                let segment_count
+                    = entry.name.as_str().chars()
+                        .filter(|&c| c == '/')
+                        .count();
+
+                let is_package_json
+                    = entry.name.basename() == Some("package.json");
+
+                (segment_count, !is_package_json)
+            })
+
             .prefix_path(subdir)
     }
 }
@@ -64,4 +72,40 @@ pub fn registry_url_for_package_data(ident: &Ident, version: &Version) -> String
     url.push_str(".tgz");
 
     url
+}
+
+#[cfg(test)]
+mod tests {
+    use zpm_formats::Entry;
+    use zpm_utils::Path;
+
+    use crate::npm::NpmEntryExt;
+
+    #[test]
+    pub fn should_sort_npm_entries() {
+        let entries = vec![
+            Entry::new(Path::try_from("b").unwrap()),
+            Entry::new(Path::try_from("a/b/c").unwrap()),
+            Entry::new(Path::try_from("a/package.json").unwrap()),
+            Entry::new(Path::try_from("package.json").unwrap()),
+            Entry::new(Path::try_from("a/b/package.json").unwrap()),
+        ];
+
+        let prepared_entries
+            = entries.into_iter()
+                .prepare_npm_entries(&Path::try_from("foo").unwrap())
+                .collect::<Vec<_>>();
+
+        let prepared_names = prepared_entries.iter()
+            .map(|entry| entry.name.as_str())
+            .collect::<Vec<_>>();
+
+        assert_eq!(prepared_names, vec![
+            "foo/package.json",
+            "foo/b",
+            "foo/a/package.json",
+            "foo/a/b/package.json",
+            "foo/a/b/c",
+        ]);
+    }
 }


### PR DESCRIPTION
### Motivation

Installing packages with patch protocol would fail with parsing errors when the package contains subdirectory package.json files with invalid names. For example, gl-matrix has mat2/package.json with name "gl-matrix/mat2", which violates package naming rules.

This caused a problem when patching the package. 

```
➤ · Yarn 6.0.0-rc.4.local
➤ ┌ Installing packages
➤ │ gl-matrix@patch:gl-matrix%40npm%3A3.3.0#~/.yarn/patches/gl-matrix-npm-3.3.0-02575e3b95.patch: File parsing error (Invalid syntax: Invalixd ident: gl-matrix/mat2 at line 2 column 26

	ix/mat2",
  "mai
	........^.......
)
➤ └ Completed in 392ms
```

### Changes

- Fix `prepare_npm_entries` to put the root package.json on the first index
- Explicitly select the root package.json (shallowest path depth) when processing patch packages.

### How to reproduce

- add gl-matrix to a project: `yarn add gl-matrix@3.3.0`
- create and apply a patch to it: `yarn patch gl-matrix`, `yarn patch-commit -s <TMP_FOLDER>`
- run `yarn install`, it should fail

### Tests

https://iteratum.ai/examples/jest-ui/?url=https%3A%2F%2Frepo.yarnpkg.com%2Fbuilds%2Fzpm%2Fcommits%2Fa1512a92f6777b55e4d864216c890435f925a7ff%2Ftests&compareUrl=https%3A%2F%2Frepo.yarnpkg.com%2Fbuilds%2Fzpm%2Fcommits%2Fe341008ad29341f7e03adb76b871ea768101209b%2Ftests

2nd run here: https://github.com/yarnpkg/zpm/actions/runs/18473371486
