### PR TITLE
Implements a cache key for the main cache

### DIFF
--- a/packages/zpm/src/cache.rs
+++ b/packages/zpm/src/cache.rs
@@ -168,7 +168,7 @@ impl DiskCache {
 
     pub fn key_path(&self, locator: &Locator, ext: &str) -> Path {
         let key_name
-            = format!("{}{}-{}{}", locator.slug(), CACHE_VERSION, self.name_suffix, ext);
+            = format!("{}-{}{}{}", locator.slug(), CACHE_VERSION, self.name_suffix, ext);
 
         let key_path = self.cache_path
             .with_join_str(&key_name);


### PR DESCRIPTION
The cache path was missing a cache key, so it would have been a little annoying to make changes as to how Yarn generates the cache files since we would have risked to keep bad files in the cache (see for instance #119).

This isn't perfect though - Berry was able to cache files per their file hash, which isn't the case in this implementation. As a result, even archives which don't change would get a new name (their content would stay the same, but git would detect them as moved; is it a problem?).

It'd also make sense to eventually implement a mechanism to purge a cache from older cache keys, but that's for a follow-up (I don't think Berry ever had this feature for instance).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce CACHE_VERSION and include it in DiskCache key names to namespace cache entries by cache format version.
> 
> - **Cache** (`packages/zpm/src/cache.rs`):
>   - Add `CACHE_VERSION: usize = 1`.
>   - Change `DiskCache::key_path` naming to include version: `"{slug}{CACHE_VERSION}-{name_suffix}{ext}"` (was `"{slug}{name_suffix}{ext}"`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 452b282663aeb2f64e561fdc400b5fe630943faf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->