### PR TITLE
Adds missing flags to `yarn up`

### DIFF
--- a/packages/zpm/src/commands/unplug.rs
+++ b/packages/zpm/src/commands/unplug.rs
@@ -1,10 +1,13 @@
+use std::collections::HashSet;
+
 use clipanion::cli;
 use zpm_parsers::{Document, JsonDocument, Value};
-use zpm_primitives::Ident;
+use zpm_primitives::{FilterDescriptor, Locator, Reference};
 use zpm_utils::ToFileString;
 
 use crate::{
     error::Error,
+    install::InstallState,
     project,
 };
 
@@ -34,29 +37,86 @@ pub struct Unplug {
     #[cli::option("--revert", default = false)]
     revert: bool,
 
-    /// The identifiers to unplug
-    identifiers: Vec<Ident>,
+    /// Unplug direct dependencies from the entire project
+    #[cli::option("-A,--all", default = false)]
+    all: bool,
+
+    /// Unplug both direct and transitive dependencies
+    #[cli::option("-R,--recursive", default = false)]
+    recursive: bool,
+
+    /// Format the output as an NDJSON stream
+    #[cli::option("--json", default = false)]
+    json: bool,
+
+    /// The patterns to unplug
+    patterns: Vec<FilterDescriptor>,
+}
+
+fn package_ident(locator: &Locator) -> &zpm_primitives::Ident {
+    match &locator.reference {
+        Reference::Registry(params) => &params.ident,
+        _ => &locator.ident,
+    }
 }
 
 impl Unplug {
     pub async fn execute(&self) -> Result<(), Error> {
-        let project
+        let mut project
             = project::Project::new(None).await?;
 
-        let manifest_path = project.project_cwd
-            .with_join_str(project::MANIFEST_NAME);
+        project.lazy_install().await?;
 
-        let manifest_content = manifest_path
-            .fs_read_prealloc()?;
+        let install_state
+            = project.install_state
+                .as_ref()
+                .ok_or(Error::InstallStateNotFound)?;
+
+        let matches_any = |ident: &zpm_primitives::Ident, version: &zpm_semver::Version| -> bool {
+            self.patterns.iter().any(|p| p.check(ident, version))
+        };
+
+        let selected = if self.all && self.recursive {
+            self.get_all_matching_packages(install_state, &matches_any)
+        } else {
+            let roots: Vec<Locator> = if self.all {
+                project.workspaces.iter().map(|w| w.locator()).collect()
+            } else {
+                vec![project.active_workspace()?.locator()]
+            };
+
+            self.get_selected_packages(&roots, install_state, &matches_any)
+        };
+
+        let manifest_path
+            = project.project_cwd
+                .with_join_str(project::MANIFEST_NAME);
+
+        let manifest_content
+            = manifest_path
+                .fs_read_prealloc()?;
 
         let mut document
             = JsonDocument::new(manifest_content)?;
 
-        for identifier in &self.identifiers {
+        let mut output
+            = Vec::new();
+
+        for (ident, version) in &selected {
+            let key
+                = format!("{}@{}", ident, version);
+
             document.set_path(
-                &zpm_parsers::Path::from_segments(vec!["dependenciesMeta".to_string(), identifier.to_file_string(), "unplugged".to_string()]),
+                &zpm_parsers::Path::from_segments(vec!["dependenciesMeta".to_string(), key, "unplugged".to_string()]),
                 if self.revert {Value::Undefined} else {Value::Bool(true)},
             )?;
+
+            if self.json {
+                output.push(serde_json::json!({
+                    "locator": format!("{}@npm:{}", ident, version),
+                    "version": version,
+                }));
+            }
         }
 
         manifest_path
@@ -66,9 +126,113 @@ impl Unplug {
             = project::Project::new(None).await?;
 
         project.run_install(project::RunInstallOptions {
+            silent_or_error: self.json,
             ..Default::default()
         }).await?;
 
+        for item in output {
+            println!("{}", serde_json::to_string(&item).unwrap());
+        }
+
         Ok(())
+    }
+
+    fn get_all_matching_packages(
+        &self,
+        install_state: &InstallState,
+        matches_any: &dyn Fn(&zpm_primitives::Ident, &zpm_semver::Version) -> bool,
+    ) -> Vec<(String, String)> {
+        let mut selected
+            = Vec::new();
+
+        for (locator, resolution) in &install_state.resolution_tree.locator_resolutions {
+            if locator.reference.is_workspace_reference() {
+                continue;
+            }
+
+            if locator.reference.is_virtual_reference() {
+                continue;
+            }
+
+            let ident
+                = package_ident(locator);
+
+            if matches_any(ident, &resolution.version) {
+                selected.push((ident.to_file_string(), resolution.version.to_file_string()));
+            }
+        }
+
+        selected.sort();
+        selected.dedup();
+        selected
+    }
+
+    fn get_selected_packages(
+        &self,
+        roots: &[Locator],
+        install_state: &InstallState,
+        matches_any: &dyn Fn(&zpm_primitives::Ident, &zpm_semver::Version) -> bool,
+    ) -> Vec<(String, String)> {
+        let mut seen
+            = HashSet::new();
+
+        let mut selected
+            = Vec::new();
+
+        for root in roots {
+            self.traverse(root, 0, &mut seen, install_state, matches_any, &mut selected);
+        }
+
+        selected.sort();
+        selected.dedup();
+        selected
+    }
+
+    fn traverse(
+        &self,
+        locator: &Locator,
+        depth: usize,
+        seen: &mut HashSet<Locator>,
+        install_state: &InstallState,
+        matches_any: &dyn Fn(&zpm_primitives::Ident, &zpm_semver::Version) -> bool,
+        selected: &mut Vec<(String, String)>,
+    ) {
+        if seen.contains(locator) {
+            return;
+        }
+
+        let is_workspace
+            = locator.reference.is_workspace_reference();
+
+        // Don't mark workspace deps as "seen" when not recursive,
+        // so they can still be visited as traversal roots in --all mode.
+        if depth > 0 && !self.recursive && is_workspace {
+            return;
+        }
+
+        seen.insert(locator.clone());
+
+        if !is_workspace {
+            if let Some(resolution) = install_state.resolution_tree.locator_resolutions.get(locator) {
+                let ident
+                    = package_ident(locator);
+
+                if matches_any(ident, &resolution.version) {
+                    selected.push((ident.to_file_string(), resolution.version.to_file_string()));
+                }
+            }
+        }
+
+        if depth > 0 && !self.recursive {
+            return;
+        }
+
+        if let Some(resolution) = install_state.resolution_tree.locator_resolutions.get(locator) {
+            for descriptor in resolution.dependencies.values() {
+                if let Some(dep_locator) = install_state.resolution_tree.descriptor_to_locator.get(descriptor) {
+                    self.traverse(dep_locator, depth + 1, seen, install_state, matches_any, selected);
+                }
+            }
+        }
     }
 }

--- a/packages/zpm/src/commands/unplug.rs
+++ b/packages/zpm/src/commands/unplug.rs
@@ -221,7 +221,7 @@ impl Unplug {
                     = package_ident(locator);
 
                 if matches_any(ident, &resolution.version) {
-                    selected.push((locator.clone(), resolution.version.clone()));
+                    selected.push((locator.physical_locator(), resolution.version.clone()));
                 }
             }
         }

--- a/packages/zpm/src/commands/unplug.rs
+++ b/packages/zpm/src/commands/unplug.rs
@@ -102,9 +102,12 @@ impl Unplug {
         let mut output
             = Vec::new();
 
-        for (ident, version) in &selected {
+        for (locator, version) in &selected {
+            let ident
+                = package_ident(locator);
+
             let key
-                = format!("{}@{}", ident, version);
+                = format!("{}@{}", ident.to_file_string(), version.to_file_string());
 
             document.set_path(
                 &zpm_parsers::Path::from_segments(vec!["dependenciesMeta".to_string(), key, "unplugged".to_string()]),
@@ -113,8 +116,8 @@ impl Unplug {
 
             if self.json {
                 output.push(serde_json::json!({
-                    "locator": format!("{}@npm:{}", ident, version),
-                    "version": version,
+                    "locator": locator.to_file_string(),
+                    "version": version.to_file_string(),
                 }));
             }
         }
@@ -141,7 +144,7 @@ impl Unplug {
         &self,
         install_state: &InstallState,
         matches_any: &dyn Fn(&zpm_primitives::Ident, &zpm_semver::Version) -> bool,
-    ) -> Vec<(String, String)> {
+    ) -> Vec<(Locator, zpm_semver::Version)> {
         let mut selected
             = Vec::new();
 
@@ -158,7 +161,7 @@ impl Unplug {
                 = package_ident(locator);
 
             if matches_any(ident, &resolution.version) {
-                selected.push((ident.to_file_string(), resolution.version.to_file_string()));
+                selected.push((locator.clone(), resolution.version.clone()));
             }
         }
 
@@ -172,7 +175,7 @@ impl Unplug {
         roots: &[Locator],
         install_state: &InstallState,
         matches_any: &dyn Fn(&zpm_primitives::Ident, &zpm_semver::Version) -> bool,
-    ) -> Vec<(String, String)> {
+    ) -> Vec<(Locator, zpm_semver::Version)> {
         let mut seen
             = HashSet::new();
 
@@ -195,7 +198,7 @@ impl Unplug {
         seen: &mut HashSet<Locator>,
         install_state: &InstallState,
         matches_any: &dyn Fn(&zpm_primitives::Ident, &zpm_semver::Version) -> bool,
-        selected: &mut Vec<(String, String)>,
+        selected: &mut Vec<(Locator, zpm_semver::Version)>,
     ) {
         if seen.contains(locator) {
             return;
@@ -218,7 +221,7 @@ impl Unplug {
                     = package_ident(locator);
 
                 if matches_any(ident, &resolution.version) {
-                    selected.push((ident.to_file_string(), resolution.version.to_file_string()));
+                    selected.push((locator.clone(), resolution.version.clone()));
                 }
             }
         }

--- a/packages/zpm/src/linker/helpers.rs
+++ b/packages/zpm/src/linker/helpers.rs
@@ -2,7 +2,7 @@ use std::{collections::{BTreeMap, BTreeSet}, fs::Permissions, os::unix::fs::Perm
 
 use zpm_formats::iter_ext::IterExt;
 use zpm_parsers::JsonDocument;
-use zpm_primitives::{Descriptor, FilterDescriptor, Locator};
+use zpm_primitives::{Descriptor, FilterDescriptor, Locator, Reference};
 use zpm_utils::{Path, PathError, System};
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
@@ -172,9 +172,14 @@ pub fn get_package_internal_info(project: &Project, install: &Install, dependenc
     // The package meta is based on the top-level configuration extracted
     // from the `dependenciesMeta` field.
     //
+    let package_ident = match &locator.reference {
+        Reference::Registry(params) => &params.ident,
+        _ => &locator.ident,
+    };
+
     let package_meta
         = dependencies_meta.iter()
-            .find(|(selector, _)| selector.check(&locator.ident, &resolution.version))
+            .find(|(selector, _)| selector.check(package_ident, &resolution.version))
             .map(|(_, meta)| meta)
             .cloned()
             .unwrap_or_default();

--- a/tests/acceptance-tests/pkg-tests-specs/sources/commands/unplug.test.ts
+++ b/tests/acceptance-tests/pkg-tests-specs/sources/commands/unplug.test.ts
@@ -240,6 +240,28 @@ describe(`Commands`, () => {
     );
 
     test(
+      `it should not produce duplicate entries for packages with peer dependencies`,
+      makeTemporaryEnv({
+        dependencies: {
+          [`provides-peer-deps-1-0-0`]: `1.0.0`,
+          [`peer-deps`]: `1.0.0`,
+          [`no-deps`]: `2.0.0`,
+        },
+      }, async ({path, run, source}) => {
+        await run(`install`);
+
+        const {stdout} = await run(`unplug`, `peer-deps`, `--recursive`, `--json`);
+        const lines = stdout.trim().split(`\n`).map(l => JSON.parse(l));
+
+        expect(lines).toHaveLength(1);
+        expect(lines[0]).toStrictEqual({
+          locator: `peer-deps@npm:1.0.0`,
+          version: `1.0.0`,
+        });
+      }),
+    );
+
+    test(
       `it should not use an outdated install state`,
       makeTemporaryEnv({
         dependencies: {

--- a/tests/acceptance-tests/pkg-tests-specs/sources/commands/unplug.test.ts
+++ b/tests/acceptance-tests/pkg-tests-specs/sources/commands/unplug.test.ts
@@ -1,6 +1,8 @@
 import {xfs, ppath, Filename} from '@yarnpkg/fslib';
 import {yarn}                 from 'pkg-tests-core';
 
+import {setPackageWhitelist}  from '../../../pkg-tests-core/sources/utils/tests';
+
 const {readManifest} = yarn;
 
 const unplugged = {
@@ -244,26 +246,20 @@ describe(`Commands`, () => {
           [`no-deps`]: `^1.0.0`,
         },
       }, async ({path, run, source}) => {
-        const lockfilePath = ppath.join(path, Filename.lockfile);
-
         // Lock the resolution to a version that isn't the latest to
         // check that the descriptor isn't unlocked during the unplug
-        await run(`install`);
-        await run(`set`, `resolution`, `no-deps@npm:^1.0.0`, `npm:1.0.0`);
-
-        // Sanity check
-        await expect(xfs.readFilePromise(lockfilePath, `utf8`)).resolves.toContain(`resolution: "no-deps@npm:1.0.0"`);
-
-        // Simulate switching to a branch where the version is different and back again
-        await xfs.copyFilePromise(lockfilePath, ppath.join(path, `original.lock`));
-        await run(`up`, `no-deps`, `-R`);
-        await expect(xfs.readFilePromise(lockfilePath, `utf8`)).resolves.toContain(`resolution: "no-deps@npm:1.1.0"`);
-        await xfs.copyFilePromise(ppath.join(path, `original.lock`), lockfilePath);
+        await setPackageWhitelist(new Map([
+          [`no-deps`, new Set([`1.0.0`])],
+        ]), async () => {
+          await run(`install`);
+        });
 
         // If a stale install state was used this will either fail or unlock the descriptor
         await run(`unplug`, `no-deps`);
 
-        await expect(xfs.readFilePromise(lockfilePath, `utf8`)).resolves.toContain(`resolution: "no-deps@npm:1.0.0"`);
+        await expect(source(`require('no-deps')`)).resolves.toMatchObject({
+          version: `1.0.0`,
+        });
       }),
     );
   });


### PR DESCRIPTION
Implements `-A`, `-R`, and `--json`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how `unplug` selects packages (workspace/all + recursive traversal) and how it writes `dependenciesMeta` entries (now keyed by `name@version`), which can affect install/linker behavior if selection or keying is wrong.
> 
> **Overview**
> Updates `unplug` to accept pattern selectors plus `-A,--all`, `-R,--recursive`, and `--json`, and to compute the exact set of matching packages from the current install state (including optional transitive traversal).
> 
> `unplug` now writes `dependenciesMeta` entries keyed by `ident@version` and can emit NDJSON `{locator, version}` output, while ensuring it refreshes state via `lazy_install` and avoids duplicates (notably around peer/virtual locators). The linker’s `dependenciesMeta` matching is adjusted to use the registry ident for registry references, aligning meta lookup with the new keying, and acceptance tests are extended to cover deduping and stale-state protection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85fa52ef062a1ec3a263c0df531e1fd82e700d17. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->