### PR TITLE
use rust 1.93

### DIFF
--- a/packages/zpm-config/build.rs
+++ b/packages/zpm-config/build.rs
@@ -337,7 +337,7 @@ impl Generator {
             writeln!(writer, "        unimplemented!(\"Configuration records cannot be returned directly just yet\");").unwrap();
             writeln!(writer, "    }}").unwrap();
             writeln!(writer).unwrap();
-            writeln!(writer, "    fn hydrate(&self, path: &[&str], value_str: &str) -> Result<AbstractValue, HydrateError> {{").unwrap();
+            writeln!(writer, "    fn hydrate(&self, path: &[&str], value_str: &str) -> Result<AbstractValue<'_>, HydrateError> {{").unwrap();
             writeln!(writer, "        let Some(key_str) = path.first() else {{").unwrap();
             writeln!(writer, "            unimplemented!(\"Configuration records cannot be returned directly just yet\");").unwrap();
             writeln!(writer, "        }};").unwrap();
@@ -363,7 +363,7 @@ impl Generator {
             writeln!(writer, "        }}").unwrap();
             writeln!(writer, "    }}").unwrap();
             writeln!(writer).unwrap();
-            writeln!(writer, "    fn get(&self, path: &[&str]) -> Result<ConfigurationEntry, GetError> {{").unwrap();
+            writeln!(writer, "    fn get(&self, path: &[&str]) -> Result<ConfigurationEntry<'_>, GetError> {{").unwrap();
             writeln!(writer, "        let Some(key_str) = path.first() else {{").unwrap();
             writeln!(writer, "            unimplemented!(\"Configuration records cannot be returned directly just yet\");").unwrap();
             writeln!(writer, "        }};").unwrap();
@@ -433,7 +433,7 @@ impl Generator {
             writeln!(writer, "        }}").unwrap();
             writeln!(writer, "    }}").unwrap();
             writeln!(writer).unwrap();
-            writeln!(writer, "    fn tree_node(&self, label: Option<String>, description: Option<String>) -> tree::Node {{").unwrap();
+            writeln!(writer, "    fn tree_node(&self, label: Option<String>, description: Option<String>) -> tree::Node<'_> {{").unwrap();
             writeln!(writer, "        let mut children = tree::Map::new();").unwrap();
 
             for field in fields {

--- a/packages/zpm-config/src/lib.rs
+++ b/packages/zpm-config/src/lib.rs
@@ -154,12 +154,12 @@ trait MergeSettings: Sized {
         &self,
         path: &[&str],
         value_str: &str,
-    ) -> Result<AbstractValue, HydrateError>;
+    ) -> Result<AbstractValue<'_>, HydrateError>;
 
     fn get(
         &self,
         path: &[&str],
-    ) -> Result<ConfigurationEntry, GetError>;
+    ) -> Result<ConfigurationEntry<'_>, GetError>;
 
     fn merge<F: Fn() -> Self>(
         context: &ConfigurationContext,
@@ -172,7 +172,7 @@ trait MergeSettings: Sized {
         &self,
         label: Option<String>,
         description: Option<String>,
-    ) -> tree::Node;
+    ) -> tree::Node<'_>;
 }
 
 impl<K: Ord + ToFileString + ToHumanString + FromFileString + Serialize + std::fmt::Debug, T: MergeSettings + Serialize + std::fmt::Debug> MergeSettings for BTreeMap<K, T> {
@@ -182,7 +182,7 @@ impl<K: Ord + ToFileString + ToHumanString + FromFileString + Serialize + std::f
         unimplemented!("Configuration maps cannot be returned directly just yet");
     }
 
-    fn hydrate(&self, path: &[&str], value_str: &str) -> Result<AbstractValue, HydrateError> {
+    fn hydrate(&self, path: &[&str], value_str: &str) -> Result<AbstractValue<'_>, HydrateError> {
         let Some(key_str) = path.first() else {
             unimplemented!("Configuration maps cannot be returned directly just yet");
         };
@@ -198,7 +198,7 @@ impl<K: Ord + ToFileString + ToHumanString + FromFileString + Serialize + std::f
         entry.hydrate(&path[1..], value_str)
     }
 
-    fn get(&self, path: &[&str]) -> Result<ConfigurationEntry, GetError> {
+    fn get(&self, path: &[&str]) -> Result<ConfigurationEntry<'_>, GetError> {
         let Some(key_str) = path.first() else {
             return Ok(ConfigurationEntry {
                 value: AbstractValue::new(Container::new(self)),
@@ -253,7 +253,7 @@ impl<K: Ord + ToFileString + ToHumanString + FromFileString + Serialize + std::f
         result
     }
 
-    fn tree_node(&self, label: Option<String>, description: Option<String>) -> tree::Node {
+    fn tree_node(&self, label: Option<String>, description: Option<String>) -> tree::Node<'_> {
         let mut children
             = tree::Map::new();
 
@@ -322,7 +322,7 @@ impl<T: std::fmt::Debug + Serialize + MergeSettings> MergeSettings for Vec<T> {
         Ok(result)
     }
 
-    fn hydrate(&self, path: &[&str], value_str: &str) -> Result<AbstractValue, HydrateError> {
+    fn hydrate(&self, path: &[&str], value_str: &str) -> Result<AbstractValue<'_>, HydrateError> {
         let Some(key_str) = path.first() else {
             unimplemented!("Configuration lists cannot be returned directly just yet");
         };
@@ -338,7 +338,7 @@ impl<T: std::fmt::Debug + Serialize + MergeSettings> MergeSettings for Vec<T> {
         self[key].hydrate(&path[1..], value_str)
     }
 
-    fn get(&self, path: &[&str]) -> Result<ConfigurationEntry, GetError> {
+    fn get(&self, path: &[&str]) -> Result<ConfigurationEntry<'_>, GetError> {
         let Some(key_str) = path.first() else {
             return Ok(ConfigurationEntry {
                 value: AbstractValue::new(Container::new(self)),
@@ -390,7 +390,7 @@ impl<T: std::fmt::Debug + Serialize + MergeSettings> MergeSettings for Vec<T> {
         result
     }
 
-    fn tree_node(&self, label: Option<String>, description: Option<String>) -> tree::Node {
+    fn tree_node(&self, label: Option<String>, description: Option<String>) -> tree::Node<'_> {
         let mut children
             = Vec::new();
 
@@ -443,7 +443,7 @@ impl MergeSettings for Setting<Path> {
         })
     }
 
-    fn hydrate(&self, path: &[&str], value_str: &str) -> Result<AbstractValue, HydrateError> {
+    fn hydrate(&self, path: &[&str], value_str: &str) -> Result<AbstractValue<'_>, HydrateError> {
         if let Some(key) = path.first() {
             return Err(HydrateError::KeyNotFound(key.to_string()));
         }
@@ -455,7 +455,7 @@ impl MergeSettings for Setting<Path> {
         Ok(AbstractValue::new(value))
     }
 
-    fn get(&self, path: &[&str]) -> Result<ConfigurationEntry, GetError> {
+    fn get(&self, path: &[&str]) -> Result<ConfigurationEntry<'_>, GetError> {
         if let Some(key) = path.first() {
             return Err(GetError::KeyNotFound(key.to_string()));
         }
@@ -496,7 +496,7 @@ impl MergeSettings for Setting<Path> {
         default()
     }
 
-    fn tree_node(&self, label: Option<String>, description: Option<String>) -> tree::Node {
+    fn tree_node(&self, label: Option<String>, description: Option<String>) -> tree::Node<'_> {
         let mut fields
             = tree::Map::new();
 
@@ -538,7 +538,7 @@ macro_rules! merge_settings_impl {
                 })
             }
 
-            fn hydrate(&self, path: &[&str], value_str: &str) -> Result<AbstractValue, HydrateError> {
+            fn hydrate(&self, path: &[&str], value_str: &str) -> Result<AbstractValue<'_>, HydrateError> {
                 if let Some(key) = path.first() {
                     return Err(HydrateError::KeyNotFound(key.to_string()));
                 }
@@ -550,7 +550,7 @@ macro_rules! merge_settings_impl {
                 Ok(AbstractValue::new(value))
             }
 
-            fn get(&self, path: &[&str]) -> Result<ConfigurationEntry, GetError> {
+            fn get(&self, path: &[&str]) -> Result<ConfigurationEntry<'_>, GetError> {
                 if let Some(key) = path.first() {
                     return Err(GetError::KeyNotFound(key.to_string()));
                 }
@@ -579,7 +579,7 @@ macro_rules! merge_settings_impl {
                 default()
             }
 
-            fn tree_node(&self, label: Option<String>, description: Option<String>) -> tree::Node {
+            fn tree_node(&self, label: Option<String>, description: Option<String>) -> tree::Node<'_> {
                 let mut fields
                     = tree::Map::new();
 
@@ -619,7 +619,7 @@ macro_rules! merge_settings_impl {
                 })
             }
 
-            fn hydrate(&self, path: &[&str], value_str: &str) -> Result<AbstractValue, HydrateError> {
+            fn hydrate(&self, path: &[&str], value_str: &str) -> Result<AbstractValue<'_>, HydrateError> {
                 if let Some(key) = path.first() {
                     return Err(HydrateError::KeyNotFound(key.to_string()));
                 }
@@ -631,7 +631,7 @@ macro_rules! merge_settings_impl {
                 Ok(AbstractValue::new(value))
             }
 
-            fn get(&self, path: &[&str]) -> Result<ConfigurationEntry, GetError> {
+            fn get(&self, path: &[&str]) -> Result<ConfigurationEntry<'_>, GetError> {
                 if !path.is_empty() {
                     return Err(GetError::KeyNotFound(path.join(".").to_string()));
                 }
@@ -678,7 +678,7 @@ macro_rules! merge_settings_impl {
                 default()
             }
 
-            fn tree_node(&self, label: Option<String>, description: Option<String>) -> tree::Node {
+            fn tree_node(&self, label: Option<String>, description: Option<String>) -> tree::Node<'_> {
                 let mut fields
                     = tree::Map::new();
 
@@ -834,15 +834,15 @@ pub enum HydrateError {
 }
 
 impl Configuration {
-    pub fn tree_node(&self) -> tree::Node {
+    pub fn tree_node(&self) -> tree::Node<'_> {
         self.settings.tree_node(None, None)
     }
 
-    pub fn hydrate(&self, path: &[&str], value_str: &str) -> Result<AbstractValue, HydrateError> {
+    pub fn hydrate(&self, path: &[&str], value_str: &str) -> Result<AbstractValue<'_>, HydrateError> {
         self.settings.hydrate(path, value_str)
     }
 
-    pub fn get(&self, path: &[&str]) -> Result<ConfigurationEntry, GetError> {
+    pub fn get(&self, path: &[&str]) -> Result<ConfigurationEntry<'_>, GetError> {
         self.settings.get(path)
     }
 

--- a/packages/zpm-formats/Cargo.toml
+++ b/packages/zpm-formats/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zpm-formats"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 crc32fast = { workspace = true }

--- a/packages/zpm-formats/src/tar.rs
+++ b/packages/zpm-formats/src/tar.rs
@@ -21,7 +21,7 @@ struct FileHeader {
     padding: [u8; 255],
 }
 
-pub fn entries_from_tar(buffer: &[u8]) -> Result<Vec<Entry>, Error> {
+pub fn entries_from_tar(buffer: &[u8]) -> Result<Vec<Entry<'_>>, Error> {
     TarIterator::new(buffer).collect()
 }
 

--- a/packages/zpm-formats/src/tar_iter.rs
+++ b/packages/zpm-formats/src/tar_iter.rs
@@ -12,7 +12,7 @@ pub struct TarIterator<'a> {
 }
 
 impl<'a> TarIterator<'a> {
-    pub fn new(buffer: &[u8]) -> TarIterator {
+    pub fn new(buffer: &[u8]) -> TarIterator<'_> {
         TarIterator {
             buffer,
             offset: 0,

--- a/packages/zpm-formats/src/zip.rs
+++ b/packages/zpm-formats/src/zip.rs
@@ -12,11 +12,11 @@ pub struct CraftZipOptions {
     pub compression: Option<CompressionAlgorithm>,
 }
 
-pub fn entries_from_zip(buffer: &[u8]) -> Result<Vec<Entry>, Error> {
+pub fn entries_from_zip(buffer: &[u8]) -> Result<Vec<Entry<'_>>, Error> {
     ZipIterator::new(buffer)?.collect()
 }
 
-pub fn first_entry_from_zip(buffer: &[u8]) -> Result<Entry, Error> {
+pub fn first_entry_from_zip(buffer: &[u8]) -> Result<Entry<'_>, Error> {
     ZipIterator::new(buffer)?.next()
         .unwrap_or_else(|| Err(Error::InvalidZipFile("Empty".to_string())))
 }

--- a/packages/zpm-utils/src/glob.rs
+++ b/packages/zpm-utils/src/glob.rs
@@ -64,7 +64,7 @@ impl Glob {
         self.inner.borrow_raw()
     }
 
-    pub fn matcher(&self) -> &wax::Glob {
+    pub fn matcher(&self) -> &wax::Glob<'_> {
         self.inner.borrow_pattern()
     }
 

--- a/packages/zpm-utils/src/path.rs
+++ b/packages/zpm-utils/src/path.rs
@@ -248,7 +248,7 @@ impl Path {
     /// assert_eq!(iterator.next(), Some(p!("")));
     /// assert_eq!(iterator.next(), None);
     /// ```
-    pub fn iter_path(&self) -> PathIterator {
+    pub fn iter_path(&self) -> PathIterator<'_> {
         PathIterator::new(self)
     }
 

--- a/packages/zpm/src/http.rs
+++ b/packages/zpm/src/http.rs
@@ -326,7 +326,7 @@ impl HttpClient {
         }))
     }
 
-    pub fn request(&self, url: impl AsRef<str>, method: Method) -> Result<HttpRequest, Error> {
+    pub fn request(&self, url: impl AsRef<str>, method: Method) -> Result<HttpRequest<'_>, Error> {
         let url
             = url.as_ref();
 
@@ -356,7 +356,7 @@ impl HttpClient {
         Ok(HttpRequest::new(self, url, method))
     }
 
-    pub fn get(&self, url: impl AsRef<str>) -> Result<HttpRequest, Error> {
+    pub fn get(&self, url: impl AsRef<str>) -> Result<HttpRequest<'_>, Error> {
         self.request(url, Method::GET)
     }
 
@@ -388,11 +388,11 @@ impl HttpClient {
         result.clone()
     }
 
-    pub fn post(&self, url: impl AsRef<str>) -> Result<HttpRequest, Error> {
+    pub fn post(&self, url: impl AsRef<str>) -> Result<HttpRequest<'_>, Error> {
         self.request(url, Method::POST)
     }
 
-    pub fn put(&self, url: impl AsRef<str>) -> Result<HttpRequest, Error> {
+    pub fn put(&self, url: impl AsRef<str>) -> Result<HttpRequest<'_>, Error> {
         self.request(url, Method::PUT)
     }
 }

--- a/packages/zpm/src/manifest/mod.rs
+++ b/packages/zpm/src/manifest/mod.rs
@@ -239,7 +239,7 @@ pub struct HardDependency<'a> {
 }
 
 impl Manifest {
-    pub fn iter_hard_dependencies(&self) -> impl Iterator<Item = HardDependency> {
+    pub fn iter_hard_dependencies(&self) -> impl Iterator<Item = HardDependency<'_>> {
         let dependencies_iter = self.remote.dependencies.values()
             .map(|descriptor| HardDependency {
                 kind: HardDependencyKind::Dependency,

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
-[toolchain]		
-channel = "1.88.0"
+[toolchain]
+channel = "1.93.0"
 components = ["clippy"]


### PR DESCRIPTION
Bump the project's Rust version to 1.93; [this release](https://blog.rust-lang.org/2026/01/22/Rust-1.93.0/#update-bundled-musl-to-1-2-5) updates the bundled musl to 1.2.5.