### PR TITLE
Renames @builtin/ into @yarnpkg/

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -14,4 +14,4 @@ packageExtensions:
 workspaceProfiles:
   default:
     devDependencies:
-      "@builtin/node": "builtin:^24.12.0"
+      "@yarnpkg/node": "builtin:^24.12.0"

--- a/documentation/src/content/docs/concepts/intermediary/nodejs-management.md
+++ b/documentation/src/content/docs/concepts/intermediary/nodejs-management.md
@@ -17,12 +17,12 @@ Yarn provides a special `@yarnpkg/node` package that you can add to your depende
 {
   "name": "my-app",
   "dependencies": {
-    "@yarnpkg/node": "^22.0.0"
+    "@yarnpkg/node": "builtin:^22.0.0"
   }
 }
 ```
 
-The range here works similarly to semver ranges - Yarn will resolve it to the highest available Node.js version that satisfies your constraint. Once resolved, this version gets locked in your `yarn.lock` file, guaranteeing that every developer and CI environment uses the exact same Node.js release.
+The `builtin:` protocol prefix tells Yarn to resolve this dependency through its built-in resolver rather than the npm registry. The range after the prefix works similarly to semver ranges - Yarn will resolve it to the highest available Node.js version that satisfies your constraint. Once resolved, this version gets locked in your `yarn.lock` file, guaranteeing that every developer and CI environment uses the exact same Node.js release.
 
 ## Why manage Node.js through Yarn?
 

--- a/documentation/src/content/docs/concepts/intermediary/nodejs-management.md
+++ b/documentation/src/content/docs/concepts/intermediary/nodejs-management.md
@@ -9,15 +9,15 @@ sidebar:
 
 One of the subtle causes of "works on my machine" bugs comes from differences in Node.js versions between developers. While tools like nvm, fnm, or Volta help manage local Node.js installations, they require each team member to manually configure their environment. Yarn takes a different approach by letting you declare Node.js as a project dependency, ensuring everyone uses exactly the same version without any extra setup.
 
-## The `@builtin/node` dependency
+## The `@yarnpkg/node` dependency
 
-Yarn provides a special `@builtin/node` package that you can add to your dependencies just like any other package. When installed, Yarn will download the appropriate Node.js binary for your platform directly from [nodejs.org](https://nodejs.org/) and make it available to your project.
+Yarn provides a special `@yarnpkg/node` package that you can add to your dependencies just like any other package. When installed, Yarn will download the appropriate Node.js binary for your platform directly from [nodejs.org](https://nodejs.org/) and make it available to your project.
 
 ```json
 {
   "name": "my-app",
   "dependencies": {
-    "@builtin/node": "^22.0.0"
+    "@yarnpkg/node": "^22.0.0"
   }
 }
 ```
@@ -64,20 +64,20 @@ yarn exec node --version
 
 ## Monorepo support
 
-In a monorepo, you typically want all workspaces to use the same Node.js version. Rather than adding `@builtin/node` to each workspace's `package.json`, you can use [workspace profiles](/concepts/profiles) to declare it once:
+In a monorepo, you typically want all workspaces to use the same Node.js version. Rather than adding `@yarnpkg/node` to each workspace's `package.json`, you can use [workspace profiles](/concepts/profiles) to declare it once:
 
 ```yaml
 workspaceProfiles:
   default:
     devDependencies:
