### PR TITLE
Prevent the sync from creating empty folders

### DIFF
--- a/packages/zpm/src/fetchers/npm.rs
+++ b/packages/zpm/src/fetchers/npm.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use zpm_config::ConfigExt;
 use zpm_formats::iter_ext::IterExt;
 use zpm_primitives::{Locator, RegistryReference};

--- a/packages/zpm/src/resolvers/npm.rs
+++ b/packages/zpm/src/resolvers/npm.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeMap, str::FromStr, sync::{Arc, LazyLock}};
+use std::{collections::BTreeMap, str::FromStr, sync::LazyLock};
 
 use chrono::{DateTime, Utc};
 use regex::Regex;

--- a/yarn.lock
+++ b/yarn.lock
@@ -602,7 +602,7 @@
       }
     },
     "@astrojs/starlight@npm:^0.36.2": {
-      "checksum": "820ba31b592504bf8a1ff5dee88512be0ba8e204f9a7f5cb121775d2d9158e945fcfdfda6a2bd863aa1e054f0bcbbe7cb75c70ff436ca27f53078c1c8c9697f0",
+      "checksum": "379604329750d97ac5c41fb6f999036d6a07924d26d3abd9425078cb0d66cbf5598dce8e1471403b7071f255a7d46caa040e2d818f1e5a0b8c15ce011c1aaf53",
       "resolution": {
         "resolution": "@astrojs/starlight@npm:0.36.2",
         "version": "0.36.2",
@@ -6913,7 +6913,7 @@
       }
     },
     "dedent@npm:^1.7.0": {
-      "checksum": "db3a07b7905e7338600e49e26ad4559ed8c6d0e4014e245da61a46b2b6858d39b255c8cbc23be5201c5ecde4dd05b33c08ab17535f0d34ac79d942339cd63f25",
+      "checksum": "5ffc45361606ce5ac9649a4f846a0315b37e6b01548c659be801bd522051eadf01e621883386bf175020f871bd721b707155fef64f8c5fe05e316132444bc1f5",
       "resolution": {
         "resolution": "dedent@npm:1.7.0",
         "version": "1.7.0",
@@ -9076,7 +9076,7 @@
       }
     },
     "inline-style-parser@npm:0.2.6": {
-      "checksum": "849d8b9772001aaf6fce97306006335612c63af8de13741ddb5518fe0ca44ee513eba343178010c5c9653e6e4cd38160d187820fa8dcc69c03c4a3fb6aad144d",
+      "checksum": "58c80dd56c032a24d77a202423a967b0b07f5f4ddff48b07037a6c87051268d9d5bccf123b2feb5c82960fad4e44920b0b212b9a9b6b125c3571cbe3f59dc556",
       "resolution": {
         "resolution": "inline-style-parser@npm:0.2.6",
         "version": "0.2.6"


### PR DESCRIPTION
The sync algorithm always creates an empty node for `.`, which means it always creates a folder at the target location. This caused a bunch of empty `node_modules` folders to be added into megarepos.

We now skip over sync folders that have neither templates nor children.