### PR TITLE
Removes unsafe calls from the tar parsing / zip generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4403,18 +4403,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.31"
+version = "0.8.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd74ec98b9250adb3ca554bdde269adf631549f51d8a8f8f0a10b50f1cb298c3"
+checksum = "668f5168d10b9ee831de31933dc111a459c97ec93225beb307aed970d1372dfd"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.31"
+version = "0.8.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8a8d209fdf45cf5138cbb5a506f6b52522a25afccc534d1475dad8e31105c6a"
+checksum = "2c7962b26b0a8685668b671ee4b54d007a67d4eaf05fda79ac0ecf41e32270f1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4575,6 +4575,7 @@ dependencies = [
  "serde",
  "thiserror 1.0.69",
  "tokio",
+ "zerocopy",
  "zpm-macro-enum",
  "zpm-utils",
 ]

--- a/packages/zpm-formats/Cargo.toml
+++ b/packages/zpm-formats/Cargo.toml
@@ -12,5 +12,6 @@ regex = "1.10.6"
 serde = { version = "1.0.207", features = ["derive"] }
 thiserror = "1.0.63"
 tokio = { version = "1.39.2", features = ["full"] }
+zerocopy = { version = "0.8.33", features = ["derive"] }
 zpm-macro-enum = { path = "../zpm-macro-enum" }
 zpm-utils = { path = "../zpm-utils" }

--- a/packages/zpm-formats/src/zip_iter.rs
+++ b/packages/zpm-formats/src/zip_iter.rs
@@ -1,5 +1,6 @@
 use std::{borrow::Cow, io::Read};
 
+use zerocopy::FromBytes;
 use zpm_utils::Path;
 
 use crate::{zip_structs::{CentralDirectoryRecord, EndOfCentralDirectoryRecord, GeneralRecord}, Compression, CompressionAlgorithm, Entry, Error};
