### PR TITLE
fix: yarn script positional arguments

### DIFF
--- a/packages/zpm/src/script.rs
+++ b/packages/zpm/src/script.rs
@@ -4,7 +4,7 @@ use bincode::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 use zpm_parsers::JsonDocument;
 use zpm_primitives::Locator;
-use zpm_utils::{shell_escape, to_shell_line, FromFileString, Hash64, Path, ToFileString};
+use zpm_utils::{to_shell_line, FromFileString, Hash64, Path, ToFileString};
 use itertools::Itertools;
 use regex::Regex;
 use tokio::process::Command;
@@ -601,19 +601,15 @@ impl ScriptEnvironment {
     }
 
     pub async fn run_script<I, S>(&mut self, script: &str, args: I) -> Result<ScriptResult, Error> where I: IntoIterator<Item = S>, S: AsRef<OsStr> + ToString {
-        let mut final_script
-            = script.to_string();
-
-        for arg in args {
-            final_script.push(' ');
-            final_script.push_str(&shell_escape(arg.to_string().as_str()));
-        }
-
         let mut bash_args = vec![];
 
         bash_args.push("-c".to_string());
-        bash_args.push(final_script);
+        bash_args.push(script.to_string());
         bash_args.push("yarn-script".to_string());
+
+        for arg in args {
+            bash_args.push(arg.to_string());
+        }
 
         self.run_exec("bash", bash_args).await
     }


### PR DESCRIPTION
## Fix `$@` expansion in yarn scripts

### Problem

Yarn scripts using `$@` to reference positional arguments were failing with syntax errors. For example:

```json
"build-zip": "cd dist && mkdir -p $(dirname \"$@\") && zip -r \"$@\" ."
```

Running `yarn build-zip output.zip` would fail with:
```
yarn-script: -c: line 1: syntax error near unexpected token `'output.zip''
```

### Cause

The `run_script` function was concatenating shell-escaped arguments directly into the script string before passing it to `bash -c`. This meant `$@` had no positional parameters to expand to, and the escaped arguments just dangled at the end of the command causing parsing issues.

### Fix

Pass arguments as bash positional parameters instead of concatenating them into the script:

```rust
// Before: args concatenated into script text
bash -c "script... $escaped_arg" yarn-script

// After: args passed as positional parameters  
bash -c "script..." yarn-script arg1 arg2
```

This allows `$@` to properly expand to the arguments passed after `$0` (`yarn-script`).

### Tests

- https://github.com/yarnpkg/zpm/actions/runs/19742355691