### PR TITLE
Clarifies the error message when running yarn run/node on a non-focused workspace

### DIFF
--- a/packages/zpm-constraints/package.json
+++ b/packages/zpm-constraints/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "@yarnpkg/zpm-constraints",
   "dependencies": {
     "@types/node": "^24.0.10",
     "@yarnpkg/types": "^4.0.1",

--- a/packages/zpm/src/error.rs
+++ b/packages/zpm/src/error.rs
@@ -336,6 +336,9 @@ pub enum Error {
     #[error("Invalid install state; please run an install operation to fix it")]
     InvalidInstallState,
 
+    #[error("Commands can only be run from focused workspaces and their dependencies")]
+    WorkspaceNotInstalled,
+
     #[error("Couldn't find a package matching the current working directory")]
     ActivePackageNotFound,
 

--- a/packages/zpm/src/project.rs
+++ b/packages/zpm/src/project.rs
@@ -436,11 +436,21 @@ impl Project {
     }
 
     pub fn active_package(&self) -> Result<Locator, Error> {
-        let install_state = self.install_state.as_ref()
-            .ok_or(Error::InstallStateNotFound)?;
+        let install_state
+            = self.install_state.as_ref()
+                .ok_or(Error::InstallStateNotFound)?;
 
-        let active_package = install_state.packages_by_location.get(&self.package_cwd)
-            .ok_or(Error::ActivePackageNotFound)?;
+        let Some(active_package) = install_state.packages_by_location.get(&self.package_cwd) else {
+            let is_workspace
+                = self.try_workspace_by_rel_path(&self.package_cwd)?
+                    .is_some();
+
+            return Err(if is_workspace {
+                Error::WorkspaceNotInstalled
+            } else {
+                Error::ActivePackageNotFound
+            });
+        };
 
         Ok(active_package.clone())
     }
@@ -648,7 +658,8 @@ impl Project {
     }
 
     pub fn find_binary(&self, name: &str) -> Result<Binary, Error> {
-        let active_package = self.active_package()?;
+        let active_package
+            = self.active_package()?;
 
         self.package_visible_binaries(&active_package)?
             .remove(name)
@@ -656,7 +667,8 @@ impl Project {
     }
 
     pub fn find_script(&self, name: &str) -> Result<(Locator, String), Error> {
-        let active_package = self.active_package()?;
+        let active_package
+            = self.active_package()?;
 
         self.find_package_script(&active_package, name)
     }


### PR DESCRIPTION
Imagine a repository with multiple workspaces, you only install some of them via `yarn workspaces focus`, then you run `yarn run` from the root directory. Yarn currently prints:

```
Couldn't find a package matching the current working directory
```

This is confusing since of course there's a package in the cwd. With this diff Yarn will now print the proper error:

```
Commands can only be run from focused workspaces and their dependencies
```
