### PR TITLE
Implements yarn cache clean

### DIFF
--- a/packages/zpm-switch/src/commands/switch/cache_clear.rs
+++ b/packages/zpm-switch/src/commands/switch/cache_clear.rs
@@ -41,7 +41,7 @@ impl CacheClearCommand {
                 };
 
                 if entry_last_used.elapsed().unwrap() > std::time::Duration::from_secs(60 * 60 * 24 * 7) {
-                    entry_path.fs_rm()?;
+                    entry_path.fs_rm().ok_missing()?;
                 }
             }
         } else {

--- a/packages/zpm/src/commands/cache_clear.rs
+++ b/packages/zpm/src/commands/cache_clear.rs
@@ -1,0 +1,103 @@
+use clipanion::cli;
+use itertools::Itertools;
+use zpm_utils::{DataType, IoResultExt, Path};
+
+use crate::{error::Error, project, report::{StreamReport, StreamReportConfig, current_report, with_report_result}};
+
+/// Clear the global cache
+#[cli::command]
+#[cli::path("cache", "clear")]
+#[cli::path("cache", "clean")]
+#[cli::category("Cache management")]
+pub struct CacheClear {
+    /// Clear cache entries older than 7 days
+    #[cli::option("--old", default = false)]
+    old: bool,
+}
+
+impl CacheClear {
+    pub async fn execute(&self) -> Result<(), Error> {
+        clear_cache(self.old).await
+    }
+}
+
+#[cli::command]
+#[cli::path("cache")]
+#[cli::category("Cache management")]
+pub struct CacheClear2 {
+    #[cli::option("-c,--clear,--clean")]
+    _clear: bool,
+
+    /// Clear cache entries older than 7 days
+    #[cli::option("--old", default = false)]
+    old: bool,
+}
+
+impl CacheClear2 {
+    pub async fn execute(&self) -> Result<(), Error> {
+        clear_cache(self.old).await
+    }
+}
+
+async fn clear_cache(old: bool) -> Result<(), Error> {
+    let project
+        = project::Project::new(None).await?;
+
+    let report = StreamReport::new(StreamReportConfig {
+        ..StreamReportConfig::from_config(&project.config)
+    });
+
+    with_report_result(report, async {
+        let cache_entries
+            = project.global_cache_path()
+                .fs_read_dir()
+                .ok_missing()?;
+
+        let mut cleared_entries
+            = 0;
+
+        if let Some(cache_entries) = cache_entries {
+            let cache_entries = cache_entries
+                .filter_map(|entry| entry.ok())
+                .map(|entry| Path::try_from(entry.path()))
+                .filter_map(|entry| entry.ok())
+                .filter(|entry| !old || age_filter(entry))
+                .collect_vec();
+
+            cleared_entries
+                = cache_entries.len();
+
+            for entry in &cache_entries {
+                entry.fs_rm().ok_missing()?;
+            }
+        }
+
+        current_report().await.as_mut().map(|report| {
+            if cleared_entries > 0 {
+                report.info(format!("Cleared {} entries from the cache.", DataType::Number.colorize(&cleared_entries.to_string())))
+            } else {
+                report.info("No entries to clear from the cache.".to_string());
+            }
+        });
+
+        Ok(())
+    }).await?;
+
+    Ok(())
+}
+
+fn age_filter(entry: &Path) -> bool {
+    let entry_last_used
+        = entry.fs_metadata().ok()
+            .and_then(|metadata| metadata.modified().ok());
+
+    let Some(entry_last_used) = entry_last_used else {
+        return false;
+    };
+
+    let Ok(elapsed) = entry_last_used.elapsed() else {
+        return false;
+    };
+
+    elapsed > std::time::Duration::from_secs(60 * 60 * 24 * 7)
+}

--- a/packages/zpm/src/commands/mod.rs
+++ b/packages/zpm/src/commands/mod.rs
@@ -8,6 +8,7 @@ mod npm;
 
 mod add;
 mod bin;
+mod cache_clear;
 mod config;
 mod config_get;
 mod config_set;
@@ -64,6 +65,8 @@ pub enum YarnCli {
     Add(add::Add),
     BinList(bin::BinList),
     Bin(bin::Bin),
+    CacheClear(cache_clear::CacheClear),
+    CacheClear2(cache_clear::CacheClear2),
     Config(config::Config),
     ConfigGet(config_get::ConfigGet),
     ConfigSet(config_set::ConfigSet),

--- a/packages/zpm/src/project.rs
+++ b/packages/zpm/src/project.rs
@@ -697,9 +697,17 @@ impl Project {
             },
         };
 
-        if let Some(install_state) = &self.install_state {
-            if self.last_changed_at <= install_state.last_installed_at {
-                return Ok(());
+        let cache_exists = if self.config.settings.enable_global_cache.value {
+            self.global_cache_path().fs_exists()
+        } else {
+            self.local_cache_path().fs_exists()
+        };
+
+        if cache_exists {
+            if let Some(install_state) = &self.install_state {
+                if self.last_changed_at <= install_state.last_installed_at {
+                    return Ok(());
+                }
             }
         }
 


### PR DESCRIPTION
This PR implements `yarn cache clean`, plus aliases for `yarn cache clear` and `yarn cache -c` (this last one to mimic the Yarn Switch syntax).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds cache clean/clear/-c commands (with optional 7-day filter), wires them into the CLI with reporting, ignores missing files on deletion, and only skips install when a cache exists.
> 
> - **CLI / Commands**:
>   - Add `cache clear`/`cache clean` and `cache -c` commands in `packages/zpm/src/commands/cache_clear.rs`.
>     - Removes entries in the global cache; supports `--old` to delete items unused for >7 days.
>     - Reports number of cleared entries.
>   - Register commands in `commands/mod.rs`.
> - **Switch**:
>   - Make cache entry deletions tolerant of missing paths (`.ok_missing()`) in `zpm-switch` `switch/cache_clear.rs`.
> - **Project behavior**:
>   - In `Project::lazy_install`, only skip install if the install state is up-to-date and a cache folder (global or local) exists.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d593f93c40d1d5144da6fcdaf12a96bec93accc7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->