-      "@builtin/node": "builtin:^22.0.0"
+      "@yarnpkg/node": "builtin:^22.0.0"
 ```
 
 Since the `default` profile is automatically applied to all workspaces, every package in your monorepo will use the same Node.js version without any additional configuration. This keeps your Node.js version centralized and easy to update.
 
 ## Platform support
 
-The `@builtin/node` package automatically downloads the correct binary for your operating system and architecture. Currently supported platforms include:
+The `@yarnpkg/node` package automatically downloads the correct binary for your operating system and architecture. Currently supported platforms include:
 
 - Linux (x64, arm64)
 - macOS (x64, arm64)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yarnpkg/monorepo",
-  "packageManager": "yarn@6.0.0-rc.10",
+  "packageManager": "yarn@6.0.0-git.20260507.hash-2d8e2f7dde07a4dbb07bf98b4801008c6ab76280",
   "scripts": {
     "codegen:daemon-types": "cargo run -p zpm --bin generate_daemon_types",
     "codegen:daemon-types:check": "cargo run -p zpm --bin generate_daemon_types -- --check",

--- a/packages/zpm-primitives/src/descriptor.rs
+++ b/packages/zpm-primitives/src/descriptor.rs
@@ -12,7 +12,7 @@ use serde::ser::SerializeMap;
 use serde::Deserializer;
 use zpm_utils::{impl_file_string_from_str, impl_file_string_serialization, FromFileString, Hash64, ToFileString, ToHumanString};
 
-use crate::{BuiltinRange, IdentError, LocatorError, RangeError};
+use crate::{IdentError, LocatorError, RangeError};
 
 use super::range::VirtualRange;
 use super::{reference, Ident, Locator, Range, Reference};
@@ -128,20 +128,8 @@ fn extract_descriptor(ident_str: &str, range_str: &str) -> Result<Descriptor, De
 
     let ident
         = Ident::from_file_string(ident_str)?;
-    let mut range
+    let range
         = Range::from_file_string(&range_str[..parent_split.map_or(range_str.len(), |idx| idx)])?;
-
-    if ident.scope() == Some("@builtin") {
-        if !matches!(range, Range::Builtin(_)) {
-            let Range::AnonymousSemver(params) = range else {
-                return Err(DescriptorError::SyntaxError(range_str.to_string()));
-            };
-
-            range = Range::Builtin(BuiltinRange {
-                range: params.range.clone(),
-            });
-        }
-    }
 
     let parent = parent_split
         .map(|idx| Locator::from_file_string(&range_str[idx + parent_marker.len()..]))

--- a/packages/zpm/src/builtins/node.rs
+++ b/packages/zpm/src/builtins/node.rs
@@ -56,7 +56,7 @@ pub async fn resolve_nodejs_descriptor(context: &InstallContext<'_>, descriptor:
 
     let variants = PLATFORM_VARIANTS.iter().map(|(_, file_name, _)| {
         let name
-            = format!("@builtin/node-{}", file_name);
+            = format!("@yarnpkg/node-{}", file_name);
         let range
             = zpm_semver::Range::exact(version.clone());
 
@@ -83,7 +83,7 @@ pub async fn resolve_nodejs_descriptor(context: &InstallContext<'_>, descriptor:
 pub async fn resolve_nodejs_variant_descriptor(context: &InstallContext<'_>, descriptor: &Descriptor, range: &zpm_semver::Range) -> Result<ResolutionResult, Error> {
     let (system, _, _)
         = PLATFORM_VARIANTS.iter()
-            .find(|(_, file_name, _)| descriptor.ident.as_str() == &format!("@builtin/node-{}", file_name))
+            .find(|(_, file_name, _)| descriptor.ident.as_str() == &format!("@yarnpkg/node-{}", file_name))
             .ok_or(Error::Unsupported)?;
 
     let version
@@ -105,7 +105,7 @@ pub async fn resolve_nodejs_variant_descriptor(context: &InstallContext<'_>, des
 pub async fn resolve_nodejs_variant_locator(context: &InstallContext<'_>, locator: &Locator, version: &zpm_semver::Version) -> Result<ResolutionResult, Error> {
     let (system, _, _)
         = PLATFORM_VARIANTS.iter()
-            .find(|(_, file_name, _)| locator.ident.as_str() == &format!("@builtin/node-{}", file_name))
+            .find(|(_, file_name, _)| locator.ident.as_str() == &format!("@yarnpkg/node-{}", file_name))
             .ok_or(Error::Unsupported)?;
 
     let mut resolution
@@ -119,7 +119,7 @@ pub async fn resolve_nodejs_variant_locator(context: &InstallContext<'_>, locato
 pub async fn fetch_nodejs_locator<'a>(context: &InstallContext<'a>, locator: &Locator, version: &zpm_semver::Version, is_mock_request: bool) -> Result<FetchResult, Error> {
     let (system, file_name, bin_file)
         = PLATFORM_VARIANTS.iter()
-            .find(|(_, file_name, _)| locator.ident.as_str() == &format!("@builtin/node-{}", file_name))
+            .find(|(_, file_name, _)| locator.ident.as_str() == &format!("@yarnpkg/node-{}", file_name))
             .ok_or(Error::Unsupported)?;
 
     if is_mock_request {

--- a/packages/zpm/src/fetchers/builtin.rs
+++ b/packages/zpm/src/fetchers/builtin.rs
@@ -3,12 +3,12 @@ use zpm_primitives::{BuiltinReference, Locator};
 use crate::{builtins, error::Error, fetchers::PackageData, install::{FetchResult, InstallContext}};
 
 pub async fn fetch_builtin_locator(context: &InstallContext<'_>, locator: &Locator, params: &BuiltinReference, is_mock_request: bool) -> Result<FetchResult, Error> {
-    if locator.ident.as_str().starts_with("@builtin/node-") {
+    if locator.ident.as_str().starts_with("@yarnpkg/node-") {
         return builtins::node::fetch_nodejs_locator(context, locator, &params.version, is_mock_request).await;
     }
 
     match locator.ident.as_str() {
-        "@builtin/node"
+        "@yarnpkg/node"
             => Ok(FetchResult::new(PackageData::Abstract)),
 
         _ => Err(Error::Unsupported)?,

--- a/packages/zpm/src/resolvers/builtin.rs
+++ b/packages/zpm/src/resolvers/builtin.rs
@@ -5,12 +5,12 @@ use crate::{
 };
 
 pub async fn resolve_builtin_descriptor(context: &InstallContext<'_>, descriptor: &Descriptor, params: &BuiltinRange) -> Result<ResolutionResult, Error> {
-    if descriptor.ident.as_str().starts_with("@builtin/node-") {
+    if descriptor.ident.as_str().starts_with("@yarnpkg/node-") {
         return builtins::node::resolve_nodejs_variant_descriptor(context, descriptor, &params.range).await;
     }
 
     match descriptor.ident.as_str() {
-        "@builtin/node"
+        "@yarnpkg/node"
             => builtins::node::resolve_nodejs_descriptor(context, descriptor, params).await,
 
         _ => Err(Error::Unsupported)?,
@@ -18,7 +18,7 @@ pub async fn resolve_builtin_descriptor(context: &InstallContext<'_>, descriptor
 }
 
 pub async fn resolve_builtin_locator(context: &InstallContext<'_>, locator: &Locator, version: &zpm_semver::Version) -> Result<ResolutionResult, Error> {
-    if locator.ident.as_str().starts_with("@builtin/node-") {
+    if locator.ident.as_str().starts_with("@yarnpkg/node-") {
         return builtins::node::resolve_nodejs_variant_locator(context, locator, version).await;
     }
 

--- a/tests/acceptance-tests/pkg-tests-specs/sources/features/nodejsVersioning.test.ts
+++ b/tests/acceptance-tests/pkg-tests-specs/sources/features/nodejsVersioning.test.ts
@@ -7,7 +7,7 @@ describe(`Features`, () => {
       `it should make the managed Node.js available through yarn node`,
       makeTemporaryEnv({
         dependencies: {
-          [`@yarnpkg/node`]: `^22.0.0`,
+          [`@yarnpkg/node`]: `builtin:^22.0.0`,
         },
       }, async ({path, run, source}) => {
         await run(`install`, {
@@ -26,7 +26,7 @@ describe(`Features`, () => {
       `it should make the managed Node.js available through yarn exec`,
       makeTemporaryEnv({
         dependencies: {
-          [`@yarnpkg/node`]: `^22.0.0`,
+          [`@yarnpkg/node`]: `builtin:^22.0.0`,
         },
       }, async ({path, run, source}) => {
         await run(`install`, {
@@ -45,7 +45,7 @@ describe(`Features`, () => {
       `it should run scripts with the managed Node.js version`,
       makeTemporaryEnv({
         dependencies: {
-          [`@yarnpkg/node`]: `^22.0.0`,
+          [`@yarnpkg/node`]: `builtin:^22.0.0`,
         },
         scripts: {
           [`check-version`]: `node --version`,
@@ -107,7 +107,7 @@ describe(`Features`, () => {
         `it should support Node.js 20.x`,
         makeTemporaryEnv({
           dependencies: {
-            [`@yarnpkg/node`]: `^20.0.0`,
+            [`@yarnpkg/node`]: `builtin:^20.0.0`,
           },
         }, async ({path, run, source}) => {
           await run(`install`, {
@@ -126,7 +126,7 @@ describe(`Features`, () => {
         `it should support Node.js 22.x`,
         makeTemporaryEnv({
           dependencies: {
-            [`@yarnpkg/node`]: `^22.0.0`,
+            [`@yarnpkg/node`]: `builtin:^22.0.0`,
           },
         }, async ({path, run, source}) => {
           await run(`install`, {
@@ -147,7 +147,7 @@ describe(`Features`, () => {
         `it should by default only fetch the @yarnpkg/node package for the current platform`,
         makeTemporaryEnv({
           dependencies: {
-            [`@yarnpkg/node`]: `^22.0.0`,
+            [`@yarnpkg/node`]: `builtin:^22.0.0`,
           },
         }, async ({path, run, source}) => {
           await run(`install`, {
@@ -170,7 +170,7 @@ describe(`Features`, () => {
         `it should fetch @yarnpkg/node packages for multiple platforms when supportedArchitectures is configured`,
         makeTemporaryEnv({
           dependencies: {
-            [`@yarnpkg/node`]: `^22.0.0`,
+            [`@yarnpkg/node`]: `builtin:^22.0.0`,
           },
         }, async ({path, run, source}) => {
           await xfs.writeJsonPromise(ppath.join(path, Filename.rc), {
@@ -201,7 +201,7 @@ describe(`Features`, () => {
         `it should produce a stable lockfile regardless of the current platform`,
         makeTemporaryEnv({
           dependencies: {
-            [`@yarnpkg/node`]: `^22.0.0`,
+            [`@yarnpkg/node`]: `builtin:^22.0.0`,
           },
         }, async ({path, run, source}) => {
           await xfs.writeJsonPromise(ppath.join(path, Filename.rc), {
@@ -237,7 +237,7 @@ describe(`Features`, () => {
         `it should resolve platform-specific packages for arm64 and x64 when both are configured`,
         makeTemporaryEnv({
           dependencies: {
-            [`@yarnpkg/node`]: `^22.0.0`,
+            [`@yarnpkg/node`]: `builtin:^22.0.0`,
           },
         }, async ({path, run, source}) => {
           await xfs.writeJsonPromise(ppath.join(path, Filename.rc), {

--- a/tests/acceptance-tests/pkg-tests-specs/sources/features/nodejsVersioning.test.ts
+++ b/tests/acceptance-tests/pkg-tests-specs/sources/features/nodejsVersioning.test.ts
@@ -7,7 +7,7 @@ describe(`Features`, () => {
       `it should make the managed Node.js available through yarn node`,
       makeTemporaryEnv({
         dependencies: {
-          [`@builtin/node`]: `^22.0.0`,
+          [`@yarnpkg/node`]: `^22.0.0`,
         },
       }, async ({path, run, source}) => {
         await run(`install`, {
@@ -26,7 +26,7 @@ describe(`Features`, () => {
       `it should make the managed Node.js available through yarn exec`,
       makeTemporaryEnv({
         dependencies: {
-          [`@builtin/node`]: `^22.0.0`,
+          [`@yarnpkg/node`]: `^22.0.0`,
         },
       }, async ({path, run, source}) => {
         await run(`install`, {
@@ -45,7 +45,7 @@ describe(`Features`, () => {
       `it should run scripts with the managed Node.js version`,
       makeTemporaryEnv({
         dependencies: {
-          [`@builtin/node`]: `^22.0.0`,
+          [`@yarnpkg/node`]: `^22.0.0`,
         },
         scripts: {
           [`check-version`]: `node --version`,
@@ -65,7 +65,7 @@ describe(`Features`, () => {
 
     describe(`Monorepo support`, () => {
       test(
-        `it should allow declaring @builtin/node in a workspace profile`,
+        `it should allow declaring @yarnpkg/node in a workspace profile`,
         makeTemporaryMonorepoEnv(
           {
             workspaces: [`packages/*`],
@@ -81,7 +81,7 @@ describe(`Features`, () => {
               workspaceProfiles: {
                 default: {
                   devDependencies: {
-                    [`@builtin/node`]: `builtin:^22.0.0`,
+                    [`@yarnpkg/node`]: `builtin:^22.0.0`,
                   },
                 },
               },
@@ -107,7 +107,7 @@ describe(`Features`, () => {
         `it should support Node.js 20.x`,
         makeTemporaryEnv({
           dependencies: {
-            [`@builtin/node`]: `^20.0.0`,
+            [`@yarnpkg/node`]: `^20.0.0`,
           },
         }, async ({path, run, source}) => {
           await run(`install`, {
@@ -126,7 +126,7 @@ describe(`Features`, () => {
         `it should support Node.js 22.x`,
         makeTemporaryEnv({
           dependencies: {
-            [`@builtin/node`]: `^22.0.0`,
+            [`@yarnpkg/node`]: `^22.0.0`,
           },
         }, async ({path, run, source}) => {
           await run(`install`, {
@@ -144,10 +144,10 @@ describe(`Features`, () => {
 
     describe(`Platform support`, () => {
       test(
-        `it should by default only fetch the @builtin/node package for the current platform`,
+        `it should by default only fetch the @yarnpkg/node package for the current platform`,
         makeTemporaryEnv({
           dependencies: {
-            [`@builtin/node`]: `^22.0.0`,
+            [`@yarnpkg/node`]: `^22.0.0`,
           },
         }, async ({path, run, source}) => {
           await run(`install`, {
@@ -158,19 +158,19 @@ describe(`Features`, () => {
           });
 
           const allCachedFiles = await xfs.readdirPromise(ppath.join(path, `.yarn/cache`));
-          const nodeFiles = allCachedFiles.sort().filter(file => file.startsWith(`@builtin-node-`));
+          const nodeFiles = allCachedFiles.sort().filter(file => file.startsWith(`@yarnpkg-node-`));
 
           expect(nodeFiles).toEqual([
-            expect.stringMatching(/@builtin-node-linux-x64-builtin-22\.0\.0-/),
+            expect.stringMatching(/@yarnpkg-node-linux-x64-builtin-22\.0\.0-/),
           ]);
         }),
       );
 
       test(
-        `it should fetch @builtin/node packages for multiple platforms when supportedArchitectures is configured`,
+        `it should fetch @yarnpkg/node packages for multiple platforms when supportedArchitectures is configured`,
         makeTemporaryEnv({
           dependencies: {
-            [`@builtin/node`]: `^22.0.0`,
+            [`@yarnpkg/node`]: `^22.0.0`,
           },
         }, async ({path, run, source}) => {
           await xfs.writeJsonPromise(ppath.join(path, Filename.rc), {
@@ -188,11 +188,11 @@ describe(`Features`, () => {
           });
 
           const allCachedFiles = await xfs.readdirPromise(ppath.join(path, `.yarn/cache`));
-          const nodeFiles = allCachedFiles.sort().filter(file => file.startsWith(`@builtin-node-`));
+          const nodeFiles = allCachedFiles.sort().filter(file => file.startsWith(`@yarnpkg-node-`));
 
           expect(nodeFiles).toEqual([
-            expect.stringMatching(/@builtin-node-darwin-x64-builtin-22\.0\.0-/),
-            expect.stringMatching(/@builtin-node-linux-x64-builtin-22\.0\.0-/),
+            expect.stringMatching(/@yarnpkg-node-darwin-x64-builtin-22\.0\.0-/),
+            expect.stringMatching(/@yarnpkg-node-linux-x64-builtin-22\.0\.0-/),
           ]);
         }),
       );
@@ -201,7 +201,7 @@ describe(`Features`, () => {
         `it should produce a stable lockfile regardless of the current platform`,
         makeTemporaryEnv({
           dependencies: {
-            [`@builtin/node`]: `^22.0.0`,
+            [`@yarnpkg/node`]: `^22.0.0`,
           },
         }, async ({path, run, source}) => {
           await xfs.writeJsonPromise(ppath.join(path, Filename.rc), {
@@ -237,7 +237,7 @@ describe(`Features`, () => {
         `it should resolve platform-specific packages for arm64 and x64 when both are configured`,
         makeTemporaryEnv({
           dependencies: {
-            [`@builtin/node`]: `^22.0.0`,
+            [`@yarnpkg/node`]: `^22.0.0`,
           },
         }, async ({path, run, source}) => {
           await xfs.writeJsonPromise(ppath.join(path, Filename.rc), {
@@ -255,11 +255,11 @@ describe(`Features`, () => {
           });
 
           const allCachedFiles = await xfs.readdirPromise(ppath.join(path, `.yarn/cache`));
-          const nodeFiles = allCachedFiles.sort().filter(file => file.startsWith(`@builtin-node-`));
+          const nodeFiles = allCachedFiles.sort().filter(file => file.startsWith(`@yarnpkg-node-`));
 
           expect(nodeFiles).toEqual([
-            expect.stringMatching(/@builtin-node-linux-arm64-builtin-22\.0\.0-/),
-            expect.stringMatching(/@builtin-node-linux-x64-builtin-22\.0\.0-/),
+            expect.stringMatching(/@yarnpkg-node-linux-arm64-builtin-22\.0\.0-/),
+            expect.stringMatching(/@yarnpkg-node-linux-x64-builtin-22\.0\.0-/),
           ]);
         }),
       );

--- a/yarn.lock
+++ b/yarn.lock
@@ -3,15 +3,15 @@
     "version": 9
   },
   "workspaces": {
-    "@yarnpkg/documentation": "105cf01165fcffc02e5a354f6734895d01fbb152899e635b1d1b152a04e48c904810d457a85b09d642ca9061bf01e02dc203eabdf0c3a29ddf20036b31e43cde",
-    "@yarnpkg/monorepo": "69da8dfb279601957675174872ca291310b88ff5e33fcc0060b11a3503fdef48f629515bcf7d74fbe12b83b2a84b7f0249cf8154978d15bc6a3fa3c634624f94",
-    "@yarnpkg/zpm-constraints": "5c6a5440669d0a0244f06ebc980b86b246235da3b4da7fc5c2bbdc0bf61ef23e95d8bb9f2fdb7402d20cf0ac8461b086799a0e0e606054b85e9ac472be1dd9d2",
-    "@yarnpkg/zpm-daemon-ui": "64b5d42d2f7f1113e164b3c3137385b0d72824abc41ca9e4d852261f61018f037cbe0b0d5c97d7b3529075ff8b6ceead5803590a5ff9ee3564a785732262564a",
-    "acceptance-tests": "9e727eab8feee6a4383eb4abec8384decbaf30d2ee37dca7d2c8fc1e6afff399509282042cc605746ffaca0ed8f7e5b964b88327ecd50c5077d7a44b7ea4a5ae",
-    "pkg-tests-core": "e68bd05709df7e934e9746828824feeea05a4de108f2b55ee6a387664e1b30d412f19108824e87263a3227358fe1fa7277207b8b041372caf95bae441452d0bf",
-    "pkg-tests-fixtures": "92f85e94a04dac9a6700073012b6c7d15c0ce80b32ef51f4463566cae3b95f69f6416e3bc1c62bd4bc400d07a559c93bcfe1c6fc5e0e0320f1c338b127f2388d",
-    "pkg-tests-specs": "99b05aaf26d1c6bf9f0da94ebe57194feb5b24c5e35a9ac127558c9c005dba0d2acf8db3a96c54c8525c608b1daa0a844414ec9a9aa7b868c50c5d39ab5eeb67",
-    "zpm": "95257b9606ea262055a12ded1215d68ea1e15447d9f99ffef0c2e86e13cb71ec9fe728ce19f98c6e421b28f71f0d210e9d260fe41cfcd8f3c1c8e16ef2ddd8f9"
+    "@yarnpkg/documentation": "91807b34e6dea592435ccae123ff1de2e4eb5915b5bf6f69e9b6108bb1fc47e614b3e6c095e90fddbc48070749ad63c372a7990a826f9c9c5da55a01875290a4",
+    "@yarnpkg/monorepo": "bb4a782d3d434fcd650e79b1367560cde2ac80cebaba1f906373cf370aa66aef412bac5d990d807b0e2c87734ac966a221b6442932a96bc0d774438e3fcafbd5",
+    "@yarnpkg/zpm-constraints": "60af699f2119810820520bb8e3eb436c2b62987eae269d932eb44f73f96cb2274059fcbe7ec29bfb8c3c3022719b5b27829653a4c00162d7a4979963f63d6055",
+    "@yarnpkg/zpm-daemon-ui": "fa7a9a93084cb9be77a2ecc957130a65d371e4755518d7ca9ad0882d86965132a9629bb843f688f22c61cccecc5e746e572cbbfaad253e0cfca99f381fc16e00",
+    "acceptance-tests": "9d8edc097d9e560116c52345d9a48c0066f7b6f25e95554a612e01de95b19c720af054e6f98c4d5a3e00696ea566f8910687a0149f591c0911cc757bd5f2bad0",
+    "pkg-tests-core": "5a2339ba2265d216312aa34bbf0b7e0fd3a8724e6fe285562c70f2b27a76c4370832597316e2d20246c8cdc54f96df0eb083aeec824f489a8f68c9bf2efc9a55",
+    "pkg-tests-fixtures": "6f988cb36fe126bc5d41ce56ce3fd0ad485e201dfe8aaa5c70bbf8a3b64a0c0e4ca7f13215026f93dd8cb6c5c43be41574f171e84a345f67a47898fb8e1204cd",
+    "pkg-tests-specs": "12b6677dde1f354be6117229b4fd4c8714ec52269a28175843170cbed4cf0942b2634c01016de5df3f1e942126a0b0141b01180201e26aca444b51637714cfa0",
+    "zpm": "f451ea7a75c0fff2ecb527015471b4aab2b18ddda36078d7949c45d7b3737a2d350781c0b561376fa56ec117ecb89b54974f17eb7c9815d028a75d40e7f7d9b5"
   },
   "entries": {
     "@ai-sdk/gateway@npm:1.0.33": {
@@ -2791,79 +2791,6 @@
       "resolution": {
         "resolution": "@builder.io/partytown@npm:0.7.6",
         "version": "0.7.6"
-      }
-    },
-    "@builtin/node@builtin:^24.12.0": {
-      "checksum": null,
-      "resolution": {
-        "resolution": "@builtin/node@builtin:24.12.0",
-        "version": "24.12.0",
-        "variants": [
-          "@builtin/node-linux-x64@builtin:24.12.0",
-          "@builtin/node-linux-arm64@builtin:24.12.0",
-          "@builtin/node-darwin-x64@builtin:24.12.0",
-          "@builtin/node-darwin-arm64@builtin:24.12.0"
-        ]
-      }
-    },
-    "@builtin/node-darwin-arm64@builtin:24.12.0": {
-      "checksum": null,
-      "resolution": {
-        "resolution": "@builtin/node-darwin-arm64@builtin:24.12.0",
-        "version": "24.12.0",
-        "requirements": {
-          "cpu": [
-            "arm64"
-          ],
-          "os": [
-            "darwin"
-          ]
-        }
-      }
-    },
-    "@builtin/node-darwin-x64@builtin:24.12.0": {
-      "checksum": null,
-      "resolution": {
-        "resolution": "@builtin/node-darwin-x64@builtin:24.12.0",
-        "version": "24.12.0",
-        "requirements": {
-          "cpu": [
-            "x64"
-          ],
-          "os": [
-            "darwin"
-          ]
-        }
-      }
-    },
-    "@builtin/node-linux-arm64@builtin:24.12.0": {
-      "checksum": null,
-      "resolution": {
-        "resolution": "@builtin/node-linux-arm64@builtin:24.12.0",
-        "version": "24.12.0",
-        "requirements": {
-          "cpu": [
-            "arm64"
-          ],
-          "os": [
-            "linux"
-          ]
-        }
-      }
-    },
-    "@builtin/node-linux-x64@builtin:24.12.0": {
-      "checksum": null,
-      "resolution": {
-        "resolution": "@builtin/node-linux-x64@builtin:24.12.0",
-        "version": "24.12.0",
-        "requirements": {
-          "cpu": [
-            "x64"
-          ],
-          "os": [
-            "linux"
-          ]
-        }
       }
     },
     "@capsizecss/unpack@npm:^2.4.0": {
@@ -9893,6 +9820,79 @@
           "@yarnpkg/core": "^4.4.2",
           "@yarnpkg/fslib": "^3.1.2",
           "@yarnpkg/pnp": "^4.1.1"
+        }
+      }
+    },
+    "@yarnpkg/node@builtin:^24.12.0": {
+      "checksum": null,
+      "resolution": {
+        "resolution": "@yarnpkg/node@builtin:24.12.0",
+        "version": "24.12.0",
+        "variants": [
+          "@yarnpkg/node-linux-x64@builtin:24.12.0",
+          "@yarnpkg/node-linux-arm64@builtin:24.12.0",
+          "@yarnpkg/node-darwin-x64@builtin:24.12.0",
+          "@yarnpkg/node-darwin-arm64@builtin:24.12.0"
+        ]
+      }
+    },
+    "@yarnpkg/node-darwin-arm64@builtin:24.12.0": {
+      "checksum": null,
+      "resolution": {
+        "resolution": "@yarnpkg/node-darwin-arm64@builtin:24.12.0",
+        "version": "24.12.0",
+        "requirements": {
+          "cpu": [
+            "arm64"
+          ],
+          "os": [
+            "darwin"
+          ]
+        }
+      }
+    },
+    "@yarnpkg/node-darwin-x64@builtin:24.12.0": {
+      "checksum": null,
+      "resolution": {
+        "resolution": "@yarnpkg/node-darwin-x64@builtin:24.12.0",
+        "version": "24.12.0",
+        "requirements": {
+          "cpu": [
+            "x64"
+          ],
+          "os": [
+            "darwin"
+          ]
+        }
+      }
+    },
+    "@yarnpkg/node-linux-arm64@builtin:24.12.0": {
+      "checksum": null,
+      "resolution": {
+        "resolution": "@yarnpkg/node-linux-arm64@builtin:24.12.0",
+        "version": "24.12.0",
+        "requirements": {
+          "cpu": [
+            "arm64"
+          ],
+          "os": [
+            "linux"
+          ]
+        }
+      }
+    },
+    "@yarnpkg/node-linux-x64@builtin:24.12.0": {
+      "checksum": null,
+      "resolution": {
+        "resolution": "@yarnpkg/node-linux-x64@builtin:24.12.0",
+        "version": "24.12.0",
+        "requirements": {
+          "cpu": [
+            "x64"
+          ],
+          "os": [
+            "linux"
+          ]
         }
       }
     },


### PR DESCRIPTION
It came to my attention that I forgot to reserve the `@builtin` org name on the npm registry. Since it seems used (and it's not clear whether it's reserved by npm or not), it's probably best to avoid that name. Even if Yarn wouldn't download packages from there, third-parties could be confused.

Let's fallback to `@yarnpkg` which we obviously own. Perhaps it'd make sense to also use a dedicated protocol or other range type, to be defined before the 6.x becomes stable.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes built-in package identification/resolution (`@builtin/node*` → `@yarnpkg/node*`), impacting installs, cache keys, and lockfile entries; breakage is possible if any downstream tooling still references the old names.
> 
> **Overview**
> Renames the built-in managed Node.js dependency from `@builtin/node` to `@yarnpkg/node` across configuration, documentation, tests, and the lockfile, standardizing on the owned scope and explicitly documenting the `builtin:` protocol.
> 
> Updates ZPM’s built-in resolver/fetcher and Node.js built-in implementation to generate/recognize `@yarnpkg/node-*` platform variant packages, and removes the descriptor parsing fallback that implicitly treated `@builtin/*` semver ranges as builtins.
> 
> Bumps the repo `packageManager` string to a new Yarn 6 git build.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11dcff970407597ccc2d6817d2db8a9f348f27c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->