### PR TITLE
Implements `yarn switch up`

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -22,6 +22,7 @@ runs:
   using: composite
   steps:
     - name: Install cross
+      if: ${{ !endsWith(inputs.target, '-apple-darwin') }}
       uses: taiki-e/install-action@a27ef18d36cfa66b0af3a360104621793b41c036 # v2.54.3
       with:
         tool: cross
@@ -57,5 +58,9 @@ runs:
     - name: Build ${{steps.version.outputs.version}}
       shell: bash
       run: |
-        cross build --verbose --profile=${{inputs.profile}} --target=${{inputs.target}}
+        if [[ "${{inputs.target}}" == *-apple-darwin ]]; then
+          cargo build --verbose --profile=${{inputs.profile}} --target=${{inputs.target}}
+        else
+          cross build --verbose --profile=${{inputs.profile}} --target=${{inputs.target}}
+        fi
         cp LICENSE.md target/${{inputs.target}}/${{inputs.profile}}/

--- a/packages/zpm-switch/src/commands/mod.rs
+++ b/packages/zpm-switch/src/commands/mod.rs
@@ -29,6 +29,7 @@ enum SwitchExecCli {
     LinkCommand(switch::link::LinkCommand),
     PostinstallCommand(switch::postinstall::PostinstallCommand),
     UnlinkCommand(switch::unlink::UnlinkCommand),
+    UpCommand(switch::up::UpCommand),
     UpdateCommand(switch::update::UpdateCommand),
     VersionCommand(switch::version::VersionCommand),
     WhichCommand(switch::which::WhichCommand),

--- a/packages/zpm-switch/src/commands/switch/mod.rs
+++ b/packages/zpm-switch/src/commands/switch/mod.rs
@@ -14,6 +14,7 @@ pub mod link_migration;
 pub mod link;
 pub mod postinstall;
 pub mod unlink;
+pub mod up;
 pub mod update;
 pub mod version;
 pub mod which;

--- a/packages/zpm-switch/src/commands/switch/up.rs
+++ b/packages/zpm-switch/src/commands/switch/up.rs
@@ -1,0 +1,69 @@
+use std::process::ExitStatus;
+
+use clipanion::cli;
+use zpm_utils::ToFileString;
+
+use crate::{
+    commands::switch::explicit::ExplicitCommand,
+    cwd::{get_fake_cwd, get_final_cwd},
+    errors::Error,
+    manifest::{find_closest_package_manager, VersionPackageManagerReference},
+    yarn::resolve_selector,
+    yarn_enums::{ChannelSelector, ReleaseLine, Selector},
+};
+
+/// Set the version of Yarn to use with the local project to the latest stable release
+///
+/// When called without arguments, downloads the latest stable Yarn version from the `zpm` release
+/// line and runs `yarn set version zpm` with it. An optional version selector can be passed to
+/// pick a specific release line, channel, version, or range, using the same syntax as the
+/// explicit `yarn switch <selector>` form.
+///
+#[cli::command]
+#[cli::path("switch", "up")]
+#[cli::category("General commands")]
+#[derive(Debug)]
+pub struct UpCommand {
+    selector: Option<Selector>,
+}
+
+impl UpCommand {
+    pub async fn execute(&self) -> Result<ExitStatus, Error> {
+        let lookup_path
+            = get_final_cwd()?;
+
+        let find_result
+            = find_closest_package_manager(&lookup_path)?;
+
+        if let Some(detected_root_path) = find_result.detected_root_path {
+            std::env::set_var("YARNSW_DETECTED_ROOT", detected_root_path.to_file_string());
+        }
+
+        let default_selector = Selector::Channel(ChannelSelector {
+            release_line: Some(ReleaseLine::Zpm),
+            channel: None,
+        });
+
+        let selector = self.selector
+            .as_ref()
+            .unwrap_or(&default_selector);
+
+        let version
+            = resolve_selector(selector).await?;
+
+        let reference
+            = VersionPackageManagerReference {version};
+
+        let mut args = vec![
+            "set".to_string(),
+            "version".to_string(),
+            selector.to_file_string(),
+        ];
+
+        if let Some(cwd) = get_fake_cwd() {
+            args.insert(0, cwd.to_file_string());
+        }
+
+        ExplicitCommand::run(&reference.into(), &args).await
+    }
+}


### PR DESCRIPTION
This diff implements `yarn switch up`, which is an alias for `yarn switch zpm set version zpm` (in other words, it runs `yarn set version` with the latest Yarn version).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new CLI entrypoint and changes the build action to bypass `cross` on `*-apple-darwin` targets, which could affect release artifact correctness for macOS targets.
> 
> **Overview**
> Adds a new `yarn switch up` command that defaults to the latest stable Yarn from the `zpm` release line (or an optional selector) and then delegates to the existing explicit switch flow by running `yarn set version <selector>`.
> 
> Updates the composite GitHub build action to **skip installing `cross`** and to build Darwin targets with `cargo build` instead of `cross build`, while keeping `cross` for non-Darwin targets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8afabbdae178bc4942f72063a7e592ff078d844f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->