### PR TITLE
feat: add -R,--recursive flag to yarn up command

### DIFF
--- a/documentation/src/content/docs/getting-started/migrating/breaking-changes.md
+++ b/documentation/src/content/docs/getting-started/migrating/breaking-changes.md
@@ -65,8 +65,6 @@ Some new features have been implemented. They are not "breaking changes" per se,
 
   - It will only update package versions and won't update the cross-dependency ranges anymore. Use the magic workspace ranges instead (`workspace:^`, `workspace:~`, `workspace:=`).
 
-  - The `--recursive` flag isn't supported at the moment. Please reach out if you find it useful, as its behaviour doesn't feel intuitive and I feel like it might be in need of a rework. Consider using `--all` instead.
-
 - Behavior inherited from npm, packages are currently allowed to omit listing dependencies on `node-gyp` if the package happens to contain a `binding.gyp` file.
 
   This behavior is unsafe as the only reasonable thing the package manager can do is to imply a dependency on `*`, meaning there are no guarantees as to the version of `node-gyp` projects would end up using.

--- a/packages/zpm/src/commands/up.rs
+++ b/packages/zpm/src/commands/up.rs
@@ -2,12 +2,12 @@ use std::collections::BTreeSet;
 
 use clipanion::cli;
 use zpm_parsers::{Document, JsonDocument, Value};
-use zpm_primitives::Ident;
+use zpm_primitives::{Descriptor, Ident};
 use zpm_semver::RangeKind;
 use zpm_utils::ToFileString;
 
 use crate::{
-    descriptor_loose::{self, LooseDescriptor},
+    descriptor_loose::{self, DescriptorLooseDescriptor, LooseDescriptor},
     error::Error,
     install::InstallContext,
     project::{InstallMode, Project, RunInstallOptions, Workspace}
@@ -21,7 +21,7 @@ use crate::{
 ///
 /// If `-R,--recursive` is set the command will change behavior and no other switch will be allowed. When operating under this mode yarn up will
 /// collect package idents from both workspace manifests and the lockfile, expand patterns against all of them, then re-resolve matching packages
-/// (often to their highest available versions). Both the lockfile and workspace manifests are updated with the new resolutions.
+/// (often to their highest available versions). The lockfile is updated with the new resolutions; workspace manifests are left unchanged.
 ///
 /// If `-i,--interactive` is set (or if the `preferInteractive` settings is toggled on) the command will offer various choices, depending on the
 /// detected upgrade paths. Some upgrades require this flag in order to resolve ambiguities.
@@ -107,9 +107,7 @@ impl Up {
             .flat_map(|workspace| self.list_workspace_idents(workspace))
             .collect::<BTreeSet<_>>();
 
-        let expanded_descriptors = self.descriptors.iter()
-            .flat_map(|descriptor| descriptor.expand(&all_idents))
-            .collect::<Vec<_>>();
+        let expanded_descriptors = self.expand_descriptors(&all_idents);
 
         let range_kind = if self.fixed {
             RangeKind::Exact
@@ -177,9 +175,11 @@ impl Up {
         let all_idents: BTreeSet<Ident> = workspace_idents.union(&lockfile_idents).cloned().collect();
 
         // Expand patterns against all idents (workspaces + lockfile)
-        let expanded_descriptors = self.descriptors.iter()
-            .flat_map(|descriptor| descriptor.expand(&all_idents))
-            .collect::<Vec<_>>();
+        let expanded_descriptors = self.expand_descriptors(&all_idents);
+
+        let expanded_idents: BTreeSet<Ident> = expanded_descriptors.iter()
+            .filter_map(Self::loose_descriptor_ident)
+            .collect();
 
         let range_kind = project.config.settings.default_semver_range_prefix.value;
 
@@ -187,6 +187,7 @@ impl Up {
             active_workspace_ident: project.active_workspace()?.name.clone(),
             range_kind,
             resolve_tags: true,
+            allow_reuse: false,
         };
 
         let package_cache = project.package_cache()?;
@@ -195,17 +196,24 @@ impl Up {
             .with_package_cache(Some(&package_cache))
             .with_project(Some(&project));
 
-        let loose_resolutions = LooseDescriptor::resolve_all(&install_context, &resolve_options, &expanded_descriptors).await?;
+        let matching_descriptors = lockfile.resolutions.keys()
+            .filter(|descriptor| expanded_idents.contains(&descriptor.ident))
+            .cloned()
+            .collect::<Vec<Descriptor>>();
 
-        for workspace in &project.workspaces {
-            self.update_workspace_manifest(workspace, &loose_resolutions)?;
-        }
+        let loose_descriptors = matching_descriptors.iter()
+            .cloned()
+            .map(|descriptor| LooseDescriptor::Descriptor(DescriptorLooseDescriptor {descriptor}))
+            .collect::<Vec<_>>();
+
+        let loose_resolutions = LooseDescriptor::resolve_all(&install_context, &resolve_options, &loose_descriptors).await?;
+
+        let enforced_resolutions = matching_descriptors.into_iter()
+            .zip(loose_resolutions.into_iter())
+            .filter_map(|(descriptor, resolution)| resolution.locator.map(|locator| (descriptor, locator)))
+            .collect();
 
         let mut project = Project::new(None).await?;
-
-        let enforced_resolutions = loose_resolutions.into_iter()
-            .filter_map(|resolution| resolution.locator.map(|locator| (resolution.descriptor, locator)))
-            .collect();
 
         project.run_install(RunInstallOptions {
             mode: self.mode,
@@ -264,5 +272,19 @@ impl Up {
         }
 
         idents
+    }
+
+    fn expand_descriptors(&self, all_idents: &BTreeSet<Ident>) -> Vec<LooseDescriptor> {
+        self.descriptors.iter()
+            .flat_map(|descriptor| descriptor.expand(all_idents))
+            .collect::<Vec<_>>()
+    }
+
+    fn loose_descriptor_ident(descriptor: &LooseDescriptor) -> Option<Ident> {
+        match descriptor {
+            LooseDescriptor::Descriptor(descriptor_loose::DescriptorLooseDescriptor {descriptor}) => Some(descriptor.ident.clone()),
+            LooseDescriptor::Ident(descriptor_loose::IdentLooseDescriptor {ident}) => Some(ident.clone()),
+            LooseDescriptor::Range(_) => None,
+        }
     }
 }


### PR DESCRIPTION
## Summary

Adds the `-R,--recursive` flag to the `yarn up` command, allowing users to re-resolve packages from both workspace manifests and the lockfile (including transitive dependencies).

## Changes

- Add `-R,--recursive` flag to `yarn up` command
- In recursive mode, collect package idents from both workspaces AND lockfile for pattern matching
- Validate that `--recursive` cannot be combined with `--exact`, `--tilde`, `--caret`, or `--fixed`
- Extract `update_workspace_manifest` helper method to avoid code duplication

## Behavior

| Mode | Pattern matching scope |
|------|------------------------|
| Normal (`yarn up foo`) | Workspace idents only (direct dependencies) |
| Recursive (`yarn up -R foo`) | Workspace + lockfile idents (includes transitive deps) |

Both modes update workspace manifests and lockfile with new resolutions.

## Test plan

- [x] `cargo test` passes
- [x] `cargo build` succeeds