### PR TITLE
Adds a workflow building a v86 image

### DIFF
--- a/.github/workflows/v86.yml
+++ b/.github/workflows/v86.yml
@@ -27,7 +27,6 @@ jobs:
           config: |
             BR2_PACKAGE_BASH=y
             BR2_PACKAGE_GIT=y
-            BR2_PACKAGE_NODEJS=y
             BR2_SYSTEM_BIN_SH_BASH=y
           script: |
             mkdir -p root


### PR DESCRIPTION
This workflow creates a new v86 image either on manual request, or when the GH workflow gets updated. The image doesn't include the Yarn binaries so that it can be reused between releases by mounting a different cdrom (those built by #118).