### PR TITLE
Adds completion support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,7 +108,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -119,7 +119,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -431,7 +431,7 @@ checksum = "aaa6b4b263a5d737e9bf6b7c09b72c41a5480aec4d7219af827f6564e950b6a5"
 [[package]]
 name = "clipanion"
 version = "0.8.1"
-source = "git+https://github.com/arcanis/clipanion-rs.git#d0728096cbb5a17be14d0e13a72ceb9325fdb43c"
+source = "git+https://github.com/arcanis/clipanion-rs.git#30f76d11de39b593a10851b06a406c2013bb2c30"
 dependencies = [
  "clipanion-core",
  "clipanion-derive",
@@ -443,7 +443,7 @@ dependencies = [
 [[package]]
 name = "clipanion-core"
 version = "0.8.1"
-source = "git+https://github.com/arcanis/clipanion-rs.git#d0728096cbb5a17be14d0e13a72ceb9325fdb43c"
+source = "git+https://github.com/arcanis/clipanion-rs.git#30f76d11de39b593a10851b06a406c2013bb2c30"
 dependencies = [
  "colored 2.2.0",
  "itertools 0.14.0",
@@ -455,7 +455,7 @@ dependencies = [
 [[package]]
 name = "clipanion-derive"
 version = "0.8.1"
-source = "git+https://github.com/arcanis/clipanion-rs.git#d0728096cbb5a17be14d0e13a72ceb9325fdb43c"
+source = "git+https://github.com/arcanis/clipanion-rs.git#30f76d11de39b593a10851b06a406c2013bb2c30"
 dependencies = [
  "indoc",
  "proc-macro2",
@@ -537,7 +537,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -546,7 +546,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -878,7 +878,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1047,7 +1047,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3076,7 +3076,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3477,6 +3477,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
+ "windows-sys 0.52.0",
  "windows-sys 0.59.0",
 ]
 
@@ -3576,7 +3577,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4287,7 +4288,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/packages/zpm-switch/src/commands/proxy.rs
+++ b/packages/zpm-switch/src/commands/proxy.rs
@@ -1,71 +1,156 @@
-use std::{io::IsTerminal, process::ExitStatus};
+use std::{io::IsTerminal, process::{ExitStatus, Stdio}};
 
 use clipanion::cli;
+use clipanion::core::{Completion, CompletionContext};
 use zpm_utils::{DataType, Note, ToFileString};
 
-use crate::{cwd::{get_fake_cwd, get_final_cwd}, errors::Error, links::{LinkTarget, get_link, unset_link}, manifest::{LocalPackageManagerReference, PackageManagerField, find_closest_package_manager}, yarn::get_default_yarn_version, yarn_enums::ReleaseLine};
+use crate::{cwd::{get_fake_cwd, get_final_cwd}, errors::Error, install::install_package_manager, ipc::YARNSW_PATH_ENV, links::{LinkTarget, get_link, unset_link}, manifest::{LocalPackageManagerReference, PackageManagerField, PackageManagerReference, find_closest_package_manager}, yarn::get_default_yarn_version, yarn_enums::ReleaseLine};
 
 use super::switch::explicit::ExplicitCommand;
+
+pub async fn resolve_proxy_reference() -> Result<PackageManagerReference, Error> {
+    let lookup_path
+        = get_final_cwd()?;
+
+    let mut find_result
+        = find_closest_package_manager(&lookup_path)?;
+
+    if let Some(detected_root_path) = find_result.detected_root_path {
+        std::env::set_var("YARNSW_DETECTED_ROOT", detected_root_path.to_file_string());
+
+        if let Some(link) = get_link(&detected_root_path)? {
+            match link.link_target {
+                LinkTarget::Local {bin_path} => {
+                    if std::io::stdout().is_terminal() {
+                        Note::Warning(format!("This command runs a local development version of Yarn. Use {} to remove the link.", DataType::Code.colorize("yarn switch unlink"))).print();
+                        println!();
+                    }
+
+                    find_result.detected_package_manager
+                        = Some(PackageManagerField::new_yarn(LocalPackageManagerReference {path: bin_path}.into()));
+                },
+
+                LinkTarget::Migration => {
+                    if let Some(migration) = find_result.detected_package_manager_migration {
+                        std::env::set_var("YARN_ENABLE_MIGRATION_MODE", "1");
+
+                        if std::io::stdout().is_terminal() {
+                            Note::Warning(format!("This command runs the checked-in migration version of Yarn. Use {} to opt-out of the migration.", DataType::Code.colorize("yarn switch unlink"))).print();
+                            println!();
+                        }
+
+                        find_result.detected_package_manager
+                            = Some(PackageManagerField::new_yarn(migration.into_reference("yarn")?));
+                    } else {
+                        unset_link(&detected_root_path)?;
+                    }
+                },
+            };
+        }
+    }
+
+    let reference = match find_result.detected_package_manager {
+        Some(package_manager) => package_manager.into_reference("yarn"),
+        None => get_default_yarn_version(Some(ReleaseLine::Classic)).await,
+    }?;
+
+    Ok(reference)
+}
+
+pub fn proxy_completer(ctx: &CompletionContext) -> Vec<Completion> {
+    let handle = tokio::runtime::Handle::current();
+
+    tokio::task::block_in_place(|| {
+        handle.block_on(async {
+            proxy_completer_async(ctx).await
+        })
+    })
+}
+
+async fn proxy_completer_async(ctx: &CompletionContext<'_>) -> Vec<Completion> {
+    let Ok(reference) = resolve_proxy_reference().await else {
+        return vec![];
+    };
+
+    let mut binary = match &reference {
+        PackageManagerReference::Version(params) => {
+            let Ok(cmd) = install_package_manager(params).await else {
+                return vec![];
+            };
+            cmd
+        },
+        PackageManagerReference::Local(params) => {
+            std::process::Command::new(params.path.to_file_string())
+        },
+    };
+
+    let mut args = vec![String::from("--clipanion-complete")];
+
+    let user_args: Vec<&str> = ctx.args_before.iter()
+        .copied()
+        .chain(std::iter::once(ctx.current))
+        .collect();
+
+    let index = ctx.args_before.len();
+    args.push(index.to_string());
+    args.push(String::from("--"));
+    args.extend(user_args.into_iter().map(String::from));
+
+    if let Some(cwd) = get_fake_cwd() {
+        binary.args(&[cwd.to_file_string()]);
+    }
+
+    binary.args(&args);
+    binary.stdout(Stdio::piped());
+    binary.stderr(Stdio::null());
+
+    if let Ok(switch_path) = std::env::current_exe() {
+        binary.env(YARNSW_PATH_ENV, switch_path);
+    }
+
+    let Ok(output) = binary.output() else {
+        return vec![];
+    };
+
+    let Ok(stdout) = String::from_utf8(output.stdout) else {
+        return vec![];
+    };
+
+    stdout.lines().filter_map(|line| {
+        let line = line.trim();
+        if line.is_empty() {
+            return None;
+        }
+
+        let mut parts = line.splitn(2, '\t');
+        let text = parts.next()?.to_string();
+        let description = parts.next().map(|s| s.to_string());
+
+        let mut completion = Completion::new(text);
+        if let Some(desc) = description {
+            completion = completion.with_description(desc);
+        }
+        Some(completion)
+    }).collect()
+}
 
 /// Call the suitable Yarn binary for the current project
 #[cli::command(default, proxy)]
 #[cli::category("General commands")]
 #[derive(Debug)]
 pub struct ProxyCommand {
+    #[cli::positional(completer = proxy_completer)]
     args: Vec<String>,
 }
 
 impl ProxyCommand {
     pub async fn execute(&self) -> Result<ExitStatus, Error> {
-        let lookup_path
-            = get_final_cwd()?;
-
-        let mut find_result
-            = find_closest_package_manager(&lookup_path)?;
-
-        if let Some(detected_root_path) = find_result.detected_root_path {
-            std::env::set_var("YARNSW_DETECTED_ROOT", detected_root_path.to_file_string());
-
-            if let Some(link) = get_link(&detected_root_path)? {
-                match link.link_target {
-                    LinkTarget::Local {bin_path} => {
-                        if std::io::stdout().is_terminal() {
-                            Note::Warning(format!("This command runs a local development version of Yarn. Use {} to remove the link.", DataType::Code.colorize("yarn switch unlink"))).print();
-                            println!();
-                        }
-
-                        find_result.detected_package_manager
-                            = Some(PackageManagerField::new_yarn(LocalPackageManagerReference {path: bin_path}.into()));
-                    },
-
-                    LinkTarget::Migration => {
-                        if let Some(migration) = find_result.detected_package_manager_migration {
-                            std::env::set_var("YARN_ENABLE_MIGRATION_MODE", "1");
-
-                            if std::io::stdout().is_terminal() {
-                                Note::Warning(format!("This command runs the checked-in migration version of Yarn. Use {} to opt-out of the migration.", DataType::Code.colorize("yarn switch unlink"))).print();
-                                println!();
-                            }
-
-                            find_result.detected_package_manager
-                                = Some(PackageManagerField::new_yarn(migration.into_reference("yarn")?));
-                        } else {
-                            unset_link(&detected_root_path)?;
-                        }
-                    },
-                };
-            }
-        }
-
-        let reference = match find_result.detected_package_manager {
-            Some(package_manager) => package_manager.into_reference("yarn"),
-            None => get_default_yarn_version(Some(ReleaseLine::Classic)).await,
-        }?;
+        let reference
+            = resolve_proxy_reference().await?;
 
         let mut args
             = self.args.clone();
 
-        // Don't forget to add back the cwd parameter that was removed earlier on!
         if let Some(cwd) = get_fake_cwd() {
             args.insert(0, cwd.to_file_string());
         }


### PR DESCRIPTION
I merged completion support in Clipanion; updating the library and adding a completer to the Yarn Switch proxy.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new completion execution path that spawns the resolved Yarn binary and parses its output, which could affect CLI responsiveness and behavior on different platforms. Also updates `clipanion` and tweaks `windows-sys` lockfile versions, which may introduce subtle build/runtime differences on Windows.
> 
> **Overview**
> Adds shell completion support to `zpm-switch`’s `yarn` proxy by introducing `resolve_proxy_reference()` and wiring a `proxy_completer` onto the proxy positional args, delegating completion generation to the resolved Yarn binary via `--clipanion-complete`.
> 
> Updates `Cargo.lock` to a newer `clipanion-rs` git commit (completion support) and adjusts several `windows-sys` resolved versions accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 605c29895d2d7812088c6f230d034f98f5f24c35. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->