### PR TITLE
Fixes `yarn node` failing after `yarn workspaces focus`

### DIFF
--- a/packages/zpm/src/commands/workspaces_focus.rs
+++ b/packages/zpm/src/commands/workspaces_focus.rs
@@ -57,6 +57,9 @@ impl WorkspacesFocus {
         let mut processed_queue
             = BTreeSet::from_iter(process_queue.iter().map(|w| &w.name));
 
+        // Always include root workspace so `yarn node` works from project root
+        processed_queue.insert(&project.root_workspace().name);
+
         while let Some(workspace) = process_queue.pop() {
             let mut relevant_dependencies
                 = workspace.manifest.remote.dependencies.iter()


### PR DESCRIPTION
When running `yarn workspaces focus <workspace> --production`, the root workspace was excluded from the focused set. This caused the root workspace to be pruned from `locator_resolutions` during tree resolution, and consequently not added to `packages_by_location` by the PnP linker.

Later, when running `yarn node` from the project root, `active_package()` would fail to find the root workspace in `packages_by_location`, resulting in:

    Error: Couldn't find a package matching the current working directory

This fix ensures the root workspace is always included in the focused set, so it remains in `packages_by_location` and `yarn node` works correctly.