### PR TITLE
Implements a metadata cache

### DIFF
--- a/.github/workflows/perfcheck.yml
+++ b/.github/workflows/perfcheck.yml
@@ -76,6 +76,14 @@ jobs:
         working-directory: ../head
         run: ./target/release-lto/yarn-bin debug bench gatsby install-full-cold
 
+      - name: Run benchmark cache only (base)
+        working-directory: ../base
+        run: ./target/release-lto/yarn-bin debug bench gatsby install-cache-only
+
+      - name: Run benchmark cache only (head)
+        working-directory: ../head
+        run: ./target/release-lto/yarn-bin debug bench gatsby install-cache-only
+
       - name: Run benchmark warm with lockfile (base)
         working-directory: ../base
         run: ./target/release-lto/yarn-bin debug bench gatsby install-cache-and-lock
@@ -106,6 +114,7 @@ jobs:
 
             const benches = [
               {mode: 'install-full-cold', label: 'gatsby install-full-cold'},
+              {mode: 'install-cache-only', label: 'gatsby install-cache-only'},
               {mode: 'install-cache-and-lock', label: 'gatsby install-cache-and-lock (warm, with lockfile)'},
             ];
 

--- a/packages/zpm/src/commands/debug/mock_proxy.rs
+++ b/packages/zpm/src/commands/debug/mock_proxy.rs
@@ -127,7 +127,20 @@ async fn handle_request(state: Arc<ProxyState>, req: Request<hyper::body::Incomi
             = state.cache.read().await;
 
         if let Some(cached) = cache.get(&path) {
+            let if_none_match = req.headers().get("if-none-match")
+                .and_then(|v| v.to_str().ok())
+                .map(|s| s.to_string());
+
+            if let Some(client_etag) = if_none_match {
+                if cached.headers.get("etag").is_some_and(|etag| etag == &client_etag) {
+                    println!("[304]   {path}");
+                    tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+                    return Ok(build_304(cached));
+                }
+            }
+
             println!("[CACHE] {path}");
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
             return Ok(build_response(cached, &state));
         }
     }
