### PR TITLE
Fixes workspace constraints

### DIFF
--- a/packages/zpm-constraints/index.ts
+++ b/packages/zpm-constraints/index.ts
@@ -134,7 +134,7 @@ for (const workspace of input.workspaces) {
 }
 
 for (const pkg of input.packages) {
-  const workspace = pkg.workspace
+  const workspace = pkg.workspace !== null
     ? workspaceByCwd.get(pkg.workspace)!
     : null;
 
@@ -149,6 +149,9 @@ for (const pkg of input.packages) {
     peerDependencies: new Map(pkg.peerDependencies),
     optionalPeerDependencies: new Map(pkg.optionalPeerDependencies),
   };
+
+  if (workspace !== null)
+    workspace.pkg = hydratedPackage;
 
   packageByLocator.set(pkg.locator, hydratedPackage);
   packageIndex.insert(hydratedPackage);
@@ -297,7 +300,7 @@ function applyEngineReport(fix: boolean) {
           unsetValues,
         });
       } else {
-        const newValue = valuesArray[0]!;
+        const newValue = valuesArray[0]![0];
 
         const currentValue = get(manifest, fieldPath);
         if (JSON.stringify(currentValue) === JSON.stringify(newValue))

--- a/packages/zpm/src/constraints/structs.rs
+++ b/packages/zpm/src/constraints/structs.rs
@@ -155,7 +155,7 @@ pub struct ConstraintsContext<'a> {
     pub packages: Vec<ConstraintsPackage<'a>>,
 }
 
-#[derive(Serialize)]
+#[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ConstraintsDependency {
     pub ident: Ident,
@@ -164,7 +164,7 @@ pub struct ConstraintsDependency {
     pub resolution: Option<Locator>,
 }
 
-#[derive(Serialize)]
+#[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ConstraintsWorkspace {
     pub cwd: Path,
@@ -174,7 +174,7 @@ pub struct ConstraintsWorkspace {
     pub dev_dependencies: Vec<ConstraintsDependency>,
 }
 
-#[derive(Serialize)]
+#[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ConstraintsPackage<'a> {
     pub locator: Locator,


### PR DESCRIPTION
The constraints weren't passing on the Babel repository. Investigation revealed three bugs:

- We were checking whether `pkg.workspace` was falsy to see whether packages should be tied to a workspace. This didn't work for the root workspace, for which `pkg.workspace` is an empty string.

- We never assigned the hydrated package instance into the accompanying workspace instance (we only did it the other way around, assigning the workspace to the package).

- I accidentally broke in 5e2a1165f636c4b65beaeee1cc04f25e33cb0c12 the value extraction (turning `[[values]]` into `values[0]` instead of `values[0][0]` in an attempt to fix types). Since I also forgot to regenerate the constraints template it didn't matter, but still ...
