### PR TITLE
Replaces infallible implementation

### DIFF
--- a/packages/zpm-utils/src/misc.rs
+++ b/packages/zpm-utils/src/misc.rs
@@ -6,25 +6,13 @@ pub fn is_default<T: Default + PartialEq>(value: &T) -> bool {
     *value == T::default()
 }
 
-/// Unwrapping an infallible result into its success value.
-pub trait UnwrapInfallible {
-    /// Type of the `Ok` variant of the result.
-    type Ok;
-
-    /// Unwraps a result, returning the content of an `Ok`.
-    ///
-    /// Unlike `Result::unwrap`, this method is known to never panic
-    /// on the result types it is implemented for. Therefore, it can be used
-    /// instead of `unwrap` as a maintainability safeguard that will fail
-    /// to compile if the error type of the `Result` is later changed
-    /// to an error that can actually occur.
-    fn unwrap_infallible(self) -> Self::Ok;
+pub trait UnwrapInfallible<T> {
+    fn unwrap_infallible(self) -> T;
 }
 
-impl<T> UnwrapInfallible for Result<T, Infallible> {
-    type Ok = T;
+impl<T> UnwrapInfallible<T> for Result<T, Infallible> {
     fn unwrap_infallible(self) -> T {
-        self.unwrap_or_else(|never| match never {})
+        self.unwrap()
     }
 }
 


### PR DESCRIPTION
I don't exactly recall how `unwrap_infallible` was implemented (was it AI? was it a snippet I manually found on GH/SO? no idea), but looking back it seems a little overcomplicated for what was needed here (all we want is to throw at compile time if the type isn't an infallible; since the trait is only implemented for `Result<T, Infallible>` we don't need the additional match).

Cleaning it up and addressing the license concern in the same pass.

Fixes #225
