### PR TITLE
Replaces Manifest by RemoteManifest in resolvers

### DIFF
--- a/packages/zpm/src/fetchers/patch.rs
+++ b/packages/zpm/src/fetchers/patch.rs
@@ -4,7 +4,7 @@ use zpm_primitives::{Ident, Locator, PatchReference};
 use zpm_utils::Hash64;
 
 use crate::{
-    error::Error, install::{FetchResult, InstallContext, InstallOpResult}, manifest::Manifest, misc::unpack_brotli_data, npm::NpmEntryExt, patch::apply::apply_patch, resolvers::Resolution
+    error::Error, install::{FetchResult, InstallContext, InstallOpResult}, manifest::RemoteManifest, misc::unpack_brotli_data, npm::NpmEntryExt, patch::apply::apply_patch, resolvers::Resolution
 };
 
 use super::PackageData;
@@ -112,11 +112,11 @@ pub async fn fetch_locator<'a>(context: &InstallContext<'a>, locator: &Locator, 
                 .first()
                 .ok_or(Error::MissingPackageManifest)?;
 
-        let package_json_content: Manifest
+        let manifest: RemoteManifest
             = JsonDocument::hydrate_from_slice(&package_json_entry.data)?;
 
         let package_version
-            = package_json_content.remote.version
+            = manifest.version
                 .unwrap_or_default();
 
         let patched_entries = match is_builtin {
@@ -141,11 +141,11 @@ pub async fn fetch_locator<'a>(context: &InstallContext<'a>, locator: &Locator, 
     let package_json_entry
         = zpm_formats::zip::first_entry_from_zip(&cached_blob.data)?;
 
-    let manifest: Manifest
+    let manifest: RemoteManifest
         = JsonDocument::hydrate_from_slice(&package_json_entry.data)?;
 
     let resolution
-        = Resolution::from_remote_manifest(locator.clone(), manifest.remote);
+        = Resolution::from_remote_manifest(locator.clone(), manifest);
 
     let package_directory = cached_blob.info.path
         .with_join(&package_subdir);

--- a/packages/zpm/src/fetchers/tarball.rs
+++ b/packages/zpm/src/fetchers/tarball.rs
@@ -3,7 +3,7 @@ use zpm_parsers::JsonDocument;
 use zpm_primitives::{Locator, TarballReference};
 
 use crate::{
-    error::Error, install::{FetchResult, InstallContext, InstallOpResult}, manifest::Manifest, npm::NpmEntryExt, resolvers::Resolution
+    error::Error, install::{FetchResult, InstallContext, InstallOpResult}, manifest::RemoteManifest, npm::NpmEntryExt, resolvers::Resolution
 };
 
 use super::PackageData;
@@ -41,11 +41,11 @@ pub async fn fetch_locator<'a>(context: &InstallContext<'a>, locator: &Locator, 
     let first_entry
         = zpm_formats::zip::first_entry_from_zip(&cached_blob.data)?;
 
-    let manifest: Manifest
+    let manifest: RemoteManifest
         = JsonDocument::hydrate_from_slice(&first_entry.data)?;
 
     let resolution
-        = Resolution::from_remote_manifest(locator.clone(), manifest.remote);
+        = Resolution::from_remote_manifest(locator.clone(), manifest);
 
     let package_directory = cached_blob.info.path
         .with_join(&package_subdir);

--- a/packages/zpm/src/fetchers/url.rs
+++ b/packages/zpm/src/fetchers/url.rs
@@ -5,7 +5,7 @@ use zpm_parsers::JsonDocument;
 use zpm_primitives::{Locator, UrlReference};
 
 use crate::{
-    error::Error, install::{FetchResult, InstallContext}, manifest::Manifest, npm::NpmEntryExt, resolvers::Resolution
+    error::Error, install::{FetchResult, InstallContext}, manifest::RemoteManifest, npm::NpmEntryExt, resolvers::Resolution
 };
 
 use super::PackageData;
@@ -42,11 +42,11 @@ pub async fn fetch_locator<'a>(context: &InstallContext<'a>, locator: &Locator, 
     let first_entry
         = zpm_formats::zip::first_entry_from_zip(&cached_blob.data)?;
 
-    let manifest: Manifest
+    let manifest: RemoteManifest
         = JsonDocument::hydrate_from_slice(&first_entry.data)?;
 
     let resolution
-        = Resolution::from_remote_manifest(locator.clone(), manifest.remote);
+        = Resolution::from_remote_manifest(locator.clone(), manifest);
 
     let package_directory = cached_blob.info.path
         .with_join(&package_subdir);

--- a/packages/zpm/src/manifest/mod.rs
+++ b/packages/zpm/src/manifest/mod.rs
@@ -74,7 +74,6 @@ pub struct RemoteManifest {
     pub dist: Option<DistManifest>,
 }
 
-
 #[derive(Clone, Debug, Default, Deserialize, Serialize, Encode, Decode, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct PublishConfig {


### PR DESCRIPTION
Some resolvers were accidentally parsing the remote manifest using the `Manifest` structure rather than `RemoteManifest`. As a result they could yield errors on fields using a format we didn't expect, even when these fields weren't actually used.

Switched to using `RemoteManifest`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns fetchers with the remote manifest schema.
> 
> - Replace `Manifest` with `RemoteManifest` when hydrating `package.json` in `patch.rs`, `tarball.rs`, and `url.rs`
> - Extract version via `manifest.version` and pass `RemoteManifest` directly to `Resolution::from_remote_manifest`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 51b8a6ef8d8f40bd7f125d72dae8e2934e58be1a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->