### PR TITLE
Makes the PnP loader non-executable

### DIFF
--- a/packages/zpm/src/linker/pnp.rs
+++ b/packages/zpm/src/linker/pnp.rs
@@ -191,7 +191,7 @@ fn generate_inline_files(project: &Project, state: &PnpState) -> Result<(), Erro
 
     project.pnp_path()
         .fs_create_parent()?
-        .fs_change(script, true)?;
+        .fs_change(script, false)?;
 
     Ok(())
 }
@@ -214,7 +214,7 @@ fn generate_split_setup(project: &Project, state: &PnpState) -> Result<(), Error
 
     project.pnp_path()
         .fs_create_parent()?
-        .fs_change(script, true)?;
+        .fs_change(script, false)?;
 
     project.pnp_data_path()
         .fs_create_parent()?


### PR DESCRIPTION
The PnP loader was made executable in an attempt to integrate with Flow. This isn't a concern of us anymore, so let's simplify that and make the PnP loader a non-exec file by default.