### PR TITLE
Renames YARN_SWITCH_... into YARNSW_...

### DIFF
--- a/packages/zpm-switch/src/commands/switch/explicit.rs
+++ b/packages/zpm-switch/src/commands/switch/explicit.rs
@@ -3,7 +3,7 @@ use std::{process::{Command, ExitStatus, Stdio}, sync::Arc};
 use clipanion::cli;
 use zpm_utils::ToFileString;
 
-use crate::{cwd::{get_fake_cwd, get_final_cwd}, errors::Error, install::install_package_manager, ipc::YARN_SWITCH_PATH_ENV, manifest::{find_closest_package_manager, PackageManagerReference, VersionPackageManagerReference}, yarn::resolve_selector, yarn_enums::Selector};
+use crate::{cwd::{get_fake_cwd, get_final_cwd}, errors::Error, install::install_package_manager, ipc::YARNSW_PATH_ENV, manifest::{find_closest_package_manager, PackageManagerReference, VersionPackageManagerReference}, yarn::resolve_selector, yarn_enums::Selector};
 
 /// Call a custom Yarn binary for the current project
 #[cli::command(proxy)]
@@ -29,7 +29,7 @@ impl ExplicitCommand {
         binary.args(args);
 
         if let Ok(switch_path) = std::env::current_exe() {
-            binary.env(YARN_SWITCH_PATH_ENV, switch_path);
+            binary.env(YARNSW_PATH_ENV, switch_path);
         }
 
         let mut child

--- a/packages/zpm-switch/src/http.rs
+++ b/packages/zpm-switch/src/http.rs
@@ -34,7 +34,7 @@ fn is_npm_registry_request(url: &str) -> bool {
 }
 
 fn attach_auth_headers(request: &mut reqwest::RequestBuilder) {
-    if let Ok(token) = std::env::var("YARN_SWITCH_NPM_AUTH_TOKEN") {
+    if let Ok(token) = std::env::var("YARNSW_NPM_AUTH_TOKEN") {
         if let Some(cloned_request) = request.try_clone() {
             *request = cloned_request.bearer_auth(token);
         }
@@ -42,7 +42,7 @@ fn attach_auth_headers(request: &mut reqwest::RequestBuilder) {
         return;
     }
 
-    if let Ok(mut auth_ident) = std::env::var("YARN_SWITCH_NPM_AUTH_IDENT") {
+    if let Ok(mut auth_ident) = std::env::var("YARNSW_NPM_AUTH_IDENT") {
         if auth_ident.contains(':') {
             auth_ident = base64::Engine::encode(&base64::engine::general_purpose::STANDARD, auth_ident);
         }

--- a/packages/zpm-switch/src/ipc.rs
+++ b/packages/zpm-switch/src/ipc.rs
@@ -1,1 +1,1 @@
-pub const YARN_SWITCH_PATH_ENV: &str = "YARN_SWITCH_PATH";
+pub const YARNSW_PATH_ENV: &str = "YARNSW_PATH";

--- a/packages/zpm-switch/src/lib.rs
+++ b/packages/zpm-switch/src/lib.rs
@@ -10,7 +10,7 @@ pub use errors::{
   Error,
 };
 
-pub use ipc::YARN_SWITCH_PATH_ENV;
+pub use ipc::YARNSW_PATH_ENV;
 
 pub use manifest::{
     PackageManagerField,

--- a/packages/zpm/src/daemon/client.rs
+++ b/packages/zpm/src/daemon/client.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, process::Stdio, sync::{atomic::{AtomicBool, Atom
 use futures::{SinkExt, stream::StreamExt};
 use tokio::{io::AsyncBufReadExt, sync::{mpsc, oneshot, Mutex}, task::AbortHandle};
 use tokio_tungstenite::{MaybeTlsStream, WebSocketStream, tungstenite::Message};
-use zpm_switch::YARN_SWITCH_PATH_ENV;
+use zpm_switch::YARNSW_PATH_ENV;
 use zpm_utils::Path;
 
 use super::{
@@ -473,7 +473,7 @@ pub struct DaemonStatsResult {
 
 async fn start_daemon(project_root: &Path) -> Result<String, Error> {
     let switch_path
-        = std::env::var(YARN_SWITCH_PATH_ENV).map_err(|_| {
+        = std::env::var(YARNSW_PATH_ENV).map_err(|_| {
             Error::IpcError(
                 "This command can only be called within a Yarn Switch context. \
                  Please run this command through `yarn` instead of calling the binary directly."


### PR DESCRIPTION
Environment variables named `YARN_*` are interpreted by Yarn as settings. Yarn Berry is strict and will throw if it receives any environment variable it doesn't recognize. Yarn Switch needs to use its own prefix (`YARNSW_*`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low-risk refactor, but it is a breaking change for any callers still setting the old `YARN_SWITCH_*`/auth env vars and could affect daemon startup or npm registry auth if not updated.
> 
> **Overview**
> Renames the internal env var used to propagate the Yarn Switch executable path from `YARN_SWITCH_PATH` to `YARNSW_PATH`, updating exports in `zpm-switch` and the consumer in `zpm` daemon startup.
> 
> Updates npm registry auth env vars used by `zpm-switch` HTTP fetching from `YARN_SWITCH_NPM_AUTH_*` to `YARNSW_NPM_AUTH_*` so Yarn Berry won’t treat them as Yarn settings and error.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f0a2a6f4e563ec30188409f8f88679ac4a7f776. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->