### PR TITLE
Fixes handling of escaped JSON metadata

### DIFF
--- a/packages/zpm-primitives/src/descriptor.rs
+++ b/packages/zpm-primitives/src/descriptor.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::collections::BTreeMap;
 use std::fmt;
 use std::hash::Hash;
@@ -183,9 +184,9 @@ pub fn descriptor_map_deserializer<'de, D>(deserializer: D) -> Result<BTreeMap<I
             let mut map
                 = BTreeMap::new();
 
-            while let Some((key, value)) = access.next_entry::<&str, &str>()? {
+            while let Some((key, value)) = access.next_entry::<Cow<'de, str>, Cow<'de, str>>()? {
                 let descriptor
-                    = extract_descriptor(key, value)
+                    = extract_descriptor(&key, &value)
                         .map_err(|e| serde::de::Error::custom(e.to_string()))?;
 
                 map.insert(descriptor.ident.clone(), descriptor);

--- a/tests/acceptance-tests/pkg-tests-fixtures/packages/one-range-dep-escaped-1.0.0/index.js
+++ b/tests/acceptance-tests/pkg-tests-fixtures/packages/one-range-dep-escaped-1.0.0/index.js
@@ -1,0 +1,7 @@
+module.exports = require(`./package.json`);
+
+for (const key of [`dependencies`, `devDependencies`, `peerDependencies`]) {
+  for (const dep of Object.keys(module.exports[key] || {})) {
+    module.exports[key][dep] = require(dep);
+  }
+}

--- a/tests/acceptance-tests/pkg-tests-fixtures/packages/one-range-dep-escaped-1.0.0/package.json
+++ b/tests/acceptance-tests/pkg-tests-fixtures/packages/one-range-dep-escaped-1.0.0/package.json
@@ -1,0 +1,7 @@
+{
+    "name": "one-range-dep-escaped",
+    "version": "1.0.0",
+    "dependencies": {
+        "no-deps": ">=1.0.0 <3"
+    }
+}

--- a/tests/acceptance-tests/pkg-tests-specs/sources/commands/install.test.ts
+++ b/tests/acceptance-tests/pkg-tests-specs/sources/commands/install.test.ts
@@ -928,6 +928,17 @@ describe(`Commands`, () => {
       }),
     );
 
+    test(
+      `it should support registries that return escaped JSON`,
+      makeTemporaryEnv({
+        dependencies: {
+          [`one-range-dep-escaped`]: `1.0.0`,
+        },
+      }, async ({path, run, source}) => {
+        await run(`install`);
+      }),
+    );
+
     test(`it should exit with an error code after an unexpected empty event loop`,
       makeTemporaryEnv({}, async ({path, run}) => {
         await xfs.writeFilePromise(ppath.join(path, `plugin.cjs`), `


### PR DESCRIPTION
Some registries don't return JSON data exactly like `JSON.serialize` would, and instead encode characters using unicode sequences. For example the GitHub Package Registry returns this:

```json
{
  "dependencies": {
    "foo": "\u003c3"
  }
}
```

Instead of this:

```json
{
  "dependencies": {
    "foo": "<3"
  }
}
```

The deserialization code wasn't expecting this, and instead tried to deserialize the string as-is (without clones), thus failing since the raw bytes couldn't safely be turned into a `&str` (since they required some transformation before).

This diff fixes that by using a `Cow` instead, which either uses a string reference when possible, or a new string when it'd otherwise fail.