### PR TITLE
semver: Enforce js numeric limits

### DIFF
--- a/packages/zpm-semver/src/lib.rs
+++ b/packages/zpm-semver/src/lib.rs
@@ -8,3 +8,11 @@ pub use range::Range;
 pub use range::RangeKind;
 pub use version::Version;
 pub use version::VersionRc;
+
+/// JS-compatible semver limits:
+/// https://github.com/npm/node-semver/blob/120968b76760cb0db85a72bde2adedd0e9628793/internal/constants.js
+pub const MAX_SAFE_INTEGER: u64 = 9_007_199_254_740_991;
+/// Maximum length of a semver string.
+pub const MAX_LENGTH: usize = 256;
+/// Maximum digits allowed for a numeric component (major/minor/patch).
+pub const MAX_SAFE_COMPONENT_LENGTH: usize = 16;

--- a/packages/zpm-semver/src/version.rs
+++ b/packages/zpm-semver/src/version.rs
@@ -1,7 +1,13 @@
 use rkyv::Archive;
 use zpm_utils::{impl_file_string_from_str, impl_file_string_serialization, DataType, FromFileString, ToFileString, ToHumanString};
 
-use crate::{extract::extract_version, range::RangeKind, Error, Range};
+use crate::{
+    extract::extract_version,
+    range::RangeKind,
+    Error,
+    Range,
+    MAX_LENGTH,
+};
 
 #[cfg(test)]
 #[path = "./version.test.rs"]
@@ -246,6 +252,10 @@ impl FromFileString for Version {
     type Error = Error;
 
     fn from_file_string(src: &str) -> Result<Self, Error> {
+        if src.len() > MAX_LENGTH {
+            return Err(Error::InvalidVersion(src.to_string()));
+        }
+
         let mut iter = src.chars().peekable();
 
         let (version, _) = extract_version(&mut iter)

--- a/packages/zpm-semver/src/version.test.rs
+++ b/packages/zpm-semver/src/version.test.rs
@@ -1,4 +1,5 @@
 use rstest::rstest;
+use zpm_utils::FromFileString;
 
 use crate::{Version, VersionRc};
 
@@ -31,4 +32,23 @@ fn test_version_lt(#[case] left: Version, #[case] right: Version) {
 #[case("1.0.0-x-y-z.-", "1.0.0-x-y-z.a")]
 fn test_version_next_immediate(#[case] left: Version, #[case] right: Version) {
     assert_eq!(left.next_immediate_spec(), right);
+}
+
+#[test]
+fn test_version_max_length() {
+    let long_prerelease = "a".repeat(257);
+    let version = format!("1.2.3-{}", long_prerelease);
+    assert!(Version::from_file_string(&version).is_err());
+}
+
+#[test]
+fn test_version_max_safe_integer() {
+    assert!(Version::from_file_string("1.2.9007199254740992").is_err());
+}
+
+#[test]
+fn test_version_max_safe_component_length() {
+    // From node-semver coerce tests: `'1'.repeat(17)` is rejected.
+    let version = "1".repeat(17);
+    assert!(Version::from_file_string(&version).is_err());
 }


### PR DESCRIPTION
Enforced [node‑semver limits](https://github.com/npm/node-semver/blob/120968b76760cb0db85a72bde2adedd0e9628793/internal/constants.js) for max length, max safe integer, and component digit length.