### PR TITLE
Fixes yarn up when preferReuse is set

### DIFF
--- a/packages/zpm/src/commands/add.rs
+++ b/packages/zpm/src/commands/add.rs
@@ -213,6 +213,7 @@ impl Add {
             active_workspace_ident: project.active_workspace()?.name.clone(),
             range_kind,
             resolve_tags: !self.fixed,
+            allow_reuse: true,
         };
 
         let package_cache

--- a/packages/zpm/src/commands/dlx.rs
+++ b/packages/zpm/src/commands/dlx.rs
@@ -59,6 +59,7 @@ impl DlxWithPackages {
             active_workspace_ident: dlx_project.active_workspace()?.name.clone(),
             range_kind: RangeKind::Exact,
             resolve_tags: true,
+            allow_reuse: true,
         };
 
         let descriptors
@@ -102,6 +103,7 @@ impl Dlx {
             active_workspace_ident: dlx_project.active_workspace()?.name.clone(),
             range_kind: RangeKind::Exact,
             resolve_tags: true,
+            allow_reuse: true,
         };
 
         let resolution

--- a/packages/zpm/src/commands/init.rs
+++ b/packages/zpm/src/commands/init.rs
@@ -72,6 +72,7 @@ impl InitWithTemplate {
             active_workspace_ident: project.active_workspace()?.name.clone(),
             range_kind: zpm_semver::RangeKind::Exact,
             resolve_tags: true,
+            allow_reuse: true,
         };
 
         let package_cache

--- a/packages/zpm/src/commands/up.rs
+++ b/packages/zpm/src/commands/up.rs
@@ -110,6 +110,7 @@ impl Up {
             active_workspace_ident: project.active_workspace()?.name.clone(),
             range_kind,
             resolve_tags: !self.fixed,
+            allow_reuse: false,
         };
 
         let package_cache

--- a/packages/zpm/src/descriptor_loose.rs
+++ b/packages/zpm/src/descriptor_loose.rs
@@ -15,6 +15,7 @@ pub struct ResolveOptions {
     pub active_workspace_ident: Ident,
     pub range_kind: RangeKind,
     pub resolve_tags: bool,
+    pub allow_reuse: bool,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
@@ -218,7 +219,7 @@ impl LooseDescriptor {
                     });
                 }
 
-                if project.config.settings.prefer_reuse.value {
+                if options.allow_reuse && project.config.settings.prefer_reuse.value {
                     if let Some(descriptor) = find_project_descriptor(project, ident.clone())? {
                         return Ok(LooseResolution {
                             descriptor: descriptor.clone(),

--- a/tests/acceptance-tests/pkg-tests-specs/sources/commands/up.test.ts
+++ b/tests/acceptance-tests/pkg-tests-specs/sources/commands/up.test.ts
@@ -130,6 +130,23 @@ describe(`Commands`, () => {
     );
 
     test(
+      `it should upgrade the dependency even when preferReuse is enabled`,
+      makeTemporaryEnv({
+        dependencies: {
+          [`no-deps`]: `1.0.0`,
+        },
+      }, {preferReuse: true}, async ({path, run, source}) => {
+        await run(`up`, `no-deps`);
+
+        await expect(xfs.readJsonPromise(ppath.join(path, Filename.manifest))).resolves.toStrictEqual({
+          dependencies: {
+            [`no-deps`]: `^2.0.0`,
+          },
+        });
+      }),
+    );
+
+    test(
       `it should skip build scripts when using --mode=skip-build`,
       makeTemporaryEnv({
         dependencies: {


### PR DESCRIPTION
When `preferReuse` is set, `yarn up pkg-name` will still attempt to reuse existing ranges ... which means it'll never update the dependency.

This diff fixes that by adding an option to the loose descriptor resolution process to disable the reuse strategy when within `yarn up`.