@@ -139,6 +152,7 @@ async fn handle_request(state: Arc<ProxyState>, req: Request<hyper::body::Incomi
 
     match fetch_and_cache(&state, &path, &remote_url).await {
         Ok(cached) => {
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
             Ok(build_response(&cached, &state))
         },
 
@@ -217,6 +231,18 @@ async fn fetch_and_cache(state: &ProxyState, path: &str, remote_url: &str) -> Re
     }
 
     Ok(cached)
+}
+
+fn build_304(cached: &CachedResponse) -> Response<Full<Bytes>> {
+    let mut builder
+        = Response::builder()
+            .status(StatusCode::NOT_MODIFIED);
+
+    if let Some(etag) = cached.headers.get("etag") {
+        builder = builder.header("etag", etag);
+    }
+
+    builder.body(Full::new(Bytes::new())).unwrap()
 }
 
 fn build_response(cached: &CachedResponse, state: &ProxyState) -> Response<Full<Bytes>> {

--- a/packages/zpm/src/http_npm.rs
+++ b/packages/zpm/src/http_npm.rs
@@ -556,8 +556,11 @@ async fn fetch_metadata_with_disk_cache(params: &GetPackageMetadataParams<'_>) -
     let body
         = response.error_for_status()?.bytes().await?;
 
-    let body_for_disk = body.clone();
-    let cache_file_for_disk = cache_file.clone();
+    let body_for_disk
+        = body.clone();
+    let cache_file_for_disk
+        = cache_file.clone();
+
     tokio::task::spawn_blocking(move || {
         write_cache_to_disk(&cache_file_for_disk, &body_for_disk, etag, last_modified);
     });

--- a/packages/zpm/src/http_npm.rs
+++ b/packages/zpm/src/http_npm.rs
@@ -371,10 +371,9 @@ static METADATA_CACHE_KEY: LazyLock<String> = LazyLock::new(|| {
 
 static METADATA_CACHE: LazyLock<DashMap<String, Arc<OnceCell<Result<Bytes, Error>>>>> = LazyLock::new(DashMap::new);
 
-#[derive(serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct CachedMetadataRead {
-    metadata: Box<serde_json::value::RawValue>,
+#[derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
+struct CachedMetadataDisk {
+    metadata: Vec<u8>,
     etag: Option<String>,
     last_modified: Option<String>,
 }
@@ -415,7 +414,7 @@ fn get_cache_file_path(global_folder: &Path, registry: &str, ident: &Ident) -> P
         .with_join_str("metadata/npm")
         .with_join_str(&*METADATA_CACHE_KEY)
         .with_join_str(&registry_hostname)
-        .with_join_str(&format!("{}.json", ident.slug()))
+        .with_join_str(&format!("{}.bin", ident.slug()))
 }
 
 fn trim_metadata(raw: &[u8]) -> Vec<u8> {
@@ -449,25 +448,18 @@ fn write_cache_to_disk(cache_file: &Path, metadata: &[u8], etag: Option<String>,
 
     let _ = cache_dir.fs_create_dir_all();
 
-    let trimmed
-        = trim_metadata(metadata);
+    let entry = CachedMetadataDisk {
+        metadata: trim_metadata(metadata),
+        etag,
+        last_modified,
+    };
 
-    let mut out = Vec::with_capacity(trimmed.len() + 128);
-    out.extend_from_slice(b"{\"metadata\":");
-    out.extend_from_slice(&trimmed);
-
-    if let Some(ref etag) = etag {
-        out.extend_from_slice(b",\"etag\":");
-        let _ = serde_json::to_writer(&mut out, etag);
-    }
-    if let Some(ref last_modified) = last_modified {
-        out.extend_from_slice(b",\"lastModified\":");
-        let _ = serde_json::to_writer(&mut out, last_modified);
-    }
-    out.push(b'}');
+    let Ok(encoded) = rkyv::to_bytes::<rkyv::rancor::BoxedError>(&entry) else {
+        return;
+    };
 
     let _ = cache_file.fs_write_atomic(|tmp| {
-        tmp.fs_write(&out)?;
+        tmp.fs_write(&encoded)?;
         Ok::<_, zpm_utils::PathError>(())
     });
 }
@@ -483,7 +475,7 @@ async fn fetch_metadata_with_disk_cache(params: &GetPackageMetadataParams<'_>) -
 
     let cached = if !params.refresh_lockfile {
         cache_file.fs_read_prealloc().ok()
-            .and_then(|data| serde_json::from_slice::<CachedMetadataRead>(&data).ok())
+            .and_then(|data| rkyv::from_bytes::<CachedMetadataDisk, rkyv::rancor::BoxedError>(&data).ok())
     } else {
         None
     };
@@ -521,7 +513,7 @@ async fn fetch_metadata_with_disk_cache(params: &GetPackageMetadataParams<'_>) -
 
     if response.status().as_u16() == 304 {
         if let Some(cached) = cached {
-            return Ok(Bytes::from(cached.metadata.get().as_bytes().to_vec()));
+            return Ok(Bytes::from(cached.metadata));
         }
     }
 

--- a/packages/zpm/src/http_npm.rs
+++ b/packages/zpm/src/http_npm.rs
@@ -371,13 +371,11 @@ static METADATA_CACHE_KEY: LazyLock<String> = LazyLock::new(|| {
 
 static METADATA_CACHE: LazyLock<DashMap<String, Arc<OnceCell<Result<Bytes, Error>>>>> = LazyLock::new(DashMap::new);
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-struct CachedMetadata {
-    metadata: serde_json::Value,
-    #[serde(skip_serializing_if = "Option::is_none")]
+struct CachedMetadataRead {
+    metadata: Box<serde_json::value::RawValue>,
     etag: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     last_modified: Option<String>,
 }
 
@@ -420,10 +418,10 @@ fn get_cache_file_path(global_folder: &Path, registry: &str, ident: &Ident) -> P
         .with_join_str(&format!("{}.json", ident.slug()))
 }
 
-fn trim_metadata(raw: &[u8]) -> Result<serde_json::Value, Error> {
-    let mut metadata: serde_json::Value
-        = serde_json::from_slice(raw)
-            .map_err(|e| Error::SerializationError(e.to_string()))?;
+fn trim_metadata(raw: &[u8]) -> Vec<u8> {
+    let Ok(mut metadata) = serde_json::from_slice::<serde_json::Value>(raw) else {
+        return raw.to_vec();
+    };
 
     let top_level_fields: HashSet<&str>
         = CACHED_TOP_LEVEL_FIELDS.iter().copied().collect();
@@ -442,7 +440,36 @@ fn trim_metadata(raw: &[u8]) -> Result<serde_json::Value, Error> {
         }
     }
 
-    Ok(metadata)
+    serde_json::to_vec(&metadata).unwrap_or_else(|_| raw.to_vec())
+}
+
+fn write_cache_to_disk(cache_file: &Path, metadata: &[u8], etag: Option<String>, last_modified: Option<String>) {
+    let cache_dir
+        = cache_file.dirname().unwrap();
+
+    let _ = cache_dir.fs_create_dir_all();
+
+    let trimmed
+        = trim_metadata(metadata);
+
+    let mut out = Vec::with_capacity(trimmed.len() + 128);
+    out.extend_from_slice(b"{\"metadata\":");
+    out.extend_from_slice(&trimmed);
+
+    if let Some(ref etag) = etag {
+        out.extend_from_slice(b",\"etag\":");
+        let _ = serde_json::to_writer(&mut out, etag);
+    }
+    if let Some(ref last_modified) = last_modified {
+        out.extend_from_slice(b",\"lastModified\":");
+        let _ = serde_json::to_writer(&mut out, last_modified);
+    }
+    out.push(b'}');
+
+    let _ = cache_file.fs_write_atomic(|tmp| {
+        tmp.fs_write(&out)?;
+        Ok::<_, zpm_utils::PathError>(())
+    });
 }
 
 async fn fetch_metadata_with_disk_cache(params: &GetPackageMetadataParams<'_>) -> Result<Bytes, Error> {
@@ -456,7 +483,7 @@ async fn fetch_metadata_with_disk_cache(params: &GetPackageMetadataParams<'_>) -
 
     let cached = if !params.refresh_lockfile {
         cache_file.fs_read_prealloc().ok()
-            .and_then(|data| serde_json::from_slice::<CachedMetadata>(&data).ok())
+            .and_then(|data| serde_json::from_slice::<CachedMetadataRead>(&data).ok())
     } else {
         None
     };
@@ -494,9 +521,7 @@ async fn fetch_metadata_with_disk_cache(params: &GetPackageMetadataParams<'_>) -
 
     if response.status().as_u16() == 304 {
         if let Some(cached) = cached {
-            let bytes = serde_json::to_vec(&cached.metadata)
-                .map_err(|e| Error::SerializationError(e.to_string()))?;
-            return Ok(Bytes::from(bytes));
+            return Ok(Bytes::from(cached.metadata.get().as_bytes().to_vec()));
         }
     }
 
@@ -512,31 +537,13 @@ async fn fetch_metadata_with_disk_cache(params: &GetPackageMetadataParams<'_>) -
     let body
         = response.error_for_status()?.bytes().await?;
 
-    let trimmed
-        = trim_metadata(&body)?;
-
-    let serialized
-        = serde_json::to_vec(&trimmed)
-            .map_err(|e| Error::SerializationError(e.to_string()))?;
-
-    let disk_entry = CachedMetadata {
-        metadata: trimmed,
-        etag,
-        last_modified,
-    };
-
-    let cache_dir
-        = cache_file.dirname().unwrap();
-
-    let _ = cache_dir.fs_create_dir_all();
-    let _ = cache_file.fs_write_atomic(|tmp| {
-        let data = serde_json::to_vec(&disk_entry)
-            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
-        tmp.fs_write(&data)?;
-        Ok::<_, zpm_utils::PathError>(())
+    let body_for_disk = body.clone();
+    let cache_file_for_disk = cache_file.clone();
+    tokio::task::spawn_blocking(move || {
+        write_cache_to_disk(&cache_file_for_disk, &body_for_disk, etag, last_modified);
     });
 
-    Ok(Bytes::from(serialized))
+    Ok(body)
 }
 
 pub async fn post(params: &NpmHttpParams<'_>, body: String) -> Result<Response, Error> {

--- a/packages/zpm/src/http_npm.rs
+++ b/packages/zpm/src/http_npm.rs
@@ -1,17 +1,22 @@
+use std::collections::HashSet;
 use std::sync::{Arc, LazyLock};
 
 use bytes::Bytes;
+use dashmap::DashMap;
 use regex::{Captures, Regex};
 use reqwest::Response;
 use serde::Deserialize;
+use sha2::{Sha256, Digest};
+use tokio::sync::OnceCell;
 use zpm_config::Configuration;
 use zpm_parsers::JsonDocument;
 use zpm_primitives::Ident;
-use zpm_utils::DataType;
+use zpm_utils::{DataType, Path};
 
 use crate::{
     error::Error,
     http::{HttpClient, HttpRequest},
+    npm,
     report::{current_report, PromptType},
 };
 
@@ -345,6 +350,193 @@ pub async fn get(params: &NpmHttpParams<'_>) -> Result<Bytes, Error> {
     };
 
     Ok(bytes)
+}
+
+const CACHED_VERSION_FIELDS: &[&str] = &[
+    "name", "version", "dist", "bin", "scripts",
+    "os", "cpu", "libc",
+    "dependencies", "dependenciesMeta", "optionalDependencies",
+    "peerDependencies", "peerDependenciesMeta",
+];
+
+const CACHED_TOP_LEVEL_FIELDS: &[&str] = &["dist-tags", "time", "versions"];
+
+static METADATA_CACHE_KEY: LazyLock<String> = LazyLock::new(|| {
+    let mut hasher = Sha256::new();
+    for field in CACHED_VERSION_FIELDS {
+        hasher.update(field.as_bytes());
+    }
+    hex::encode(&hasher.finalize()[..3])
+});
+
+static METADATA_CACHE: LazyLock<DashMap<String, Arc<OnceCell<Result<Bytes, Error>>>>> = LazyLock::new(DashMap::new);
+
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CachedMetadata {
+    metadata: serde_json::Value,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    etag: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    last_modified: Option<String>,
+}
+
+pub struct GetPackageMetadataParams<'a> {
+    pub http_client: &'a HttpClient,
+    pub registry: &'a str,
+    pub ident: &'a Ident,
+    pub authorization: Option<&'a str>,
+    pub global_folder: &'a Path,
+    pub refresh_lockfile: bool,
+}
+
+pub async fn get_package_metadata(params: &GetPackageMetadataParams<'_>) -> Result<Bytes, Error> {
+    let cache_key
+        = params.ident.to_string();
+
+    let cell = METADATA_CACHE
+        .entry(cache_key)
+        .or_insert_with(|| Arc::new(OnceCell::new()))
+        .clone();
+
+    let result = cell.get_or_init(|| async {
+        fetch_metadata_with_disk_cache(params).await
+    }).await;
+
+    result.clone()
+}
+
+fn get_cache_file_path(global_folder: &Path, registry: &str, ident: &Ident) -> Path {
+    let registry_hostname
+        = url::Url::parse(registry)
+            .ok()
+            .and_then(|u| u.host_str().map(|s| s.to_string()))
+            .unwrap_or_else(|| "unknown".to_string());
+
+    global_folder
+        .with_join_str("metadata/npm")
+        .with_join_str(&*METADATA_CACHE_KEY)
+        .with_join_str(&registry_hostname)
+        .with_join_str(&format!("{}.json", ident.slug()))
+}
+
+fn trim_metadata(raw: &[u8]) -> Result<serde_json::Value, Error> {
+    let mut metadata: serde_json::Value
+        = serde_json::from_slice(raw)
+            .map_err(|e| Error::SerializationError(e.to_string()))?;
+
+    let top_level_fields: HashSet<&str>
+        = CACHED_TOP_LEVEL_FIELDS.iter().copied().collect();
+    let version_fields: HashSet<&str>
+        = CACHED_VERSION_FIELDS.iter().copied().collect();
+
+    if let Some(obj) = metadata.as_object_mut() {
+        obj.retain(|k, _| top_level_fields.contains(k.as_str()));
+    }
+
+    if let Some(versions) = metadata.get_mut("versions").and_then(|v| v.as_object_mut()) {
+        for version_data in versions.values_mut() {
+            if let Some(obj) = version_data.as_object_mut() {
+                obj.retain(|k, _| version_fields.contains(k.as_str()));
+            }
+        }
+    }
+
+    Ok(metadata)
+}
+
+async fn fetch_metadata_with_disk_cache(params: &GetPackageMetadataParams<'_>) -> Result<Bytes, Error> {
+    let registry_path
+        = npm::registry_url_for_all_versions(params.ident);
+    let url
+        = format!("{}{}", params.registry, registry_path);
+
+    let cache_file
+        = get_cache_file_path(params.global_folder, params.registry, params.ident);
+
+    let cached = if !params.refresh_lockfile {
+        cache_file.fs_read_prealloc().ok()
+            .and_then(|data| serde_json::from_slice::<CachedMetadata>(&data).ok())
+    } else {
+        None
+    };
+
+    let mut request
+        = params.http_client.get(&url)?
+            .enable_status_check(false);
+
+    if let Some(auth) = params.authorization {
+        request = request.header("authorization", Some(auth));
+    }
+
+    if let Some(ref cached) = cached {
+        if let Some(ref etag) = cached.etag {
+            request = request.header("if-none-match", Some(etag.as_str()));
+        }
+        if let Some(ref last_modified) = cached.last_modified {
+            request = request.header("if-modified-since", Some(last_modified.as_str()));
+        }
+    }
+
+    let response
+        = request.send().await?;
+
+    if params.authorization.is_some() {
+        let npm_params = NpmHttpParams {
+            http_client: params.http_client,
+            registry: params.registry,
+            path: &registry_path,
+            authorization: params.authorization,
+            otp: None,
+        };
+        handle_invalid_authentication_error(&npm_params, &response).await?;
+    }
+
+    if response.status().as_u16() == 304 {
+        if let Some(cached) = cached {
+            let bytes = serde_json::to_vec(&cached.metadata)
+                .map_err(|e| Error::SerializationError(e.to_string()))?;
+            return Ok(Bytes::from(bytes));
+        }
+    }
+
+    let etag
+        = response.headers().get("etag")
+            .and_then(|v| v.to_str().ok())
+            .map(|s| s.to_string());
+    let last_modified
+        = response.headers().get("last-modified")
+            .and_then(|v| v.to_str().ok())
+            .map(|s| s.to_string());
+
+    let body
+        = response.error_for_status()?.bytes().await?;
+
+    let trimmed
+        = trim_metadata(&body)?;
+
+    let serialized
+        = serde_json::to_vec(&trimmed)
+            .map_err(|e| Error::SerializationError(e.to_string()))?;
+
+    let disk_entry = CachedMetadata {
+        metadata: trimmed,
+        etag,
+        last_modified,
+    };
+
+    let cache_dir
+        = cache_file.dirname().unwrap();
+
+    let _ = cache_dir.fs_create_dir_all();
+    let _ = cache_file.fs_write_atomic(|tmp| {
+        let data = serde_json::to_vec(&disk_entry)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+        tmp.fs_write(&data)?;
+        Ok::<_, zpm_utils::PathError>(())
+    });
+
+    Ok(Bytes::from(serialized))
 }
 
 pub async fn post(params: &NpmHttpParams<'_>, body: String) -> Result<Response, Error> {

--- a/packages/zpm/src/http_npm.rs
+++ b/packages/zpm/src/http_npm.rs
@@ -353,23 +353,44 @@ pub async fn get(params: &NpmHttpParams<'_>) -> Result<Bytes, Error> {
 }
 
 const CACHED_VERSION_FIELDS: &[&str] = &[
-    "name", "version", "dist", "bin", "scripts",
-    "os", "cpu", "libc",
-    "dependencies", "dependenciesMeta", "optionalDependencies",
-    "peerDependencies", "peerDependenciesMeta",
+    "bin",
+    "cpu",
+    "dependenciesMeta",
+    "dependencies",
+    "dist",
+    "libc",
+    "name",
+    "optionalDependencies",
+    "os",
+    "peerDependenciesMeta",
+    "peerDependencies",
+    "scripts",
+    "version",
 ];
 
-const CACHED_TOP_LEVEL_FIELDS: &[&str] = &["dist-tags", "time", "versions"];
+const CACHED_TOP_LEVEL_FIELDS: &[&str] = &[
+    "dist-tags",
+    "time",
+    "versions",
+];
 
 static METADATA_CACHE_KEY: LazyLock<String> = LazyLock::new(|| {
-    let mut hasher = Sha256::new();
+    let mut hasher
+        = Sha256::new();
+
+    for field in CACHED_TOP_LEVEL_FIELDS {
+        hasher.update(field.as_bytes());
+    }
+
     for field in CACHED_VERSION_FIELDS {
         hasher.update(field.as_bytes());
     }
+
     hex::encode(&hasher.finalize()[..3])
 });
 
-static METADATA_CACHE: LazyLock<DashMap<String, Arc<OnceCell<Result<Bytes, Error>>>>> = LazyLock::new(DashMap::new);
+static METADATA_CACHE: LazyLock<DashMap<String, Arc<OnceCell<Bytes>>>>
+    = LazyLock::new(DashMap::new);
 
 #[derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
 struct CachedMetadataDisk {
@@ -391,30 +412,36 @@ pub async fn get_package_metadata(params: &GetPackageMetadataParams<'_>) -> Resu
     let cache_key
         = params.ident.to_string();
 
-    let cell = METADATA_CACHE
-        .entry(cache_key)
-        .or_insert_with(|| Arc::new(OnceCell::new()))
-        .clone();
+    let cell
+        = METADATA_CACHE
+            .entry(cache_key)
+            .or_default()
+            .clone();
 
-    let result = cell.get_or_init(|| async {
+    let result = cell.get_or_try_init(|| async {
         fetch_metadata_with_disk_cache(params).await
-    }).await;
+    }).await?;
 
-    result.clone()
+    Ok(result.clone())
 }
 
-fn get_cache_file_path(global_folder: &Path, registry: &str, ident: &Ident) -> Path {
-    let registry_hostname
-        = url::Url::parse(registry)
-            .ok()
-            .and_then(|u| u.host_str().map(|s| s.to_string()))
-            .unwrap_or_else(|| "unknown".to_string());
+pub fn ensure_metadata_cache_dir(global_folder: &Path) {
+    let cache_dir = global_folder
+        .with_join_str("metadata/npm")
+        .with_join_str(&*METADATA_CACHE_KEY);
+
+    let _ = cache_dir.fs_create_dir_all();
+}
+
+fn get_cache_file_path(global_folder: &Path, url: &str) -> Path {
+    let mut hasher = Sha256::new();
+    hasher.update(url.as_bytes());
+    let url_hash = hex::encode(hasher.finalize());
 
     global_folder
         .with_join_str("metadata/npm")
         .with_join_str(&*METADATA_CACHE_KEY)
-        .with_join_str(&registry_hostname)
-        .with_join_str(&format!("{}.bin", ident.slug()))
+        .with_join_str(&format!("{}.bin", url_hash))
 }
 
 fn trim_metadata(raw: &[u8]) -> Vec<u8> {
@@ -422,10 +449,15 @@ fn trim_metadata(raw: &[u8]) -> Vec<u8> {
         return raw.to_vec();
     };
 
-    let top_level_fields: HashSet<&str>
-        = CACHED_TOP_LEVEL_FIELDS.iter().copied().collect();
-    let version_fields: HashSet<&str>
-        = CACHED_VERSION_FIELDS.iter().copied().collect();
+    let top_level_fields: HashSet<_>
+        = CACHED_TOP_LEVEL_FIELDS.iter()
+            .copied()
+            .collect();
+
+    let version_fields: HashSet<_>
+        = CACHED_VERSION_FIELDS.iter()
+            .copied()
+            .collect();
 
     if let Some(obj) = metadata.as_object_mut() {
         obj.retain(|k, _| top_level_fields.contains(k.as_str()));
@@ -443,11 +475,6 @@ fn trim_metadata(raw: &[u8]) -> Vec<u8> {
 }
 
 fn write_cache_to_disk(cache_file: &Path, metadata: &[u8], etag: Option<String>, last_modified: Option<String>) {
-    let cache_dir
-        = cache_file.dirname().unwrap();
-
-    let _ = cache_dir.fs_create_dir_all();
-
     let entry = CachedMetadataDisk {
         metadata: trim_metadata(metadata),
         etag,
@@ -471,7 +498,7 @@ async fn fetch_metadata_with_disk_cache(params: &GetPackageMetadataParams<'_>) -
         = format!("{}{}", params.registry, registry_path);
 
     let cache_file
-        = get_cache_file_path(params.global_folder, params.registry, params.ident);
+        = get_cache_file_path(params.global_folder, &url);
 
     let cached = if !params.refresh_lockfile {
         cache_file.fs_read_prealloc().ok()

--- a/packages/zpm/src/install.rs
+++ b/packages/zpm/src/install.rs
@@ -19,6 +19,7 @@ use crate::{
     content_flags::ContentFlags,
     error::Error,
     fetchers::{PackageData, SyncFetchAttempt, fetch_locator, patch::has_builtin_patch, try_fetch_locator_sync},
+    http_npm,
     graph::WaitMap,
     linker,
     lockfile::{Lockfile, LockfileEntry, LockfileMetadata},
@@ -765,6 +766,10 @@ impl<'a> InstallManager<'a> {
 
         let lockfile
             = self.initial_lockfile.clone();
+
+        if let Some(project) = self.context.project {
+            http_npm::ensure_metadata_cache_dir(&project.config.settings.global_folder.value);
+        }
 
         // --- Island resolution ---
         // Resolve islands from project config and partition roots between

--- a/packages/zpm/src/resolvers/mod.rs
+++ b/packages/zpm/src/resolvers/mod.rs
@@ -329,8 +329,6 @@ pub async fn resolve_versions(context: &InstallContext<'_>, registry: &Registry)
 
             let registry_base
                 = http_npm::get_registry(&project.config, ident.scope(), false)?;
-            let registry_path
-                = crate::npm::registry_url_for_all_versions(ident);
 
             let authorization
                 = http_npm::get_authorization(&http_npm::GetAuthorizationOptions {
@@ -343,12 +341,13 @@ pub async fn resolve_versions(context: &InstallContext<'_>, registry: &Registry)
                 }).await?;
 
             let bytes
-                = http_npm::get(&http_npm::NpmHttpParams {
+                = http_npm::get_package_metadata(&http_npm::GetPackageMetadataParams {
                     http_client: &project.http_client,
                     registry: &registry_base,
-                    path: &registry_path,
+                    ident,
                     authorization: authorization.as_deref(),
-                    otp: None,
+                    global_folder: &project.config.settings.global_folder.value,
+                    refresh_lockfile: context.refresh_lockfile,
                 }).await?;
 
             #[derive(Deserialize)]

--- a/packages/zpm/src/resolvers/npm.rs
+++ b/packages/zpm/src/resolvers/npm.rs
@@ -162,8 +162,6 @@ pub async fn resolve_semver_descriptor(context: &InstallContext<'_>, descriptor:
 
     let registry_base
         = http_npm::get_registry(&project.config, package_ident.scope(), false)?;
-    let registry_path
-        = npm::registry_url_for_all_versions(&package_ident);
 
     let authorization
         = http_npm::get_authorization(&http_npm::GetAuthorizationOptions {
@@ -176,12 +174,13 @@ pub async fn resolve_semver_descriptor(context: &InstallContext<'_>, descriptor:
         }).await?;
 
     let bytes
-        = http_npm::get(&http_npm::NpmHttpParams {
+        = http_npm::get_package_metadata(&http_npm::GetPackageMetadataParams {
             http_client: &project.http_client,
             registry: &registry_base,
-            path: &registry_path,
+            ident: package_ident,
             authorization: authorization.as_deref(),
-            otp: None,
+            global_folder: &project.config.settings.global_folder.value,
+            refresh_lockfile: context.refresh_lockfile,
         }).await?;
 
     #[serde_as]
@@ -231,8 +230,6 @@ pub async fn resolve_tag_descriptor(context: &InstallContext<'_>, descriptor: &D
 
     let registry_base
         = http_npm::get_registry(&project.config, package_ident.scope(), false)?;
-    let registry_path
-        = npm::registry_url_for_all_versions(&package_ident);
 
     let authorization
         = http_npm::get_authorization(&http_npm::GetAuthorizationOptions {
@@ -245,12 +242,13 @@ pub async fn resolve_tag_descriptor(context: &InstallContext<'_>, descriptor: &D
         }).await?;
 
     let bytes
-        = http_npm::get(&http_npm::NpmHttpParams {
+        = http_npm::get_package_metadata(&http_npm::GetPackageMetadataParams {
             http_client: &project.http_client,
             registry: &registry_base,
-            path: &registry_path,
+            ident: package_ident,
             authorization: authorization.as_deref(),
-            otp: None,
+            global_folder: &project.config.settings.global_folder.value,
+            refresh_lockfile: context.refresh_lockfile,
         }).await?;
 
     #[serde_as]


### PR DESCRIPTION
Checking the benchmarks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds persistent caching and conditional HTTP behavior to npm metadata fetches, which can subtly affect version resolution and cache invalidation if ETag/Last-Modified handling or refresh logic is wrong.
> 
> **Overview**
> Adds an on-disk + in-memory cache for npm package metadata (`get_package_metadata`) that stores a trimmed subset of registry JSON, persists it under the global folder, and revalidates via `If-None-Match`/`If-Modified-Since` with `304` handling.
> 
> Switches npm version resolution paths to use this metadata cache (and ensures the cache directory exists during install), and updates the debug mock proxy to return `304 Not Modified` for cached ETag matches. CI perfcheck now also benchmarks an `install-cache-only` mode and includes it in the PR benchmark comment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1082fd337d2504616d0b4da26139483d30dd7ec3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->