### PR TITLE
Fixes error passing from the configuration

### DIFF
--- a/packages/zpm-formats/src/error.rs
+++ b/packages/zpm-formats/src/error.rs
@@ -13,6 +13,12 @@ pub enum Error {
     #[error(transparent)]
     Utf8Conversion(#[from] std::str::Utf8Error),
 
+    #[error("Using 'mixed' as compression level is deprecated - the compression will now be automatically mixed if beneficial")]
+    MixedValueDeprecated,
+
+    #[error("Compression level must be between 0 and 9")]
+    InvalidCompressionLevel,
+
     #[error("Invalid os string conversion")]
     OsStringConversion(std::ffi::OsString),
 

--- a/packages/zpm-formats/src/lib.rs
+++ b/packages/zpm-formats/src/lib.rs
@@ -22,7 +22,19 @@ impl FromFileString for CompressionAlgorithm {
     type Error = Error;
 
     fn from_file_string(src: &str) -> Result<Self, Self::Error> {
-        Ok(CompressionAlgorithm::Deflate(src.parse().unwrap()))
+        if src == "mixed" {
+            return Err(Error::MixedValueDeprecated);
+        }
+
+        let level
+            = src.parse::<usize>()
+                .map_err(|_| Error::InvalidCompressionLevel)?;
+
+        if level > 9 {
+            return Err(Error::InvalidCompressionLevel);
+        }
+
+        Ok(CompressionAlgorithm::Deflate(level))
     }
 }
 

--- a/packages/zpm-semver/src/version.rs
+++ b/packages/zpm-semver/src/version.rs
@@ -1,5 +1,4 @@
 use bincode::{Decode, Encode};
-use itertools::Itertools;
 use zpm_utils::{impl_file_string_from_str, impl_file_string_serialization, DataType, FromFileString, ToFileString, ToHumanString};
 
 use crate::{extract::extract_version, range::RangeKind, Error, Range};

--- a/packages/zpm/src/error.rs
+++ b/packages/zpm/src/error.rs
@@ -258,6 +258,9 @@ pub enum Error {
     #[error("An error occured while parsing the Yarn Berry lockfile: {0}")]
     LegacyLockfileParseError(Arc<serde_yaml::Error>),
 
+    #[error("An error occured while parsing your configuration: {0}")]
+    ConfigurationParseError(Arc<dyn std::error::Error + Send + Sync>),
+
     #[error("Lockfile generation error: {0}")]
     LockfileGenerationError(zpm_parsers::Error),
 


### PR DESCRIPTION
A stacktrace was displayed when a project lists `compressionLevel: mixed` due to `unwrap` calls. I replaced them by proper error messages, and fixed an additional issue that was covering errors returned by the configuration parser.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Strengthens error handling across configuration and formats.
> 
> - Add `ConfigurationParseError` and propagate config parsing failures in `Project::new` instead of unwrapping
> - Implement custom `Deserialize` for `Partial<T>` to preserve real deserialization errors; rely on `#[serde(default)]` for missing fields
> - Validate `CompressionAlgorithm` parsing: reject `"mixed"` with a deprecation error and require levels 0–9 (replace previous `unwrap`)
> - Parse YAML configs into intermediates before wrapping in `Partial::Value` to avoid swallowed errors
> - Minor cleanup (remove unused import)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 619d5adca623df234bffcb264129543f13bf6ce7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->