@@ -35,12 +36,11 @@ impl<'a> ZipIterator<'a> {
         let end_of_central_directory_record_offset
             = buffer.len() - end_of_central_directory_record_size;
 
-        let end_of_central_directory_record = *unsafe {
-            &*(buffer[end_of_central_directory_record_offset..].as_ptr() as *const EndOfCentralDirectoryRecord)
-        };
+        let end_of_central_directory_record = EndOfCentralDirectoryRecord::read_from_bytes(&buffer[end_of_central_directory_record_offset..])
+            .map_err(|_| Error::InvalidZipFile("Failed to parse end of central directory record".to_string()))?;
 
         let central_directory_record_offset
-            = end_of_central_directory_record.offset_of_central_directory as usize;
+            = end_of_central_directory_record.offset_of_central_directory.get() as usize;
 
         Ok(ZipIterator {
             buffer,
@@ -54,27 +54,27 @@ impl<'a> ZipIterator<'a> {
         let name_offset
             = local_file_header_offset + std::mem::size_of::<GeneralRecord>();
         let data_offset
-            = name_offset + general_record.header.file_name_length as usize + general_record.header.extra_field_length as usize;
+            = name_offset + general_record.header.file_name_length.get() as usize + general_record.header.extra_field_length.get() as usize;
 
         let name_str
-            = std::str::from_utf8(&self.buffer[name_offset..name_offset + general_record.header.file_name_length as usize])?;
+            = std::str::from_utf8(&self.buffer[name_offset..name_offset + general_record.header.file_name_length.get() as usize])?;
         let name
             = Path::try_from(name_str)?;
 
         let data_size
-            = central_directory_record.header.compressed_size as usize;
+            = central_directory_record.header.compressed_size.get() as usize;
         let data
             = &self.buffer[data_offset..data_offset + data_size];
 
         let mut entry = Entry {
             name,
-            mode: (central_directory_record.external_file_attributes as u64 >> 16) as u32,
-            crc: general_record.header.crc_32,
+            mode: (central_directory_record.external_file_attributes.get() >> 16) as u32,
+            crc: general_record.header.crc_32.get(),
             data: Cow::Borrowed(data),
             compression: None,
         };
 
-        match central_directory_record.header.compression_method {
+        match central_directory_record.header.compression_method.get() {
             8 => {
                 entry.compression = Some(Compression {
                     data: Cow::Borrowed(data),
@@ -103,21 +103,23 @@ impl<'a> Iterator for ZipIterator<'a> {
 
         let offset = self.central_directory_record_offset;
 
-        let central_directory_record = unsafe {
-            &*(self.buffer[offset..].as_ptr() as *const CentralDirectoryRecord)
+        let central_directory_record = match CentralDirectoryRecord::ref_from_prefix(&self.buffer[offset..]) {
+            Ok((record, _)) => record,
+            Err(_) => return Some(Err(Error::InvalidZipFile("Failed to parse central directory record".to_string()))),
         };
 
         let local_file_header_offset
-            = central_directory_record.relative_offset_of_local_header as usize;
+            = central_directory_record.relative_offset_of_local_header.get() as usize;
 
-        let general_record = unsafe {
-            &*(self.buffer[local_file_header_offset..].as_ptr() as *const GeneralRecord)
+        let general_record = match GeneralRecord::ref_from_prefix(&self.buffer[local_file_header_offset..]) {
+            Ok((record, _)) => record,
+            Err(_) => return Some(Err(Error::InvalidZipFile("Failed to parse general record".to_string()))),
         };
 
         self.central_directory_record_offset += std::mem::size_of::<CentralDirectoryRecord>()
-            + central_directory_record.header.file_name_length as usize
-            + central_directory_record.header.extra_field_length as usize
-            + central_directory_record.file_comment_length as usize;
+            + central_directory_record.header.file_name_length.get() as usize
+            + central_directory_record.header.extra_field_length.get() as usize
+            + central_directory_record.file_comment_length.get() as usize;
 
         Some(self.parse_entry_at(local_file_header_offset, central_directory_record, general_record))
     }

--- a/packages/zpm-formats/src/zip_structs.rs
+++ b/packages/zpm-formats/src/zip_structs.rs
@@ -1,50 +1,50 @@
-#[derive(Debug, Clone, Copy)]
-#[allow(dead_code)]
-#[repr(packed)]
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
+use zerocopy::little_endian::{U16, U32};
+
+#[derive(Debug, Clone, Copy, FromBytes, IntoBytes, Immutable, KnownLayout, Unaligned)]
+#[repr(C)]
 pub struct FileHeader {
-    pub version_needed_to_extract: u16,
-    pub general_purpose_bit_flag: u16,
-    pub compression_method: u16,
-    pub last_mod_file_time: u16,
-    pub last_mod_file_date: u16,
-    pub crc_32: u32,
-    pub compressed_size: u32,
-    pub uncompressed_size: u32,
-    pub file_name_length: u16,
-    pub extra_field_length: u16,
+    pub version_needed_to_extract: U16,
+    pub general_purpose_bit_flag: U16,
+    pub compression_method: U16,
+    pub last_mod_file_time: U16,
+    pub last_mod_file_date: U16,
+    pub crc_32: U32,
+    pub compressed_size: U32,
+    pub uncompressed_size: U32,
+    pub file_name_length: U16,
+    pub extra_field_length: U16,
 }
 
-#[derive(Debug, Clone, Copy)]
-#[allow(dead_code)]
-#[repr(packed)]
+#[derive(Debug, Clone, Copy, FromBytes, IntoBytes, Immutable, KnownLayout, Unaligned)]
+#[repr(C)]
 pub struct GeneralRecord {
     pub signature: [u8; 4],
     pub header: FileHeader,
 }
 
-#[allow(dead_code)]
-#[repr(packed)]
+#[derive(Debug, Clone, Copy, FromBytes, IntoBytes, Immutable, KnownLayout, Unaligned)]
+#[repr(C)]
 pub struct CentralDirectoryRecord {
     pub signature: [u8; 4],
-    pub version_made_by: u16,
+    pub version_made_by: U16,
     pub header: FileHeader,
-    pub file_comment_length: u16,
-    pub disk_number_start: u16,
-    pub internal_file_attributes: u16,
-    pub external_file_attributes: u32,
-    pub relative_offset_of_local_header: u32,
+    pub file_comment_length: U16,
+    pub disk_number_start: U16,
+    pub internal_file_attributes: U16,
+    pub external_file_attributes: U32,
+    pub relative_offset_of_local_header: U32,
 }
 
-#[allow(dead_code)]
-#[repr(packed)]
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy, FromBytes, IntoBytes, Immutable, KnownLayout, Unaligned)]
+#[repr(C)]
 pub struct EndOfCentralDirectoryRecord {
     pub signature: [u8; 4],
-    pub disk_number: u16,
-    pub disk_with_central_directory: u16,
-    pub number_of_files_on_this_disk: u16,
-    pub number_of_files: u16,
-    pub size_of_central_directory: u32,
-    pub offset_of_central_directory: u32,
-    pub comment_length: u16,
+    pub disk_number: U16,
+    pub disk_with_central_directory: U16,
+    pub number_of_files_on_this_disk: U16,
+    pub number_of_files: U16,
+    pub size_of_central_directory: U32,
+    pub offset_of_central_directory: U32,
+    pub comment_length: U16,
 }


### PR DESCRIPTION
We were previously directly manipulating raw bytes. While it worked, it relied on the structures being packed, and didn't account for endianness. This PR addresses both issues.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces raw pointer casting with safe, endian-aware serialization/parsing.
> 
> - Add `zerocopy` dependency and upgrade `zerocopy` crates; derive `FromBytes`/`IntoBytes`/`Immutable`/`KnownLayout`/`Unaligned`
> - Tar: convert `FileHeader` to `repr(C)` with `IntoBytes`; compute checksum and write headers via `as_bytes()` (no `unsafe`)
> - Zip write: build `GeneralRecord`, `CentralDirectoryRecord`, and `EndOfCentralDirectoryRecord` using `U16`/`U32` and append via `as_bytes()`
> - Zip read/iterate: parse records with `read_from_bytes`/`ref_from_prefix`; access sizes/offsets via `.get()`; remove packed structs and manual pointer casts
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5bd84f5b5ff9f16332411111179872467477f7a9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->