### PR TITLE
Adds a spinner when performing a lazy install

### DIFF
--- a/packages/zpm-utils/src/progress.rs
+++ b/packages/zpm-utils/src/progress.rs
@@ -75,10 +75,13 @@ where
     let mut frame_idx: usize
         = 0;
 
-    let mut stdout
-        = std::io::stdout().lock();
+    {
+        let mut stdout
+            = std::io::stdout().lock();
 
-    stdout.write_all(b"\x1b[?25l").ok();
+        stdout.write_all(b"\x1b[?25l").ok();
+        stdout.flush().ok();
+    }
 
     loop {
         match stop_rx.recv_timeout(Duration::from_millis(50)) {

--- a/packages/zpm/src/project.rs
+++ b/packages/zpm/src/project.rs
@@ -1,4 +1,4 @@
-use std::{collections::{BTreeMap, BTreeSet, HashSet}, io::ErrorKind, sync::Arc, time::UNIX_EPOCH};
+use std::{collections::{BTreeMap, BTreeSet, HashSet}, io::ErrorKind, sync::Arc, time::{Duration, UNIX_EPOCH}};
 
 use globset::{GlobBuilder, GlobSetBuilder};
 use zpm_config::{Configuration, ConfigurationContext};
@@ -6,7 +6,7 @@ use zpm_macro_enum::zpm_enum;
 use zpm_parsers::JsonDocument;
 use zpm_primitives::{Descriptor, Ident, Locator, Range, Reference, WorkspaceIdentReference, WorkspaceMagicRange, WorkspacePathReference};
 use zpm_tasks::{parse as parse_taskfile, ResolvedTasks, TaskId};
-use zpm_utils::{Glob, LastModifiedAt, Path, ToFileString, ToHumanString};
+use zpm_utils::{Glob, LastModifiedAt, Path, ToFileString, ToHumanString, is_terminal, start_progress};
 use serde::Deserialize;
 use zpm_formats::zip::ZipSupport;
 
@@ -764,7 +764,7 @@ impl Project {
             }
         }
 
-        self.run_install(RunInstallOptions {
+        let install = self.run_install(RunInstallOptions {
             check_checksums: false,
             check_resolutions: false,
             enforced_resolutions: BTreeMap::new(),
@@ -774,7 +774,34 @@ impl Project {
             mode: None,
             roots: None,
             ..Default::default()
-        }).await?;
+        });
+
+        tokio::pin!(install);
+
+        if !is_terminal() {
+            install.await?;
+            return Ok(());
+        }
+
+        tokio::select! {
+            result = &mut install => {
+                result?;
+                return Ok(());
+            },
+
+            _ = tokio::time::sleep(Duration::from_millis(200)) => {
+            }
+        }
+
+        let mut progress_handle
+            = start_progress(|_| "Installing dependencies...".to_string());
+
+        let install_result
+            = install.await;
+
+        progress_handle.stop();
+
+        install_result?;
 
         Ok(())
     }


### PR DESCRIPTION
Most Yarn commands now silently run installs under the hood when they detect the project isn't in sync compared to the last modification time of package.json. Only problem is that it's a little _too_ silent and it may look like the command is unexpectedly hanging.

To address this we now display a spinner if the install takes more than 200ms.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the async lazy-install control flow with a new `tokio::select!` timing branch and threaded terminal output, which could affect install completion timing or terminal behavior in edge cases.
> 
> **Overview**
> Improves UX for `lazy_install` by showing a spinner message ("Installing dependencies...") **only when running in a TTY** and the install hasn’t finished within ~200ms; non-terminal contexts still run silently.
> 
> Refactors `lazy_install` to pin the install future, race it against a short sleep via `tokio::select!`, start/stop a `start_progress` spinner around the remaining work, and updates the progress thread to flush immediately after hiding the cursor to make terminal state changes visible promptly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 328144fb9b7ee3c69b618cc4386e00f11779c698. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->