### PR TITLE
Optimize pack hot path in CachePacker

### DIFF
--- a/packages/zpm-formats/src/iter_ext.rs
+++ b/packages/zpm-formats/src/iter_ext.rs
@@ -189,7 +189,7 @@ impl<'a, T> Iterator for Compress<T> where T: Iterator<Item = Entry<'a>> {
         let compressed_data = match algorithm {
             CompressionAlgorithm::Deflate(level) => {
                 let mut encoder
-                    = DeflateEncoder::new(Vec::new(), flate2::Compression::new(level as u32));
+                    = DeflateEncoder::new(Vec::with_capacity(next.data.len()), flate2::Compression::new(level as u32));
 
                 encoder.write_all(&next.data).unwrap();
                 encoder.finish().unwrap()

--- a/packages/zpm-formats/src/lib.rs
+++ b/packages/zpm-formats/src/lib.rs
@@ -1,5 +1,6 @@
-use std::{borrow::Cow, os::unix::fs::PermissionsExt};
+use std::{borrow::Cow, io::Write, os::unix::fs::PermissionsExt};
 
+use flate2::write::DeflateEncoder;
 use zpm_utils::{FromFileString, impl_file_string_from_str, Path, ToFileString, ToHumanString};
 
 pub(crate) mod zip_structs;
@@ -108,6 +109,23 @@ impl<'a> Entry<'a> {
             data,
             compression: None,
         }
+    }
+
+    pub fn compress_in_place(&mut self, algorithm: CompressionAlgorithm) {
+        let compressed_data = match algorithm {
+            CompressionAlgorithm::Deflate(level) => {
+                let mut encoder
+                    = DeflateEncoder::new(Vec::with_capacity(self.data.len()), flate2::Compression::new(level as u32));
+
+                encoder.write_all(&self.data).unwrap();
+                encoder.finish().unwrap()
+            },
+        };
+
+        self.compression = Some(Compression {
+            data: Cow::Owned(compressed_data),
+            algorithm,
+        });
     }
 }
 

--- a/packages/zpm-formats/src/zip.rs
+++ b/packages/zpm-formats/src/zip.rs
@@ -27,7 +27,7 @@ pub trait ToZip {
 
 impl<'a> ToZip for Vec<Entry<'a>> {
     fn to_zip(&self) -> Vec<u8> {
-        let mut general_capacity = 0;
+        let mut local_headers_capacity = 0;
         let mut central_directory_capacity = std::mem::size_of::<EndOfCentralDirectoryRecord>();
 
         for entry in self {
@@ -38,17 +38,22 @@ impl<'a> ToZip for Vec<Entry<'a>> {
             let name_bytes
                 = entry.name.as_str().as_bytes();
 
-            general_capacity
+            local_headers_capacity
                 += std::mem::size_of::<GeneralRecord>() + name_bytes.len() + compressed_data.len();
 
             central_directory_capacity
                 += std::mem::size_of::<CentralDirectoryRecord>() + name_bytes.len();
         }
 
-        let mut general_segment
-            = Vec::with_capacity(general_capacity);
-        let mut central_directory_segment
-            = Vec::with_capacity(central_directory_capacity);
+        let total_capacity
+            = local_headers_capacity + central_directory_capacity;
+
+        let mut buffer
+            = Vec::with_capacity(total_capacity);
+
+        // First pass: write local file headers + data, computing CRC32 inline
+        let mut entry_metadata: Vec<(usize, u32)>
+            = Vec::with_capacity(self.len());
 
         for entry in self {
             let compressed_data = entry.compression
@@ -59,33 +64,58 @@ impl<'a> ToZip for Vec<Entry<'a>> {
                 .as_ref()
                 .map(|compressed_data| compressed_data.algorithm);
 
-            let offset = general_segment.len();
+            let crc
+                = crc32fast::hash(&entry.data);
 
-            inject_general_record(&mut general_segment, entry, compressed_data, compression);
-            inject_central_directory_record(&mut central_directory_segment, entry, compressed_data, offset, compression);
+            let offset = buffer.len();
+            entry_metadata.push((offset, crc));
+
+            inject_general_record(&mut buffer, entry, compressed_data, compression, crc);
         }
 
-        central_directory_segment.extend_from_slice(
+        assert_eq!(buffer.len(), local_headers_capacity);
+
+        let central_directory_offset
+            = buffer.len();
+
+        // Second pass: write central directory records
+        for (i, entry) in self.iter().enumerate() {
+            let compressed_data = entry.compression
+                .as_ref()
+                .map_or(&entry.data, |compressed_data| &compressed_data.data);
+
+            let compression = entry.compression
+                .as_ref()
+                .map(|compressed_data| compressed_data.algorithm);
+
+            let (offset, crc) = entry_metadata[i];
+
+            inject_central_directory_record(&mut buffer, entry, compressed_data, offset, compression, crc);
+        }
+
+        let central_directory_size
+            = buffer.len() - central_directory_offset;
+
+        buffer.extend_from_slice(
             EndOfCentralDirectoryRecord {
                 signature: [0x50, 0x4b, 0x05, 0x06],
                 disk_number: U16::new(0x00),
                 disk_with_central_directory: U16::new(0x00),
                 number_of_files_on_this_disk: U16::new(self.len() as u16),
                 number_of_files: U16::new(self.len() as u16),
-                size_of_central_directory: U32::new(central_directory_segment.len() as u32),
-                offset_of_central_directory: U32::new(general_segment.len() as u32),
+                size_of_central_directory: U32::new(central_directory_size as u32),
+                offset_of_central_directory: U32::new(central_directory_offset as u32),
                 comment_length: U16::new(0x00),
             }.as_bytes(),
         );
 
-        assert_eq!(general_segment.len(), general_capacity);
-        assert_eq!(central_directory_segment.len(), central_directory_capacity);
+        assert_eq!(buffer.len(), total_capacity);
 
-        [general_segment, central_directory_segment].concat()
+        buffer
     }
 }
 
-fn inject_general_record(target: &mut Vec<u8>, entry: &Entry, compressed_data: &[u8], compression: Option<CompressionAlgorithm>) {
+fn inject_general_record(target: &mut Vec<u8>, entry: &Entry, compressed_data: &[u8], compression: Option<CompressionAlgorithm>, crc: u32) {
     let compression_method: u16 = match compression {
         Some(CompressionAlgorithm::Deflate(_)) => 0x08, // Deflate compression
         None => 0x00, // No compression
@@ -103,7 +133,7 @@ fn inject_general_record(target: &mut Vec<u8>, entry: &Entry, compressed_data: &
                 compression_method: U16::new(compression_method),
                 last_mod_file_time: U16::new(0xae40),
                 last_mod_file_date: U16::new(0x08d6),
-                crc_32: U32::new(entry.crc),
+                crc_32: U32::new(crc),
                 compressed_size: U32::new(compressed_data.len() as u32),
                 uncompressed_size: U32::new(entry.data.len() as u32),
                 file_name_length: U16::new(name_bytes.len() as u16),
@@ -119,7 +149,7 @@ fn inject_general_record(target: &mut Vec<u8>, entry: &Entry, compressed_data: &
     target.extend_from_slice(compressed_data);
 }
 
-fn inject_central_directory_record(target: &mut Vec<u8>, entry: &Entry, compressed_data: &[u8], offset: usize, compression: Option<CompressionAlgorithm>) {
+fn inject_central_directory_record(target: &mut Vec<u8>, entry: &Entry, compressed_data: &[u8], offset: usize, compression: Option<CompressionAlgorithm>, crc: u32) {
     let compression_method: u16 = match compression {
         Some(CompressionAlgorithm::Deflate(_)) => 0x08, // Deflate compression
         None => 0x00, // No compression
@@ -138,7 +168,7 @@ fn inject_central_directory_record(target: &mut Vec<u8>, entry: &Entry, compress
                 compression_method: U16::new(compression_method),
                 last_mod_file_time: U16::new(0xae40),
                 last_mod_file_date: U16::new(0x08d6),
-                crc_32: U32::new(entry.crc),
+                crc_32: U32::new(crc),
                 compressed_size: U32::new(compressed_data.len() as u32),
                 uncompressed_size: U32::new(entry.data.len() as u32),
                 file_name_length: U16::new(name_bytes.len() as u16),

--- a/packages/zpm/src/cache.rs
+++ b/packages/zpm/src/cache.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use std::collections::HashSet;
 use std::sync::Mutex;
 use itertools::Itertools;
-use zpm_formats::{iter_ext::IterExt, zip::ToZip, Entry};
+use zpm_formats::{zip::ToZip, Entry};
 use zpm_macro_enum::zpm_enum;
 use zpm_primitives::Locator;
 use zpm_utils::{Hash64, Path};
@@ -49,15 +49,14 @@ pub struct CachePacker {
 }
 
 impl CachePacker {
-    pub fn pack<'a>(&self, entries: Vec<Entry<'a>>) -> Result<Vec<u8>, Error> {
-        let archive = entries
-            .into_iter()
-            .update_crc32()
-            .compress(self.compression_algorithm)
-            .collect::<Vec<_>>()
-            .to_zip();
+    pub fn pack<'a>(&self, mut entries: Vec<Entry<'a>>) -> Result<Vec<u8>, Error> {
+        if let Some(algorithm) = self.compression_algorithm {
+            for entry in &mut entries {
+                entry.compress_in_place(algorithm);
+            }
+        }
 
-        Ok(archive)
+        Ok(entries.to_zip())
     }
 }
 

--- a/packages/zpm/src/fetchers/folder.rs
+++ b/packages/zpm/src/fetchers/folder.rs
@@ -35,14 +35,23 @@ pub async fn fetch_locator<'a>(context: &InstallContext<'a>, locator: &Locator, 
     let package_subdir
         = locator.ident.nm_subdir();
 
-    let pkg_blob = package_cache.upsert_blob(locator.clone(), ".zip", || async {
-        let entries
-            = zpm_formats::entries_from_folder(&context_directory)?
-                .into_iter()
-                .prepare_npm_entries(&package_subdir)
-                .collect::<Vec<_>>();
+    let package_subdir_for_entries
+        = package_subdir.clone();
+    let context_directory_for_entries
+        = context_directory.clone();
 
-        Ok(cache_packer.pack(entries)?)
+    let pkg_blob = package_cache.upsert_blob(locator.clone(), ".zip", || async {
+        let archive = tokio::task::spawn_blocking(move || -> Result<Vec<u8>, Error> {
+            let entries
+                = zpm_formats::entries_from_folder(&context_directory_for_entries)?
+                    .into_iter()
+                    .prepare_npm_entries(&package_subdir_for_entries)
+                    .collect::<Vec<_>>();
+
+            cache_packer.pack(entries)
+        }).await??;
+
+        Ok(archive)
     }).await?;
 
     let first_entry

--- a/packages/zpm/src/fetchers/patch.rs
+++ b/packages/zpm/src/fetchers/patch.rs
@@ -98,61 +98,76 @@ pub async fn fetch_locator<'a>(context: &InstallContext<'a>, locator: &Locator, 
     let package_subdir
         = locator.ident.nm_subdir();
 
+    let package_subdir_for_entries
+        = package_subdir.clone();
+
     let cached_blob = package_cache.upsert_blob(locator.clone(), ".zip", || async {
+        // Extract owned data from references before spawn_blocking
         let original_bytes = match &original_data.package_data {
             PackageData::Zip {archive_path, ..} => Some(archive_path.fs_read()?),
             _ => None,
         };
 
-        let original_entries = match &original_data.package_data {
-            PackageData::Local {package_directory, ..} => {
-                zpm_formats::entries_from_folder(package_directory)?
-            },
+        let original_package_directory = match &original_data.package_data {
+            PackageData::Local {package_directory, ..} => Some(package_directory.clone()),
+            _ => None,
+        };
 
-            PackageData::Zip {..} => {
-                let package_subpath
-                    = original_data.package_data.package_subpath();
+        let original_package_subpath = match &original_data.package_data {
+            PackageData::Zip {..} => Some(original_data.package_data.package_subpath()),
+            _ => None,
+        };
 
-                zpm_formats::zip::entries_from_zip(original_bytes.as_ref().unwrap())?
-                    .into_iter()
-                    .strip_path_prefix(&package_subpath)
-                    .collect::<Vec<_>>()
-            },
+        let is_unsupported = matches!(&original_data.package_data, PackageData::Abstract | PackageData::MissingZip {..});
 
-            PackageData::Abstract | PackageData::MissingZip {..} => {
+        let archive = tokio::task::spawn_blocking(move || -> Result<Vec<u8>, Error> {
+            if is_unsupported {
                 return Err(Error::Unsupported);
-            },
-        };
+            }
 
-        let package_json_entry
-            = original_entries
-                .first()
-                .ok_or(Error::MissingPackageManifest)?;
+            let original_entries = if let Some(ref bytes) = original_bytes {
+                zpm_formats::zip::entries_from_zip(bytes)?
+                    .into_iter()
+                    .strip_path_prefix(&original_package_subpath.unwrap())
+                    .collect::<Vec<_>>()
+            } else if let Some(ref dir) = original_package_directory {
+                zpm_formats::entries_from_folder(dir)?
+            } else {
+                return Err(Error::Unsupported);
+            };
 
-        let manifest: RemoteManifest
-            = JsonDocument::hydrate_from_slice(&package_json_entry.data)?;
+            let package_json_entry
+                = original_entries
+                    .first()
+                    .ok_or(Error::MissingPackageManifest)?;
 
-        let package_version
-            = manifest.version
-                .unwrap_or_default();
+            let manifest: RemoteManifest
+                = JsonDocument::hydrate_from_slice(&package_json_entry.data)?;
 
-        let patched_entries = match is_builtin {
-            true => {
-                apply_patch(original_entries.clone(), &patch_content, &package_version)
-                    .unwrap_or(original_entries)
-            },
+            let package_version
+                = manifest.version
+                    .unwrap_or_default();
 
-            false => {
-                apply_patch(original_entries, &patch_content, &package_version)?
-            },
-        };
+            let patched_entries = match is_builtin {
+                true => {
+                    apply_patch(original_entries.clone(), &patch_content, &package_version)
+                        .unwrap_or(original_entries)
+                },
 
-        let patched_entries = patched_entries
-            .into_iter()
-            .prepare_npm_entries(&package_subdir)
-            .collect::<Vec<_>>();
+                false => {
+                    apply_patch(original_entries, &patch_content, &package_version)?
+                },
+            };
 
-        Ok(cache_packer.pack(patched_entries)?)
+            let patched_entries = patched_entries
+                .into_iter()
+                .prepare_npm_entries(&package_subdir_for_entries)
+                .collect::<Vec<_>>();
+
+            cache_packer.pack(patched_entries)
+        }).await??;
+
+        Ok(archive)
     }).await?;
 
     let package_json_entry


### PR DESCRIPTION
- Remove redundant memory copies in `to_zip()`
- Eliminate intermediate `.collect::<Vec<_>>()`
- Move `pack` to `spawn_blocking`

<img width="1917" height="355" alt="image" src="https://github.com/user-attachments/assets/1673faf2-38af-42e0-b010-76560004c792" />

In the original flame graph, this function accounts for 11.46%.
