### PR TITLE
Fixes alias import

### DIFF
--- a/packages/zpm-primitives/src/range.rs
+++ b/packages/zpm-primitives/src/range.rs
@@ -136,11 +136,16 @@ impl Range {
         Ok(Range::AnonymousSemver(AnonymousSemverRange {range}.into()))
     }
 
-    pub fn inner_descriptor(&self) -> Option<&Descriptor> {
+    pub fn inner_descriptor(&self) -> Option<Descriptor> {
         match self {
-            Range::Patch(params) => {
-                Some(&params.inner.0)
-            },
+            Range::RegistrySemver(params) if params.ident.is_some()
+                => Some(Descriptor::new(params.ident.clone().unwrap(), RegistrySemverRange {ident: None, range: params.range.clone()}.into())),
+
+            Range::RegistryTag(params) if params.ident.is_some()
+                => Some(Descriptor::new(params.ident.clone().unwrap(), RegistryTagRange {ident: None, tag: params.tag.clone()}.into())),
+
+            Range::Patch(params)
+                => Some(params.inner.0.clone()),
 
             _ => None,
         }

--- a/packages/zpm/src/install.rs
+++ b/packages/zpm/src/install.rs
@@ -332,7 +332,7 @@ impl<'a> GraphIn<'a, InstallContext<'a>, InstallOpResult, Error> for InstallOp<'
                     resolved_it.next();
                 }
 
-                if let Some(mut inner_descriptor) = descriptor.range.inner_descriptor().cloned() {
+                if let Some(mut inner_descriptor) = descriptor.range.inner_descriptor() {
                     if inner_descriptor.range.details().require_binding {
                         inner_descriptor.parent = descriptor.parent.clone();
                     }

--- a/packages/zpm/src/primitives_exts.rs
+++ b/packages/zpm/src/primitives_exts.rs
@@ -30,6 +30,22 @@ impl RangeExt for Range {
     #[inline]
     fn details(&self) -> RangeDetails {
         match self {
+            Range::RegistrySemver(params) if params.ident.is_some() => {
+                RangeDetails {
+                    require_binding: false,
+                    fetch_before_resolve: false,
+                    transient_resolution: true,
+                }
+            },
+
+            Range::RegistryTag(params) if params.ident.is_some() => {
+                RangeDetails {
+                    require_binding: false,
+                    fetch_before_resolve: false,
+                    transient_resolution: true,
+                }
+            },
+
             Range::Builtin(_) |
             Range::AnonymousSemver(_) |
             Range::AnonymousTag(_) |


### PR DESCRIPTION
I noticed when running `yarn install` on the Babel repository that we were hitting a strange assertion failure. Digging into it, I figured out that the Berry lockfile import had an incorrect assumption for aliased packaged.

As a bit of prior context, Yarn Berry stored aliases like this:

```yaml
my-aliased-lodash@npm:lodash@^1.13.0:
  resolution: lodash@1.13.0
```

Whereas Yarn zpm keeps aliases like this (ignore the yaml formatting):

```yaml
my-aliased-lodash@npm:lodash@^1.13.0:
  resolution: my-aliased-lodash@npm:lodash@1.13.0

lodash@^1.13.0:
  resolution: lodash@1.13.0
```

The importer was ignoring this difference, so the generated lockfile was breaking the expected model, causing the install to crash with bad invariants.

As I fixed this I also improved how aliases are handled so that instead of resolving `my-aliased-lodash@npm:lodash@^1.13.0` as a completely separate descriptor than `lodash@^1.13.0`, we now make the first depend on the second, and only keep the second in the lockfile.

It leads to more natural interactions where overrides can affect the version of the aliased packages, which wasn't the case before.
