### PR TITLE
Fixes the "yarn debug print-hoisting" command

### DIFF
--- a/packages/zpm/src/linker/nm/hoist.rs
+++ b/packages/zpm/src/linker/nm/hoist.rs
@@ -19,7 +19,7 @@ fn convert_workspace_to_link(project: &Project, locator: Locator) -> Locator {
             = project.package_location(&physical_locator)
                 .expect("Expected the workspace to have a package location");
 
-        Locator::new(locator.ident.clone(), LinkReference {
+        Locator::new(locator.ident, LinkReference {
             path: workspace_location.to_file_string(),
         }.into())
     } else {
@@ -218,9 +218,7 @@ impl<'a, 'b> TreeRenderer<'a, 'b> {
 
         let is_workspace_link
             = |expected_locator: &Locator, locator: &Locator|
-                expected_locator.reference.is_workspace_reference() && locator.ident == expected_locator.ident && locator.reference == LinkReference {
-                    path: self.tree.project.package_location(&expected_locator).unwrap().to_file_string(),
-                }.into();
+                expected_locator.reference.is_workspace_reference() && locator.ident == expected_locator.ident && locator == &convert_workspace_to_link(self.tree.project, expected_locator.clone());
 
         let is_dependency_valid
             = |expected_locator: &Locator|


### PR DESCRIPTION
The `yarn debug print-hoisting` was failing. Investigation revealed that the hoisting algorithm was attempting to look up nodes by their `locator.ident`, but the parents were referencing them by their own ident. While the two are typically identical, this isn't the case when aliased dependencies are involved.

I also fixed the command output which was reporting conflicts when the dependency had a `link:` reference instead of the `workspace:` reference it expects. This mismatch is expected because we convert the transitive workspace dependencies into `link:` dependencies, since that's what they are from the perspective of the hoister (we never want to traverse their dependencies).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes hoisting visualization and aliased dependency handling.
> 
> - In `TreeRenderer`, treat `link:` refs to workspaces as valid when a `workspace:` dep is expected, preventing false conflict reports
> - In `Hoister`, track transitive candidates as `(parent_idx, child_ident, node_idx)` and operate using `child_ident`/stored node index instead of `locator.ident`, ensuring correct hoisting/removal for aliased dependencies
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2ae406f78c944451e23bf6dfc288bfcdf20fe7b8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->