### PR TITLE
Fixes package aliasing w/ unconventional registry urls

### DIFF
--- a/tests/acceptance-tests/pkg-tests-specs/sources/protocols/npm.test.js
+++ b/tests/acceptance-tests/pkg-tests-specs/sources/protocols/npm.test.js
@@ -144,5 +144,25 @@ describe(`Protocols`, () => {
         },
       ),
     );
+
+    test(
+      `it should allow aliasing packages that have an unconventional url`,
+      makeTemporaryEnv(
+        {
+          dependencies: {[`aliased-unconventional`]: `npm:unconventional-tarball@1.0.0`},
+        },
+        async ({path, run, source}) => {
+          await run(`install`);
+
+          await expect(source(`require('aliased-unconventional')`)).resolves.toMatchObject({
+            name: `unconventional-tarball`,
+            version: `1.0.0`,
+          });
+
+          await xfs.removePromise(`${path}/.yarn`);
+          await run(`install`);
+        },
+      ),
+    );
   });
 });


### PR DESCRIPTION
I discovered an edge case when using aliased packages with a registry returning unconventional urls. In that case we would end up going into an "unreachable" code path, crashing the process. Fixed it by explicitly supporting this use case, and added a test to prevent regressions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures aliased npm packages resolve correctly when the registry returns unconventional tarball URLs.
> 
> - Updates `resolve_aliased` to map `Shorthand`/`Registry` to `RegistryReference` and preserve `Url` references, avoiding the previous unreachable crash path
> - Adds acceptance test verifying aliasing works with unconventional URLs (`aliased-unconventional`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ffc634ab6e83b2cd12166c62df0c28c2a211db98. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->