### PR TITLE
Implements "yarn config set --json"

### DIFF
--- a/packages/zpm-config/build.rs
+++ b/packages/zpm-config/build.rs
@@ -365,7 +365,10 @@ impl Generator {
             writeln!(writer).unwrap();
             writeln!(writer, "    fn get(&self, path: &[&str]) -> Result<ConfigurationEntry<'_>, GetError> {{").unwrap();
             writeln!(writer, "        let Some(key_str) = path.first() else {{").unwrap();
-            writeln!(writer, "            unimplemented!(\"Configuration records cannot be returned directly just yet\");").unwrap();
+            writeln!(writer, "            return Ok(ConfigurationEntry {{").unwrap();
+            writeln!(writer, "                value: AbstractValue::new_container(Container::new(self)),").unwrap();
+            writeln!(writer, "                source: Source::Mixed,").unwrap();
+            writeln!(writer, "            }});").unwrap();
             writeln!(writer, "        }};").unwrap();
             writeln!(writer, "").unwrap();
             writeln!(writer, "        match *key_str {{").unwrap();

--- a/packages/zpm-config/schema.json
+++ b/packages/zpm-config/schema.json
@@ -46,7 +46,7 @@
     "deferredVersionFolder": {
       "type": "zpm_utils::Path",
       "description": "Folder where the versioning files are stored.",
-      "default": "crate::fns::default_deferred_version_folder(context)"
+      "default": ".yarn/versions"
     },
     "enableAutoTypes": {
       "type": "boolean",

--- a/packages/zpm-config/src/fns.rs
+++ b/packages/zpm-config/src/fns.rs
@@ -1,5 +1,3 @@
-use zpm_utils::Path;
-
 use crate::ConfigurationContext;
 
 pub fn check_tsconfig(context: &ConfigurationContext) -> bool {
@@ -26,11 +24,3 @@ pub fn check_tsconfig(context: &ConfigurationContext) -> bool {
     false
 }
 
-pub fn default_deferred_version_folder(context: &ConfigurationContext) -> Path {
-    context
-        .project_cwd
-        .as_ref()
-        .or(context.package_cwd.as_ref())
-        .expect("A project or package directory should be set when resolving the default deferred version folder")
-        .with_join_str(".yarn/versions")
-}

--- a/packages/zpm-config/src/lib.rs
+++ b/packages/zpm-config/src/lib.rs
@@ -201,7 +201,7 @@ impl<K: Ord + ToFileString + ToHumanString + FromFileString + Serialize + std::f
     fn get(&self, path: &[&str]) -> Result<ConfigurationEntry<'_>, GetError> {
         let Some(key_str) = path.first() else {
             return Ok(ConfigurationEntry {
-                value: AbstractValue::new(Container::new(self)),
+                value: AbstractValue::new_container(Container::new(self)),
                 source: Source::Mixed,
             });
         };
@@ -341,7 +341,7 @@ impl<T: std::fmt::Debug + Serialize + MergeSettings> MergeSettings for Vec<T> {
     fn get(&self, path: &[&str]) -> Result<ConfigurationEntry<'_>, GetError> {
         let Some(key_str) = path.first() else {
             return Ok(ConfigurationEntry {
-                value: AbstractValue::new(Container::new(self)),
+                value: AbstractValue::new_container(Container::new(self)),
                 source: Source::Mixed,
             });
         };
@@ -988,9 +988,7 @@ impl Configuration {
 
     pub fn load(context: &ConfigurationContext, last_modified_at: &mut LastModifiedAt) -> Result<Configuration, ConfigurationError> {
         let project_cwd
-            = context.project_cwd
-                .as_ref()
-                .expect("A project directory should be set");
+            = context.project_cwd.as_ref();
 
         let rc_filename
             = std::env::var("YARN_RC_FILENAME")
@@ -1000,7 +998,7 @@ impl Configuration {
         let user_rc
             = RcFile::try_read(context.user_cwd.as_ref(), &rc_filename, last_modified_at)?;
         let project_rc
-            = RcFile::try_read(Some(project_cwd), &rc_filename, last_modified_at)?;
+            = RcFile::try_read(project_cwd, &rc_filename, last_modified_at)?;
 
         // Phase 1: Extract injectEnvironmentFiles from the raw YAML text.
         // We check the project rc first, falling back to the user rc, then
@@ -1013,10 +1011,13 @@ impl Configuration {
             .unwrap_or_else(|| vec![".env.yarn?".to_string()]);
 
         // Phase 2: Load .env files and collect variables
-        let env_files = Self::load_env_files(
-            project_cwd,
-            &inject_environment_files,
-        )?;
+        let env_files = match project_cwd {
+            Some(project_cwd) => Self::load_env_files(
+                project_cwd,
+                &inject_environment_files,
+            )?,
+            None => BTreeMap::new(),
+        };
 
         // Phase 3: Set env file variables in the process environment so that
         // shellexpand::env() (used by the Interpolated deserializer) can

--- a/packages/zpm-config/src/lib.rs
+++ b/packages/zpm-config/src/lib.rs
@@ -931,6 +931,11 @@ impl Configuration {
         self.settings.tree_node(None, None)
     }
 
+    pub fn validate(text: &str) -> Result<(), ConfigurationError> {
+        serde_yaml::from_str::<intermediate::Settings>(text)?;
+        Ok(())
+    }
+
     pub fn hydrate(&self, path: &[&str], value_str: &str) -> Result<AbstractValue<'_>, HydrateError> {
         self.settings.hydrate(path, value_str)
     }

--- a/packages/zpm-utils/src/serialization.rs
+++ b/packages/zpm-utils/src/serialization.rs
@@ -40,11 +40,20 @@ serialize_trait_object!(Extracted);
 
 pub struct AbstractValue<'a> {
     value: Box<dyn Extracted + 'a>,
+    is_container: bool,
 }
 
 impl<'a> AbstractValue<'a> {
     pub fn new<T: Extracted + 'a>(value: T) -> Self {
-        Self {value: Box::new(value)}
+        Self {value: Box::new(value), is_container: false}
+    }
+
+    pub fn new_container<T: Extracted + 'a>(value: T) -> Self {
+        Self {value: Box::new(value), is_container: true}
+    }
+
+    pub fn is_container(&self) -> bool {
+        self.is_container
     }
 
     pub fn export(self, json: bool) -> String {

--- a/packages/zpm/src/commands/config_set.rs
+++ b/packages/zpm/src/commands/config_set.rs
@@ -90,6 +90,9 @@ impl ConfigSet {
             value,
         )?;
 
+        Configuration::validate(&updated_document)
+            .map_err(|e| Error::ConfigurationParseError(Arc::new(e)))?;
+
         document_path
             .fs_change(&updated_document, false)?;
 

--- a/packages/zpm/src/commands/config_set.rs
+++ b/packages/zpm/src/commands/config_set.rs
@@ -1,6 +1,9 @@
+use std::sync::Arc;
+
 use clipanion::cli;
-use zpm_parsers::DataDocument;
-use zpm_utils::IoResultExt;
+use zpm_config::{Configuration, ConfigurationContext};
+use zpm_parsers::{DataDocument, JsonDocument, RawJsonOwnedValue};
+use zpm_utils::{IoResultExt, LastModifiedAt, Path, ToFileString, ToHumanString, set_redacted};
 
 use crate::{
     error::Error,
@@ -9,18 +12,25 @@ use crate::{
 
 /// Set a configuration value
 ///
-/// This command will set a configuration setting, by default in the project configuration file unless the `-U,--user` flag is set.
+/// This command will set a configuration setting, by default in the project configuration file unless the `-H,--home` flag is set, in which case it
+/// will be set in the home configuration file.
 ///
-/// The new value will be hydrated depending on the type of the field being set: primitives such as string will be hydrated directly, while complex
-/// types such as arrays and objects will be hydrated through JSON.
+/// When used without the `--json` flag, the new value will be hydrated depending on the type of the field being set: primitives such as strings will
+/// be hydrated directly, while complex types such as arrays and objects will be hydrated through JSON.
+///
+/// When used with the `--json` flag, the new value will always be parsed as JSON before being written to the configuration file.
 ///
 #[cli::command]
 #[cli::path("config", "set")]
 #[cli::category("Configuration commands")]
 pub struct ConfigSet {
-    // If set, the configuration will be set in the user configuration file
-    #[cli::option("-U,--user", default = false)]
-    user: bool,
+    /// If set, the configuration will be set in the home configuration file
+    #[cli::option("-H,--home", default = false)]
+    home: bool,
+
+    /// Set complex configuration settings to JSON values
+    #[cli::option("--json", default = false)]
+    json: bool,
 
     /// The name of the configuration value to set
     name: zpm_parsers::Path,
@@ -31,37 +41,107 @@ pub struct ConfigSet {
 
 impl ConfigSet {
     pub async fn execute(&self) -> Result<(), Error> {
-        let project
-            = Project::new(None).await?;
-
         let segments
             = self.name.segments()
                 .iter()
                 .map(|v| v.as_str())
                 .collect::<Vec<_>>();
 
-        let value
-            = project.config.hydrate(&segments, &self.value)?;
+        let (config, document_path) = if self.home {
+            let config
+                = Self::load_home_config()?;
 
-        let document_path = match self.user {
-            true => project.config.user_config_path.as_ref().unwrap(),
-            false => project.config.project_config_path.as_ref().unwrap(),
+            let user_cwd = Path::home_dir()?
+                .ok_or(Error::HomeDirectoryNotFound)?;
+
+            let rc_filename = std::env::var("YARN_RC_FILENAME")
+                .unwrap_or_else(|_| ".yarnrc.yml".to_string());
+
+            (config, user_cwd.with_join_str(&rc_filename))
+        } else {
+            let project
+                = Project::new(None).await?;
+
+            let path
+                = project.config.project_config_path.clone().unwrap();
+
+            (project.config, path)
         };
 
-        let document = document_path
-            .fs_read_text()
-            .ok_missing()?
-            .unwrap_or_default();
+        let value = if self.json {
+            let json_value: RawJsonOwnedValue
+                = JsonDocument::hydrate_from_str(&self.value)?;
+
+            zpm_parsers::Value::from(&json_value)
+        } else {
+            config.hydrate(&segments, &self.value)?;
+            zpm_parsers::Value::String(self.value.clone())
+        };
+
+        let document
+            = document_path
+                .fs_read_text()
+                .ok_missing()?
+                .unwrap_or_default();
 
         let updated_document = DataDocument::update_document_field(
             &document,
             self.name.clone(),
-            zpm_parsers::Value::Raw(value.export(true)),
+            value,
         )?;
 
         document_path
             .fs_change(&updated_document, false)?;
 
+        set_redacted(true);
+
+        let config = if self.home {
+            Self::load_home_config()?
+        } else {
+            Project::new(None).await?.config
+        };
+
+        let entry
+            = config.get(&segments)?;
+
+        let is_container
+            = entry.value.is_container();
+        let json_str
+            = entry.value.export(true);
+
+        let display_value = if is_container {
+            let yaml_value: serde_yaml::Value
+                = JsonDocument::hydrate_from_str(&json_str)?;
+
+            serde_yaml::to_string(&yaml_value)
+                .map_err(|e| Error::ConfigurationParseError(Arc::new(e)))?
+                .trim_end()
+                .to_string()
+        } else {
+            json_str
+        };
+
+        println!("Successfully set {} to {}", self.name.to_file_string(), display_value);
+
         Ok(())
+    }
+
+    fn load_home_config() -> Result<Configuration, Error> {
+        let user_cwd
+            = Path::home_dir()?
+                .ok_or(Error::HomeDirectoryNotFound)?;
+
+        let context = ConfigurationContext {
+            env: std::env::vars().collect(),
+            user_cwd: Some(user_cwd),
+            project_cwd: None,
+            package_cwd: None,
+        };
+
+        let mut last_modified_at
+            = LastModifiedAt::new();
+
+        Configuration::load(&context, &mut last_modified_at)
+            .map_err(|e| Error::ConfigurationParseError(Arc::new(e)))
     }
 }

--- a/tests/acceptance-tests/pkg-tests-specs/sources/commands/config/get.test.js
+++ b/tests/acceptance-tests/pkg-tests-specs/sources/commands/config/get.test.js
@@ -17,7 +17,7 @@ describe(`Commands`, () => {
         await xfs.writeFilePromise(`${path}/.yarnrc.yml`, `npmAuthToken: foobar\n`);
 
         await expect(run(`config`, `get`, `npmAuthToken`)).resolves.toMatchObject({
-          stdout: `********\n`,
+          stdout: `<redacted>\n`,
         });
       }),
     );
@@ -79,7 +79,7 @@ describe(`Commands`, () => {
       makeTemporaryEnv({}, async ({path, run, source}) => {
         const {stdout} = await run(`config`, `get`, `--json`, `deferredVersionFolder`);
 
-        expect(JSON.parse(stdout)).toEqual(`${path}/.yarn/versions`);
+        expect(JSON.parse(stdout)).toEqual(`.yarn/versions`);
       }),
     );
 
@@ -90,7 +90,7 @@ describe(`Commands`, () => {
 
         const {stdout} = await run(`config`, `get`, `--json`, `deferredVersionFolder`);
 
-        expect(JSON.parse(stdout)).toEqual(`${path}/.custom-versions`);
+        expect(JSON.parse(stdout)).toEqual(`.custom-versions`);
       }),
     );
 

--- a/tests/acceptance-tests/pkg-tests-specs/sources/commands/config/get.test.js
+++ b/tests/acceptance-tests/pkg-tests-specs/sources/commands/config/get.test.js
@@ -75,22 +75,22 @@ describe(`Commands`, () => {
     );
 
     test(
-      `it should print deferredVersionFolder default value`,
+      `it should print localCacheFolderName default value`,
       makeTemporaryEnv({}, async ({path, run, source}) => {
-        const {stdout} = await run(`config`, `get`, `--json`, `deferredVersionFolder`);
+        const {stdout} = await run(`config`, `get`, `--json`, `localCacheFolderName`);
 
-        expect(JSON.parse(stdout)).toEqual(`.yarn/versions`);
+        expect(JSON.parse(stdout)).toEqual(`cache`);
       }),
     );
 
     test(
-      `it should print deferredVersionFolder configured value`,
+      `it should print localCacheFolderName configured value`,
       makeTemporaryEnv({}, async ({path, run, source}) => {
-        await xfs.writeFilePromise(`${path}/.yarnrc.yml`, `deferredVersionFolder: ./.custom-versions\n`);
+        await xfs.writeFilePromise(`${path}/.yarnrc.yml`, `localCacheFolderName: my-cache\n`);
 
-        const {stdout} = await run(`config`, `get`, `--json`, `deferredVersionFolder`);
+        const {stdout} = await run(`config`, `get`, `--json`, `localCacheFolderName`);
 
-        expect(JSON.parse(stdout)).toEqual(`.custom-versions`);
+        expect(JSON.parse(stdout)).toEqual(`my-cache`);
       }),
     );
 

--- a/tests/acceptance-tests/pkg-tests-specs/sources/commands/config/set.test.ts
+++ b/tests/acceptance-tests/pkg-tests-specs/sources/commands/config/set.test.ts
@@ -36,7 +36,7 @@ describe(`Commands`, () => {
         const {stdout} = await run(`config`, `set`, `npmAuthToken`, `foobar`);
 
         expect(stdout).not.toContain(`foobar`);
-        expect(stdout).toContain(`********`);
+        expect(stdout).toContain(`<redacted>`);
 
         await expect(xfs.readFilePromise(ppath.join(path, Filename.rc), `utf8`)).resolves.toContain(`npmAuthToken: foobar`);
       }),

--- a/tests/acceptance-tests/pkg-tests-specs/sources/commands/config/set.test.ts
+++ b/tests/acceptance-tests/pkg-tests-specs/sources/commands/config/set.test.ts
@@ -61,6 +61,21 @@ describe(`Commands`, () => {
     );
 
     test(
+      `it should reject invalid JSON values and not corrupt the config file`,
+      makeTemporaryEnv({}, async ({path, run, source}) => {
+        await run(`config`, `set`, `pnpShebang`, `#!/usr/bin/env iojs\n`);
+
+        await expect(run(`config`, `set`, `enableColors`, `--json`, JSON.stringify(`not-a-bool`))).rejects.toMatchObject({
+          code: 1,
+        });
+
+        expect(parseSyml(await xfs.readFilePromise(ppath.join(path, Filename.rc), `utf8`))).toMatchObject({
+          pnpShebang: `#!/usr/bin/env iojs\n`,
+        });
+      }),
+    );
+
+    test(
       `it should allow running the command from arbitrary folders if the -H,--home option is set`,
       makeTemporaryEnv({}, async ({path, run, source}) => {
         const tmpDir = await xfs.mktempPromise();


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches configuration mutation and validation paths, including new JSON parsing and post-write validation that could affect CLI behavior and error handling. Also changes container value handling and config loading when `project_cwd` is absent, which may impact edge cases.
> 
> **Overview**
> Adds `yarn config set --json` and replaces `-U,--user` with `-H,--home`, allowing config writes from any directory to the home `.yarnrc.yml`.
> 
> `config set` now parses JSON values when `--json` is used, validates the updated YAML via `Configuration::validate` before writing, and prints the resolved value (rendering container values as YAML) while forcing secret output to remain redacted.
> 
> Updates config internals to allow returning container entries from `get` (via `AbstractValue::new_container`/`is_container`) and makes `Configuration::load` tolerate missing `project_cwd` (skipping env file loading). Also changes `deferredVersionFolder`’s schema default to a static `.yarn/versions` and adjusts acceptance tests (including `<redacted>` output expectations and new invalid-JSON regression coverage).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe020cc0eb15dcc33355eafbd431255eca640340. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->