### PR TITLE
Adds .bin folders for node_modules installs

### DIFF
--- a/packages/zpm/src/linker/nm/mod.rs
+++ b/packages/zpm/src/linker/nm/mod.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 
-use zpm_primitives::Reference;
+use zpm_primitives::{Ident, Reference};
 use zpm_sync::{SyncItem, SyncTemplate, SyncTree};
 use zpm_utils::{FromFileString, Path, ToHumanString};
 
@@ -11,6 +11,94 @@ use crate::{
 pub mod hoist;
 
 const EXPECT_CHILDREN: &str = "All nodes should be expanded by the end of the hoisting process";
+
+fn collect_binaries_from_dependencies(install: &Install, children: &BTreeMap<Ident, usize>, work_tree: &WorkTree) -> BTreeMap<String, (Ident, Path)> {
+    let mut binaries
+        = BTreeMap::new();
+
+    for (ident, child_idx) in children {
+        let child_node
+            = &work_tree.nodes[*child_idx];
+
+        let physical_locator
+            = child_node.locator.physical_locator();
+
+        if let Some(content_flags) = install.install_state.content_flags.get(&physical_locator) {
+            for (bin_name, bin_path) in &content_flags.binaries {
+                binaries.insert(bin_name.clone(), (ident.clone(), bin_path.clone()));
+            }
+        }
+    }
+
+    binaries
+}
+
+fn collect_workspace_binaries(install: &Install, workspace_node: &hoist::WorkNode) -> BTreeMap<String, (Ident, Path)> {
+    let mut binaries
+        = BTreeMap::new();
+
+    let physical_locator
+        = workspace_node.locator.physical_locator();
+
+    if let Some(content_flags) = install.install_state.content_flags.get(&physical_locator) {
+        for (bin_name, bin_path) in &content_flags.binaries {
+            binaries.insert(bin_name.clone(), (workspace_node.locator.ident.clone(), bin_path.clone()));
+        }
+    }
+
+    binaries
+}
+
+/// Registers bin symlinks in the sync tree for a given node_modules subfolder.
+/// `node_rel_path` is the path within node_modules where dependencies are located
+/// (e.g., "" for top-level, or "foo/node_modules" for nested).
+fn register_bin_symlinks_at_path(workspace_nm_tree: &mut SyncTree, node_rel_path: &Path, binaries: &BTreeMap<String, (Ident, Path)>) -> Result<(), Error> {
+    for (bin_name, (dep_ident, bin_path)) in binaries {
+        // The symlink will be at <node_rel_path>/.bin/<bin_name>
+        // It needs to point to ../<dep_name>/<bin_path>
+        let bin_symlink_path = node_rel_path
+            .with_join_str(".bin")
+            .with_join_str(bin_name);
+
+        let target_path = Path::new()
+            .with_join_str("..")
+            .with_join_str(&dep_ident.as_str())
+            .with_join(bin_path);
+
+        workspace_nm_tree.register_entry(bin_symlink_path, SyncItem::Symlink {
+            target_path,
+        })?;
+    }
+
+    Ok(())
+}
+
+fn register_workspace_bin_symlinks(workspace_nm_tree: &mut SyncTree, workspace_path: &Path, binaries: &BTreeMap<String, (Ident, Path)>) -> Result<(), Error> {
+    for (bin_name, (_ident, bin_path)) in binaries {
+        let target_abs_path
+            = workspace_path
+                .with_join(bin_path);
+
+        if !target_abs_path.fs_exists() {
+            continue;
+        }
+
+        let bin_symlink_path = Path::new()
+            .with_join_str(".bin")
+            .with_join_str(bin_name);
+
+        let target_path = Path::new()
+            .with_join_str("..")
+            .with_join_str("..")
+            .with_join(bin_path);
+
+        workspace_nm_tree.register_entry(bin_symlink_path, SyncItem::Symlink {
+            target_path,
+        })?;
+    }
+
+    Ok(())
+}
 
 pub async fn link_project_nm(project: &Project, install: &Install) -> Result<LinkResult, Error> {
     let mut work_tree
@@ -36,15 +124,23 @@ pub async fn link_project_nm(project: &Project, install: &Install) -> Result<Lin
 
         packages_by_location.insert(workspace.rel_path.clone(), workspace_node.locator.clone());
 
-        let workspace_abs_path
+        let workspace_dir
             = project.project_cwd
-                .with_join(&workspace.rel_path)
+                .with_join(&workspace.rel_path);
+
+        let workspace_abs_path
+            = workspace_dir
                 .with_join_str("node_modules");
 
         let mut workspace_nm_tree
             = SyncTree::new();
 
         workspace_nm_tree.dry_run = false;
+
+        let workspace_binaries
+            = collect_workspace_binaries(install, &work_tree.nodes[workspace_node_idx]);
+
+        register_workspace_bin_symlinks(&mut workspace_nm_tree, &workspace_dir, &workspace_binaries)?;
 
         let mut workspace_queue
             = vec![(Path::new(), workspace_node_idx)];
@@ -126,6 +222,20 @@ pub async fn link_project_nm(project: &Project, install: &Install) -> Result<Lin
                     },
                 }
             }
+
+            // Register bin symlinks for all direct dependencies of this node
+            // Skip any bins that conflict with workspace binaries (workspace takes precedence)
+            let mut binaries
+                = collect_binaries_from_dependencies(install, children, &work_tree);
+
+            // For root level, filter out bins that conflict with workspace binaries
+            if node_rel_path.is_empty() {
+                for bin_name in workspace_binaries.keys() {
+                    binaries.remove(bin_name);
+                }
+            }
+
+            register_bin_symlinks_at_path(&mut workspace_nm_tree, &node_rel_path, &binaries)?;
         }
 
         workspace_nm_tree


### PR DESCRIPTION
The `node_modules` installs were missing the `.bin` folder.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `.bin` symlink generation to the `node-modules` linker and establishes workspace-bin precedence.
> 
> - Implemented collection of dependency and workspace `bin` entries and registration of symlinks under `node_modules/.bin` at each `node_modules` level
> - Prefer workspace `bin` symlinks over dependency bins at the root; skip workspace bin symlinks if the binary target doesn't exist
> - Supports direct and hoisted transitive dependencies (symlinks point to hoisted locations as applicable)
> - Minor refactor in `nm/mod.rs` (e.g., `Ident` usage, `workspace_dir`) to support the new logic
> - Added acceptance tests covering `.bin` folder creation, hoisted transitive bins, and workspace-over-dependency precedence
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6c077c009448928d408d54958bfed77fc7d2c31c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->