### PR TITLE
fix: surface workspace resolution errors during install

### DIFF
--- a/packages/zpm/src/install.rs
+++ b/packages/zpm/src/install.rs
@@ -381,12 +381,12 @@ impl<'a> GraphIn<'a, InstallContext<'a>, InstallOpResult, Error> for InstallOp<'
             },
 
             InstallOp::Resolve {descriptor} => {
-                let dependencies = match try_resolve_descriptor_sync(context.clone(), descriptor.clone(), dependencies)? {
-                    SyncResolutionAttempt::Success(result) => return Ok(InstallOpResult::Resolved(result)),
-                    SyncResolutionAttempt::Failure(dependencies) => dependencies,
-                };
-
                 with_context_result(ReportContext::Descriptor(descriptor.clone()), async {
+                    let dependencies = match try_resolve_descriptor_sync(context.clone(), descriptor.clone(), dependencies)? {
+                        SyncResolutionAttempt::Success(result) => return Ok(InstallOpResult::Resolved(result)),
+                        SyncResolutionAttempt::Failure(dependencies) => dependencies,
+                    };
+
                     let future = tokio::time::timeout(
                         timeout,
                         resolve_descriptor(context.clone(), descriptor.clone(), dependencies)
@@ -397,12 +397,12 @@ impl<'a> GraphIn<'a, InstallContext<'a>, InstallOpResult, Error> for InstallOp<'
             },
 
             InstallOp::Fetch {locator, is_mock_request} => {
-                let dependencies = match try_fetch_locator_sync(context.clone(), &locator, is_mock_request, dependencies)? {
-                    SyncFetchAttempt::Success(result) => return Ok(InstallOpResult::Fetched(result)),
-                    SyncFetchAttempt::Failure(dependencies) => dependencies,
-                };
-
                 with_context_result(ReportContext::Locator(locator.clone()), async {
+                    let dependencies = match try_fetch_locator_sync(context.clone(), &locator, is_mock_request, dependencies)? {
+                        SyncFetchAttempt::Success(result) => return Ok(InstallOpResult::Fetched(result)),
+                        SyncFetchAttempt::Failure(dependencies) => dependencies,
+                    };
+
                     let future = tokio::time::timeout(
                         timeout,
                         fetch_locator(context.clone(), &locator.clone(), is_mock_request, dependencies)


### PR DESCRIPTION
When a project has a dependency to a non-existing workspace (e.g., `"@myScope/myLib": "workspace:*"`), errors were silently discarded.

This wraps sync resolution/fetch operations with `with_context_result` so errors are properly reported:

```
➤ │ @myScope/nonexistent@workspace:*: Workspace not found (@myScope/nonexistent)
```

### Before: 
<img width="437" height="94" alt="image" src="https://github.com/user-attachments/assets/dbd35916-2e52-4674-8f0d-db1bab5fcb52" />

### After:
<img width="736" height="108" alt="image" src="https://github.com/user-attachments/assets/55fae419-1da2-4bbc-a5b6-557a6479f380" />
