### PR TITLE
Fixes semver comparison

### DIFF
--- a/packages/zpm-switch/src/install.rs
+++ b/packages/zpm-switch/src/install.rs
@@ -160,15 +160,15 @@ pub async fn install_package_manager(package_manager: &VersionPackageManagerRefe
         platform: get_system_string().to_string(),
     };
 
-    if zpm_semver::Range::from_file_string(">=6.0.0").unwrap().check_ignore_rc(&package_manager.version) {
+    if zpm_semver::Range::from_file_string(">=6.0.0-0").unwrap().check_ignore_rc(&package_manager.version) {
         return install_native_from_zpm(&version_platform, &Path::from_str("yarn-bin").unwrap()).await;
     }
 
-    if zpm_semver::Range::from_file_string(">=2.0.0").unwrap().check_ignore_rc(&package_manager.version) {
+    if zpm_semver::Range::from_file_string(">=2.0.0-0").unwrap().check_ignore_rc(&package_manager.version) {
         return install_node_js_from_url(&version_platform).await;
     }
 
-    if zpm_semver::Range::from_file_string(">=0.0.0").unwrap().check_ignore_rc(&package_manager.version) {
+    if zpm_semver::Range::from_file_string(">=0.0.0-0").unwrap().check_ignore_rc(&package_manager.version) {
         return install_node_js_from_package(&version_platform, &Path::from_str("bin/yarn.js").unwrap()).await;
     }
 


### PR DESCRIPTION
The fix in https://github.com/yarnpkg/zpm/pull/230 changed the `6.0.0-0` comparison into `6.0.0`. I was thinking that `check_ignore_rc` would ignore all RCs, but it's a little stricter than I thought and still took into account the one from the original range (in other words, it accepts `7.0.0-rc`, but it still requires the version to be greater than `6.0.0`).

This diff fixes that by reverting to `6.0.0-0` which, together with `check_ignore_rc`, provides the right result.