### PR TITLE
Bumps GHA versions

### DIFF
--- a/.github/actions/run-e2e-sandbox/Dockerfile
+++ b/.github/actions/run-e2e-sandbox/Dockerfile
@@ -2,6 +2,8 @@ FROM ubuntu:24.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 
+ARG NODE_VERSION=26
+
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \
     bash \
@@ -9,11 +11,17 @@ RUN apt-get update \
     curl \
     git \
     jq \
-    nodejs \
-    npm \
     python3 \
     python-is-python3 \
+    xz-utils \
   && rm -rf /var/lib/apt/lists/* \
+  && ARCH=$(uname -m | sed 's/x86_64/x64/' | sed 's/aarch64/arm64/') \
+  && curl -fsSL "https://nodejs.org/dist/latest-v${NODE_VERSION}.x/SHASUMS256.txt" -o /tmp/SHASUMS256.txt \
+  && NODE_FILENAME=$(grep "linux-${ARCH}.tar.xz" /tmp/SHASUMS256.txt | awk '{print $2}') \
+  && curl -fsSL "https://nodejs.org/dist/latest-v${NODE_VERSION}.x/${NODE_FILENAME}" -o /tmp/node.tar.xz \
+  && echo "$(grep "${NODE_FILENAME}" /tmp/SHASUMS256.txt | awk '{print $1}')  /tmp/node.tar.xz" | sha256sum -c - \
+  && tar -xJf /tmp/node.tar.xz -C /usr/local --strip-components=1 \
+  && rm -f /tmp/node.tar.xz /tmp/SHASUMS256.txt \
   && npm install -g pnpm
 
 COPY entrypoint.sh /entrypoint.sh

--- a/.github/actions/run-e2e-sandbox/Dockerfile
+++ b/.github/actions/run-e2e-sandbox/Dockerfile
@@ -1,28 +1,10 @@
-FROM ubuntu:24.04
+FROM node:26
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-ARG NODE_VERSION=26
-
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends \
-    bash \
-    ca-certificates \
-    curl \
-    git \
-    jq \
-    python3 \
-    python-is-python3 \
-    xz-utils \
-  && rm -rf /var/lib/apt/lists/* \
-  && ARCH=$(uname -m | sed 's/x86_64/x64/' | sed 's/aarch64/arm64/') \
-  && curl -fsSL "https://nodejs.org/dist/latest-v${NODE_VERSION}.x/SHASUMS256.txt" -o /tmp/SHASUMS256.txt \
-  && NODE_FILENAME=$(grep "linux-${ARCH}.tar.xz" /tmp/SHASUMS256.txt | awk '{print $2}') \
-  && curl -fsSL "https://nodejs.org/dist/latest-v${NODE_VERSION}.x/${NODE_FILENAME}" -o /tmp/node.tar.xz \
-  && echo "$(grep "${NODE_FILENAME}" /tmp/SHASUMS256.txt | awk '{print $1}')  /tmp/node.tar.xz" | sha256sum -c - \
-  && tar -xJf /tmp/node.tar.xz -C /usr/local --strip-components=1 \
-  && rm -f /tmp/node.tar.xz /tmp/SHASUMS256.txt \
-  && npm install -g pnpm
+  && apt-get install -y --no-install-recommends jq python3 python-is-python3 \
+  && rm -rf /var/lib/apt/lists/*
 
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
     - name: Checkout the repo
-      uses: actions/checkout@v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
     - name: Build the repository
       uses: ./.github/actions/build
@@ -35,7 +35,7 @@ jobs:
         profile: release-lto
 
     - name: Store the build artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       with:
         name: benchmark-binary
         path: target/x86_64-unknown-linux-musl/release-lto
@@ -55,12 +55,12 @@ jobs:
 
     steps:
     - name: Checkout the repo
-      uses: actions/checkout@v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
     - name: Install Yarn Switch
       uses: yarnpkg/setup-action@main
 
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
       with:
         name: benchmark-binary
         path: local

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{github.event.pull_request.head.sha || github.sha}}
 
@@ -59,7 +59,7 @@ jobs:
           genisoimage -R -o yarn.iso {yarn,yarn-bin}
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: yarn-${{matrix.target}}
           path: |
@@ -69,7 +69,7 @@ jobs:
 
       - name: Upload iso image
         if: matrix.target == 'i686-unknown-linux-musl'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: yarn-${{matrix.target}}-iso
           path: target/${{matrix.target}}/release-lto-nodebug/yarn.iso
@@ -87,12 +87,12 @@ jobs:
 
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{github.event.pull_request.head.sha || github.sha}}
 
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: yarn-${{matrix.target}}
           path: artifacts
@@ -112,7 +112,7 @@ jobs:
           yarn ./tests/acceptance-tests jest --json --outputFile=$(pwd)/report.json || true
 
       - name: Upload test report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: yarn-${{matrix.target}}-test-report
           path: report.json
@@ -133,7 +133,7 @@ jobs:
 
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
           ref: ${{github.event.pull_request.head.sha || github.sha}}

--- a/.github/workflows/check-js.yml
+++ b/.github/workflows/check-js.yml
@@ -8,7 +8,7 @@ jobs:
     name: Typecheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Yarn
         uses: yarnpkg/setup-action@main
@@ -21,7 +21,7 @@ jobs:
     name: Linting
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Yarn
         uses: yarnpkg/setup-action@main

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
 
@@ -49,7 +49,7 @@ jobs:
 
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
 
@@ -66,7 +66,7 @@ jobs:
           tar -czf e2e-binary-yarn-bin.tgz -C target/release yarn-bin
 
       - name: Upload e2e binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: e2e-binary-yarn-bin
           path: e2e-binary-yarn-bin.tgz
@@ -82,12 +82,12 @@ jobs:
 
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
 
       - name: Download e2e binary
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: e2e-binary-yarn-bin
           path: .
@@ -154,7 +154,7 @@ jobs:
 
       - name: Upload e2e logs and status
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: e2e-result-${{ steps.meta.outputs.test_name }}
           path: e2e-artifacts/${{ steps.meta.outputs.test_name }}
@@ -171,16 +171,16 @@ jobs:
 
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 22
 
       - name: Download e2e result artifacts
         continue-on-error: true
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           path: e2e-artifacts
           pattern: e2e-result-*

--- a/.github/workflows/flamegraphs.yml
+++ b/.github/workflows/flamegraphs.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
     - name: Checkout the repo
-      uses: actions/checkout@v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
     - name: Build the repository
       uses: ./.github/actions/build
@@ -24,7 +24,7 @@ jobs:
         profile: release-lto
 
     - name: Store the build artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       with:
         name: flamegraph-binary
         path: target/aarch64-apple-darwin/release-lto
@@ -43,9 +43,9 @@ jobs:
 
     steps:
     - name: Checkout the repo
-      uses: actions/checkout@v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
       with:
         name: flamegraph-binary
         path: local
@@ -71,7 +71,7 @@ jobs:
         sudo bash scripts/bench-run.sh zpm ${{matrix.benchmark[1]}} flamegraph ${{steps.bench-dir.outputs.BENCH_DIR}}
 
     - name: 'Upload the flamegraph'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       with:
         name: flamegraphs-${{matrix.benchmark[1]}}
         path: ${{steps.bench-dir.outputs.BENCH_DIR}}/flamegraphs

--- a/.github/workflows/perfcheck-comment.yml
+++ b/.github/workflows/perfcheck-comment.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Download comment artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: perfcheck-comment
           path: perfcheck-comment
@@ -22,7 +22,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Post or update comment
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/perfcheck.yml
+++ b/.github/workflows/perfcheck.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
@@ -93,7 +93,7 @@ jobs:
         run: ./target/release-lto/yarn-bin debug bench gatsby install-cache-and-lock
 
       - name: Generate benchmark comment
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             const fs = require('fs');
@@ -178,13 +178,13 @@ jobs:
             fs.writeFileSync('perfcheck-comment/pr-number.txt', String(context.issue.number));
 
       - name: Upload comment body artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: perfcheck-comment
           path: perfcheck-comment/
 
       - name: Upload merged benchmark results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: benchmark-results
           path: bench-merged.json

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Compute version
         id: version
@@ -60,7 +60,7 @@ jobs:
 
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - uses: ./.github/actions/build
         id: build
@@ -74,7 +74,7 @@ jobs:
           zip -jX yarn-${{matrix.target}}.zip target/${{matrix.target}}/release-lto-nodebug/{yarn-bin,yarn,LICENSE.md}
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: yarn-${{matrix.target}}
           path: |
@@ -91,10 +91,10 @@ jobs:
 
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           path: artifacts
           merge-multiple: true
@@ -130,16 +130,16 @@ jobs:
 
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           path: artifacts
           merge-multiple: true
 
       - name: Unpack the build of Yarn we just created
-        uses: actions/github-script@v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         env:
           VERSION: ${{needs.check.outputs.version}}
         with:
@@ -215,7 +215,7 @@ jobs:
           echo "$PWD/artifacts/yarn-x86_64-unknown-linux-musl" >> $GITHUB_PATH
 
       - name: Generate the packages
-        uses: actions/github-script@v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         env:
           YARN_NPM_AUTH_TOKEN: ${{secrets.TEMPORARY_NPM_PUBLISH_TOKEN}}
         with:

--- a/.github/workflows/v86.yml
+++ b/.github/workflows/v86.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Build V86 Image
         uses: arcanis/v86-buildroot-action@main
@@ -86,7 +86,7 @@ jobs:
             cd /root/proj
 
       - name: Save as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: yarn-v86-image
           path: yarn-v86-image.bzimage

--- a/documentation/src/content/docs/advanced/general-reference/error-codes.mdx
+++ b/documentation/src/content/docs/advanced/general-reference/error-codes.mdx
@@ -464,7 +464,7 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - run: npm install -g corepack && corepack enable
       - run: yarn && yarn build
       - run: yarn config set npmAuthToken '${{ secrets.NPM_TOKEN }}'

--- a/documentation/src/content/docs/getting-started/basics/install.mdx
+++ b/documentation/src/content/docs/getting-started/basics/install.mdx
@@ -51,7 +51,7 @@ jobs:
   my-job:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Yarn
         uses: yarnpkg/setup-action@main

--- a/documentation/src/content/docs/getting-started/extra/github-actions.mdx
+++ b/documentation/src/content/docs/getting-started/extra/github-actions.mdx
@@ -18,7 +18,7 @@ jobs:
     name: Typecheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6 # 6.0.2
 
       - name: Setup Yarn
         uses: yarnpkg/setup-action@c9778d0717d1b46cf29f06ae5ae5ad41c1bb1c1a

--- a/tests/e2e/pnpm-migration.sh
+++ b/tests/e2e/pnpm-migration.sh
@@ -30,7 +30,7 @@ cat > packages/pkg-a/package.json <<'JSON'
 }
 JSON
 
-pnpm install
+pnpm install --ignore-scripts
 
 # Capture the versions pnpm resolved (normalized to name@version)
 pnpm ls -r --json --depth=Infinity \

--- a/tests/e2e/pnpm-migration.sh
+++ b/tests/e2e/pnpm-migration.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+npm install -g pnpm
+
 mkdir -p packages/pkg-a
 
 cat > package.json <<'JSON'


### PR DESCRIPTION
Bumps the actions so we stop relying on Node.js 20 runners (slated to soon disappear):

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/checkout@v4. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly CI/workflow maintenance: pins core GitHub Actions (`checkout`, `upload/download-artifact`, `setup-node`, `github-script`) to newer major versions and updates the E2E sandbox base image, with small risk of CI behavior changes or artifact handling differences.
> 
> **Overview**
> Updates CI to stop relying on deprecated Node 20-backed actions by **pinning GitHub Actions dependencies to newer major versions** across build, release, perf, e2e, and JS check workflows (notably `actions/checkout`, `actions/upload-artifact`, `actions/download-artifact`, `actions/setup-node`, and `actions/github-script`).
> 
> Modernizes the E2E sandbox container by switching from `ubuntu:24.04` + manually installed Node tooling to `node:26`, and adjusts the `pnpm` migration E2E test to install `pnpm` at runtime and run `pnpm install --ignore-scripts`.
> 
> Documentation snippets are updated to reflect the new pinned `actions/checkout` reference.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c439bcd3e84fb2d5e2e5881b97e6948eb8ddf023. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->