### PR TITLE
Fixes version check in Yarn Switch

### DIFF
--- a/packages/zpm-switch/src/install.rs
+++ b/packages/zpm-switch/src/install.rs
@@ -141,15 +141,15 @@ pub async fn install_package_manager(package_manager: &VersionPackageManagerRefe
         platform: get_system_string().to_string(),
     };
 
-    if zpm_semver::Range::from_file_string(">=6.0.0-0").unwrap().check(&package_manager.version) {
+    if zpm_semver::Range::from_file_string(">=6.0.0").unwrap().check_ignore_rc(&package_manager.version) {
         return install_native_from_zpm(&version_platform, &Path::from_str("yarn-bin").unwrap()).await;
     }
 
-    if zpm_semver::Range::from_file_string(">=2.0.0-0").unwrap().check(&package_manager.version) {
+    if zpm_semver::Range::from_file_string(">=2.0.0").unwrap().check_ignore_rc(&package_manager.version) {
         return install_node_js_from_url(&version_platform).await;
     }
 
-    if zpm_semver::Range::from_file_string(">=0.0.0-0").unwrap().check(&package_manager.version) {
+    if zpm_semver::Range::from_file_string(">=0.0.0").unwrap().check_ignore_rc(&package_manager.version) {
         return install_node_js_from_package(&version_platform, &Path::from_str("bin/yarn.js").unwrap()).await;
     }
 


### PR DESCRIPTION
The original comparison was attempting to allow all greater semver version regardless whether they used prerelease specifiers or not, but it was incorrect due to a quirk in how semver ranges work: prerelease versions are only accepted if they have the same major as a version in the range. As a result `4.0.0-rc.1` couldn't match `2.0.0-0` (`4` vs `2`).

This diff fixes that by using the `check_ignore_rc` function which ignores this check.

Fixes #229