### PR TITLE
Splits perfchecks in two workflows

### DIFF
--- a/.github/workflows/perfcheck-comment.yml
+++ b/.github/workflows/perfcheck-comment.yml
@@ -1,0 +1,62 @@
+name: Post Benchmark Comment
+
+on:
+  workflow_run:
+    workflows: ["Benchmarks"]
+    types:
+      - completed
+
+jobs:
+  comment:
+    name: Post benchmark comment
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'success'
+
+    steps:
+      - name: Download comment artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: perfcheck-comment
+          path: perfcheck-comment
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Post or update comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+
+            const commentBody = fs.readFileSync('perfcheck-comment/comment-body.md', 'utf8');
+            const prNumber = parseInt(fs.readFileSync('perfcheck-comment/pr-number.txt', 'utf8').trim(), 10);
+
+            // Find existing comment
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+            });
+
+            const botComment = comments.find(c =>
+              c.user.type === 'Bot' && c.body.includes('## ⏱️ Benchmark Results')
+            );
+
+            if (botComment) {
+              // Update existing comment
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: botComment.id,
+                body: commentBody,
+              });
+              console.log(`Updated comment ${botComment.id} on PR #${prNumber}`);
+            } else {
+              // Create new comment
+              const { data: newComment } = await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body: commentBody,
+              });
+              console.log(`Created comment ${newComment.id} on PR #${prNumber}`);
+            }

--- a/.github/workflows/perfcheck.yml
+++ b/.github/workflows/perfcheck.yml
@@ -76,7 +76,7 @@ jobs:
         working-directory: ../head
         run: ./target/release/yarn-bin debug bench gatsby install-full-cold
 
-      - name: Merge benchmark results and post comment
+      - name: Generate benchmark comment
         uses: actions/github-script@v7
         with:
           script: |
@@ -144,34 +144,16 @@ jobs:
             *Benchmark: \`gatsby install-full-cold\`*
             `.split('\n').map(l => l.trim()).join('\n');
 
-            // Find existing comment
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-            });
+            // Save comment body and PR number for the perfcheck-comment workflow
+            fs.mkdirSync('perfcheck-comment', { recursive: true });
+            fs.writeFileSync('perfcheck-comment/comment-body.md', comment);
+            fs.writeFileSync('perfcheck-comment/pr-number.txt', String(context.issue.number));
 
-            const botComment = comments.find(c =>
-              c.user.type === 'Bot' && c.body.includes('## ⏱️ Benchmark Results')
-            );
-
-            if (botComment) {
-              // Update existing comment
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: botComment.id,
-                body: comment,
-              });
-            } else {
-              // Create new comment
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                body: comment,
-              });
-            }
+      - name: Upload comment body artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: perfcheck-comment
+          path: perfcheck-comment/
 
       - name: Upload merged benchmark results
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
The perfcheck workflow currently tries to post a comment on the PR from the same job that runs the performance check. It worked fine until now because all my PRs are on this repo, but it can't work with PRs originating from forks.

This PR fixes that by splitting perfcheck in two: the workflow from the fork will generate a comment and upload it as an artifact, then a second workflow will trigger from the main repo and will post that comment. This second workflow will have a write token on the repository, but since it won't clone or execute anything from the originating PR (outside of the generated md file) it should be safe.