### PR TITLE
Fixes lint

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,6 +1,17 @@
 import reactEslintConfig from '@yarnpkg/eslint-config/react';
 import eslintConfig      from '@yarnpkg/eslint-config';
 
+const browserGlobals = {
+  customElements: `readonly`,
+  document: `readonly`,
+  HTMLElement: `readonly`,
+  history: `readonly`,
+  localStorage: `readonly`,
+  location: `readonly`,
+  requestAnimationFrame: `readonly`,
+  window: `readonly`,
+};
+
 // eslint-disable-next-line arca/no-default-export
 export default [
   {
@@ -24,6 +35,44 @@ export default [
     ],
     rules: {
       [`arca/no-default-export`]: `off`,
+    },
+  },
+  {
+    files: [
+      `website/astro.config.mjs`,
+      `website/plugins/**/*.mjs`,
+    ],
+    rules: {
+      [`arca/no-default-export`]: `off`,
+    },
+  },
+  {
+    files: [
+      `website/public/**/*.js`,
+    ],
+    languageOptions: {
+      globals: {
+        ...browserGlobals,
+        LEVELS: `readonly`,
+        QUESTIONS: `readonly`,
+      },
+    },
+  },
+  {
+    files: [
+      `website/plugins/remark-mermaid.mjs`,
+    ],
+    languageOptions: {
+      globals: browserGlobals,
+    },
+  },
+  {
+    files: [
+      `website/scripts/record-terminal.ts`,
+      `website/src/components/package/utils.ts`,
+    ],
+    rules: {
+      [`no-control-regex`]: `off`,
     },
   },
   {

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -1,15 +1,15 @@
-import react                from '@astrojs/react';
-import sitemap              from '@astrojs/sitemap';
-import tailwindcss          from '@tailwindcss/vite';
-import {defineConfig}       from 'astro/config';
-import remarkDirective      from 'remark-directive';
+import react                  from '@astrojs/react';
+import sitemap                from '@astrojs/sitemap';
+import tailwindcss            from '@tailwindcss/vite';
+import {defineConfig}         from 'astro/config';
+import remarkDirective        from 'remark-directive';
 
-import rehypeDocs               from './plugins/rehype-docs.mjs';
-import rehypeFootnoteTooltips   from './plugins/rehype-footnote-tooltips.mjs';
-import remarkAutolinkFields from './plugins/remark-autolink-fields.mjs';
-import remarkBluesky        from './plugins/remark-bluesky.mjs';
-import remarkDocs           from './plugins/remark-docs.mjs';
-import remarkMermaid        from './plugins/remark-mermaid.mjs';
+import rehypeDocs             from './plugins/rehype-docs.mjs';
+import rehypeFootnoteTooltips from './plugins/rehype-footnote-tooltips.mjs';
+import remarkAutolinkFields   from './plugins/remark-autolink-fields.mjs';
+import remarkBluesky          from './plugins/remark-bluesky.mjs';
+import remarkDocs             from './plugins/remark-docs.mjs';
+import remarkMermaid          from './plugins/remark-mermaid.mjs';
 
 export default defineConfig({
   site: `https://v6.yarnpkg.com`,

--- a/website/plugins/rehype-docs.mjs
+++ b/website/plugins/rehype-docs.mjs
@@ -7,7 +7,7 @@ const admonitionSvgs = {
   danger: `<svg viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.5"><circle cx="7" cy="7" r="5.5"/><path d="M7 4v4M7 9.5v0.3"/></svg>`,
 };
 
-// eslint-disable-next-line arca/no-default-export
+
 export default function rehypeDocs() {
   return tree => {
     visit(tree, `element`, node => {
@@ -60,9 +60,9 @@ export default function rehypeDocs() {
     visit(tree, `element`, node => {
       if (![`h2`, `h3`, `h4`].includes(node.tagName)) return;
 
-      if (!node.properties.id) {
+      if (!node.properties.id)
         node.properties.id = slugifyId(textContent(node));
-      }
+
 
       const id = node.properties.id;
       const text = {type: `element`, tagName: `span`, properties: {}, children: node.children};

--- a/website/plugins/rehype-footnote-tooltips.mjs
+++ b/website/plugins/rehype-footnote-tooltips.mjs
@@ -26,12 +26,13 @@ function serializeNode(node) {
 
     const attrs = [];
     for (const [k, v] of Object.entries(props)) {
-      if (k === `className`)
+      if (k === `className`) {
         attrs.push(`class="${escAttr(v.join(` `))}"`);
-      else if (typeof v === `string`)
+      } else if (typeof v === `string`) {
         attrs.push(`${k.replace(/([A-Z])/g, `-$1`).toLowerCase()}="${escAttr(v)}"`);
-      else if (v === true)
+      } else if (v === true) {
         attrs.push(k.replace(/([A-Z])/g, `-$1`).toLowerCase());
+      }
     }
 
     const open = attrs.length ? `<${tag} ${attrs.join(` `)}>` : `<${tag}>`;
@@ -61,29 +62,40 @@ export default function rehypeFootnoteTooltips() {
     const footnotes = new Map();
 
     visit(tree, `element`, node => {
-      if (node.tagName !== `li`) return;
+      if (node.tagName !== `li`)
+        return;
+
       const id = node.properties?.id;
-      if (!id || !id.startsWith(`user-content-fn-`)) return;
+      if (!id || !id.startsWith(`user-content-fn-`))
+        return;
+
 
       const key = id.replace(`user-content-fn-`, ``);
       const html = serializeFootnote(node.children);
-      if (html)
+      if (html) {
         footnotes.set(key, html);
+      }
     });
 
     if (!footnotes.size) return;
 
     visit(tree, `element`, node => {
-      if (node.tagName !== `sup`) return;
+      if (node.tagName !== `sup`)
+        return undefined;
+
 
       const link = (node.children || []).find(c =>
         c.type === `element` && c.tagName === `a` && c.properties?.dataFootnoteRef != null,
       );
-      if (!link) return;
+      if (!link)
+        return undefined;
+
 
       const key = (link.properties.href || ``).replace(`#user-content-fn-`, ``);
       const html = footnotes.get(key);
-      if (!html) return;
+      if (!html)
+        return undefined;
+
 
       node.properties = node.properties || {};
       node.properties.className = [...(node.properties.className || []), `fn-ref`];

--- a/website/plugins/remark-docs.mjs
+++ b/website/plugins/remark-docs.mjs
@@ -1,5 +1,5 @@
-import {visit} from 'unist-util-visit';
 import {createHighlighter, createCssVariablesTheme} from 'shiki';
+import {visit}                                      from 'unist-util-visit';
 
 const cssVarsTheme = createCssVariablesTheme({
   name: `css-variables`,
@@ -180,7 +180,7 @@ export default function remarkDocs() {
           type: `html`,
           value: buildTerminalHtml(node.value),
         };
-        return index;
+        return;
       }
 
       codeNodes.push({node, index, parent});
@@ -219,7 +219,7 @@ export default function remarkDocs() {
           const data = ol.data || (ol.data = {});
           data.hProperties = {...(data.hProperties || {}), className: [`steps`]};
           parent.children[index] = ol;
-          return index;
+          return;
         }
       }
     });
@@ -253,7 +253,7 @@ export default function remarkDocs() {
       if (!parent || !PILL_NAMES.includes(node.name)) return;
       const content = toString(node);
       parent.children[index] = {type: `html`, value: pillToHtml(node.name, content)};
-      return index;
+      return;
     });
   };
 }

--- a/website/plugins/test-rehype-footnote-tooltips.mjs
+++ b/website/plugins/test-rehype-footnote-tooltips.mjs
@@ -1,9 +1,9 @@
-import {unified}        from 'unified';
-import remarkParse      from 'remark-parse';
-import remarkGfm        from 'remark-gfm';
-import remarkRehype     from 'remark-rehype';
-import rehypeRaw        from 'rehype-raw';
-import rehypeStringify  from 'rehype-stringify';
+import rehypeRaw              from 'rehype-raw';
+import rehypeStringify        from 'rehype-stringify';
+import remarkGfm              from 'remark-gfm';
+import remarkParse            from 'remark-parse';
+import remarkRehype           from 'remark-rehype';
+import {unified}              from 'unified';
 
 import rehypeFootnoteTooltips from './rehype-footnote-tooltips.mjs';
 
@@ -170,8 +170,8 @@ assert(content8 !== null && !content8.includes(`<p>`), `no <p> in multi-paragrap
 
 // ── Summary ──
 
-console.log(`${'═'.repeat(40)}`);
+console.log(`${`═`.repeat(40)}`);
 console.log(`  ${passed} passed, ${failed} failed`);
-console.log(`${'═'.repeat(40)}\n`);
+console.log(`${`═`.repeat(40)}\n`);
 
 process.exit(failed > 0 ? 1 : 0);

--- a/website/public/blog/blog.js
+++ b/website/public/blog/blog.js
@@ -1,81 +1,91 @@
 (function () {
   function toast(msg) {
-    let t = document.querySelector('.blog-toast');
+    let t = document.querySelector(`.blog-toast`);
     if (!t) {
-      t = document.createElement('div');
-      t.className = 'blog-toast';
-      t.setAttribute('role', 'status');
+      t = document.createElement(`div`);
+      t.className = `blog-toast`;
+      t.setAttribute(`role`, `status`);
       Object.assign(t.style, {
-        position: 'fixed', left: '50%', bottom: '28px',
-        transform: 'translateX(-50%) translateY(10px)',
-        padding: '10px 16px', borderRadius: '10px',
-        background: 'color-mix(in oklch, var(--bg-0) 80%, transparent)',
-        border: '1px solid var(--line-strong)', color: 'var(--fg)',
-        fontSize: '13px', fontFamily: 'inherit', zIndex: 100,
-        backdropFilter: 'blur(10px)', opacity: '0',
-        transition: 'opacity 0.2s, transform 0.2s', pointerEvents: 'none',
+        position: `fixed`, left: `50%`, bottom: `28px`,
+        transform: `translateX(-50%) translateY(10px)`,
+        padding: `10px 16px`, borderRadius: `10px`,
+        background: `color-mix(in oklch, var(--bg-0) 80%, transparent)`,
+        border: `1px solid var(--line-strong)`, color: `var(--fg)`,
+        fontSize: `13px`, fontFamily: `inherit`, zIndex: 100,
+        backdropFilter: `blur(10px)`, opacity: `0`,
+        transition: `opacity 0.2s, transform 0.2s`, pointerEvents: `none`,
       });
       document.body.appendChild(t);
     }
     t.textContent = msg;
     requestAnimationFrame(() => {
-      t.style.opacity = '1';
-      t.style.transform = 'translateX(-50%) translateY(0)';
+      t.style.opacity = `1`;
+      t.style.transform = `translateX(-50%) translateY(0)`;
     });
     clearTimeout(t._timer);
     t._timer = setTimeout(() => {
-      t.style.opacity = '0';
-      t.style.transform = 'translateX(-50%) translateY(10px)';
+      t.style.opacity = `0`;
+      t.style.transform = `translateX(-50%) translateY(10px)`;
     }, 1600);
   }
 
-  var prose = document.querySelector('.article-prose');
+  var prose = document.querySelector(`.article-prose`);
   if (!prose) return;
 
-  var headings = Array.from(prose.querySelectorAll('h2, h3'));
-  headings.forEach(function (h) {
-    var anchor = h.querySelector('.heading-anchor');
+  var headings = Array.from(prose.querySelectorAll(`h2, h3`));
+  headings.forEach(h => {
+    var anchor = h.querySelector(`.heading-anchor`);
     if (anchor) {
-      anchor.addEventListener('click', function (e) {
+      anchor.addEventListener(`click`, e => {
         e.preventDefault();
-        var url = location.origin + location.pathname + '#' + h.id;
-        history.replaceState(null, '', '#' + h.id);
+        var url = `${location.origin + location.pathname}#${h.id}`;
+        history.replaceState(null, ``, `#${h.id}`);
         if (navigator.clipboard) {
           navigator.clipboard.writeText(url).then(
-            function () { toast('Link copied'); },
-            function () { toast('Press \u2318C to copy'); }
+            () => {
+              toast(`Link copied`);
+            },
+            () => {
+              toast(`Press \u2318C to copy`);
+            },
           );
         }
       });
     }
   });
 
-  var toc = document.querySelector('.toc');
+  var toc = document.querySelector(`.toc`);
   if (toc) {
-    var h2s = headings.filter(function (h) { return h.tagName === 'H2'; });
-    var links = Array.from(toc.querySelectorAll('a'));
+    var h2s = headings.filter(h => {
+      return h.tagName === `H2`;
+    });
+    var links = Array.from(toc.querySelectorAll(`a`));
     function onScroll() {
       var y = window.scrollY + 140;
       var activeId = h2s[0].id;
-      for (var i = 0; i < h2s.length; i++) {
+      for (var i = 0; i < h2s.length; i++)
         if (h2s[i].offsetTop <= y) activeId = h2s[i].id;
-      }
-      links.forEach(function (l) {
-        l.classList.toggle('active', l.getAttribute('href') === '#' + activeId);
+
+      links.forEach(l => {
+        l.classList.toggle(`active`, l.getAttribute(`href`) === `#${activeId}`);
       });
     }
-    window.addEventListener('scroll', onScroll, { passive: true });
+    window.addEventListener(`scroll`, onScroll, {passive: true});
     onScroll();
   }
 
-  document.querySelectorAll('[data-share="copy-url"]').forEach(function (btn) {
-    btn.addEventListener('click', function (e) {
+  document.querySelectorAll(`[data-share="copy-url"]`).forEach(btn => {
+    btn.addEventListener(`click`, e => {
       e.preventDefault();
       var url = location.href;
       if (navigator.clipboard) {
         navigator.clipboard.writeText(url).then(
-          function () { toast('Link copied'); },
-          function () { toast('Press \u2318C to copy'); }
+          () => {
+            toast(`Link copied`);
+          },
+          () => {
+            toast(`Press \u2318C to copy`);
+          },
         );
       }
     });

--- a/website/public/deck-stage.js
+++ b/website/public/deck-stage.js
@@ -3,7 +3,7 @@
   const DESIGN_H_DEFAULT = 1080;
   const OVERLAY_HIDE_MS = 1800;
 
-  const pad2 = (n) => String(n).padStart(2, '0');
+  const pad2 = n => String(n).padStart(2, `0`);
 
   const stylesheet = `
     :host {
@@ -204,11 +204,13 @@
   `;
 
   class DeckStage extends HTMLElement {
-    static get observedAttributes() { return ['width', 'height', 'noscale']; }
+    static get observedAttributes() {
+      return [`width`, `height`, `noscale`];
+    }
 
     constructor() {
       super();
-      this._root = this.attachShadow({ mode: 'open' });
+      this._root = this.attachShadow({mode: `open`});
       this._index = 0;
       this._slides = [];
       this._hideTimer = null;
@@ -226,76 +228,80 @@
     }
 
     get designWidth() {
-      return parseInt(this.getAttribute('width'), 10) || DESIGN_W_DEFAULT;
+      return parseInt(this.getAttribute(`width`), 10) || DESIGN_W_DEFAULT;
     }
     get designHeight() {
-      return parseInt(this.getAttribute('height'), 10) || DESIGN_H_DEFAULT;
+      return parseInt(this.getAttribute(`height`), 10) || DESIGN_H_DEFAULT;
     }
 
     connectedCallback() {
       this._render();
-      window.addEventListener('keydown', this._onKey);
-      window.addEventListener('resize', this._onResize);
-      window.addEventListener('mousemove', this._onMouseMove, { passive: true });
-      document.addEventListener('fullscreenchange', this._onFullscreenChange);
+      window.addEventListener(`keydown`, this._onKey);
+      window.addEventListener(`resize`, this._onResize);
+      window.addEventListener(`mousemove`, this._onMouseMove, {passive: true});
+      document.addEventListener(`fullscreenchange`, this._onFullscreenChange);
     }
 
     disconnectedCallback() {
-      window.removeEventListener('keydown', this._onKey);
-      window.removeEventListener('resize', this._onResize);
-      window.removeEventListener('mousemove', this._onMouseMove);
-      document.removeEventListener('fullscreenchange', this._onFullscreenChange);
-      if (this._hideTimer) clearTimeout(this._hideTimer);
-      if (this._mouseIdleTimer) clearTimeout(this._mouseIdleTimer);
+      window.removeEventListener(`keydown`, this._onKey);
+      window.removeEventListener(`resize`, this._onResize);
+      window.removeEventListener(`mousemove`, this._onMouseMove);
+      document.removeEventListener(`fullscreenchange`, this._onFullscreenChange);
+      if (this._hideTimer)
+        clearTimeout(this._hideTimer);
+
+      if (this._mouseIdleTimer) {
+        clearTimeout(this._mouseIdleTimer);
+      }
     }
 
     attributeChangedCallback() {
       if (this._canvas) {
-        this._canvas.style.width = this.designWidth + 'px';
-        this._canvas.style.height = this.designHeight + 'px';
-        this._canvas.style.setProperty('--deck-design-w', this.designWidth + 'px');
-        this._canvas.style.setProperty('--deck-design-h', this.designHeight + 'px');
+        this._canvas.style.width = `${this.designWidth}px`;
+        this._canvas.style.height = `${this.designHeight}px`;
+        this._canvas.style.setProperty(`--deck-design-w`, `${this.designWidth}px`);
+        this._canvas.style.setProperty(`--deck-design-h`, `${this.designHeight}px`);
         this._fit();
       }
     }
 
     _render() {
-      const style = document.createElement('style');
+      const style = document.createElement(`style`);
       style.textContent = stylesheet;
 
-      const stage = document.createElement('div');
-      stage.className = 'stage';
+      const stage = document.createElement(`div`);
+      stage.className = `stage`;
 
-      const canvas = document.createElement('div');
-      canvas.className = 'canvas';
-      canvas.style.width = this.designWidth + 'px';
-      canvas.style.height = this.designHeight + 'px';
-      canvas.style.setProperty('--deck-design-w', this.designWidth + 'px');
-      canvas.style.setProperty('--deck-design-h', this.designHeight + 'px');
+      const canvas = document.createElement(`div`);
+      canvas.className = `canvas`;
+      canvas.style.width = `${this.designWidth}px`;
+      canvas.style.height = `${this.designHeight}px`;
+      canvas.style.setProperty(`--deck-design-w`, `${this.designWidth}px`);
+      canvas.style.setProperty(`--deck-design-h`, `${this.designHeight}px`);
 
-      const slot = document.createElement('slot');
-      slot.addEventListener('slotchange', this._onSlotChange);
+      const slot = document.createElement(`slot`);
+      slot.addEventListener(`slotchange`, this._onSlotChange);
       canvas.appendChild(slot);
       stage.appendChild(canvas);
 
-      const tapzones = document.createElement('div');
-      tapzones.className = 'tapzones';
-      tapzones.setAttribute('aria-hidden', 'true');
-      const tzBack = document.createElement('div');
-      tzBack.className = 'tapzone';
-      const tzMid = document.createElement('div');
-      tzMid.className = 'tapzone';
-      tzMid.style.pointerEvents = 'none';
-      const tzFwd = document.createElement('div');
-      tzFwd.className = 'tapzone';
-      tzBack.addEventListener('click', this._onTapBack);
-      tzFwd.addEventListener('click', this._onTapForward);
+      const tapzones = document.createElement(`div`);
+      tapzones.className = `tapzones`;
+      tapzones.setAttribute(`aria-hidden`, `true`);
+      const tzBack = document.createElement(`div`);
+      tzBack.className = `tapzone`;
+      const tzMid = document.createElement(`div`);
+      tzMid.className = `tapzone`;
+      tzMid.style.pointerEvents = `none`;
+      const tzFwd = document.createElement(`div`);
+      tzFwd.className = `tapzone`;
+      tzBack.addEventListener(`click`, this._onTapBack);
+      tzFwd.addEventListener(`click`, this._onTapForward);
       tapzones.append(tzBack, tzMid, tzFwd);
 
-      const overlay = document.createElement('div');
-      overlay.className = 'overlay';
-      overlay.setAttribute('role', 'toolbar');
-      overlay.setAttribute('aria-label', 'Deck controls');
+      const overlay = document.createElement(`div`);
+      overlay.className = `overlay`;
+      overlay.setAttribute(`role`, `toolbar`);
+      overlay.setAttribute(`aria-label`, `Deck controls`);
       overlay.innerHTML = `
         <button class="btn prev" type="button" aria-label="Previous slide" title="Previous">
           <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M10 3L5 8l5 5"/></svg>
@@ -309,35 +315,35 @@
         <button class="btn present" type="button" aria-label="Present (fullscreen)" title="Present (P)">Present<span class="kbd">P</span></button>
       `;
 
-      overlay.querySelector('.prev').addEventListener('click', () => this._go(this._index - 1, 'click'));
-      overlay.querySelector('.next').addEventListener('click', () => this._go(this._index + 1, 'click'));
-      overlay.querySelector('.reset').addEventListener('click', () => this._go(0, 'click'));
-      overlay.querySelector('.present').addEventListener('click', this._togglePresent);
+      overlay.querySelector(`.prev`).addEventListener(`click`, () => this._go(this._index - 1, `click`));
+      overlay.querySelector(`.next`).addEventListener(`click`, () => this._go(this._index + 1, `click`));
+      overlay.querySelector(`.reset`).addEventListener(`click`, () => this._go(0, `click`));
+      overlay.querySelector(`.present`).addEventListener(`click`, this._togglePresent);
 
       this._root.append(style, stage, tapzones, overlay);
       this._canvas = canvas;
       this._slot = slot;
       this._overlay = overlay;
-      this._countEl = overlay.querySelector('.current');
-      this._totalEl = overlay.querySelector('.total');
+      this._countEl = overlay.querySelector(`.current`);
+      this._totalEl = overlay.querySelector(`.total`);
     }
 
     _onSlotChange() {
       this._collectSlides();
       this._restoreIndex();
-      this._applyIndex({ showOverlay: false, broadcast: true, reason: 'init' });
+      this._applyIndex({showOverlay: false, broadcast: true, reason: `init`});
       this._fit();
     }
 
     _collectSlides() {
-      const assigned = this._slot.assignedElements({ flatten: true });
-      this._slides = assigned.filter((el) => {
+      const assigned = this._slot.assignedElements({flatten: true});
+      this._slides = assigned.filter(el => {
         const tag = el.tagName;
-        return tag !== 'TEMPLATE' && tag !== 'SCRIPT' && tag !== 'STYLE';
+        return tag !== `TEMPLATE` && tag !== `SCRIPT` && tag !== `STYLE`;
       });
 
       this._slides.forEach((slide, i) => {
-        slide.setAttribute('data-deck-slide', String(i));
+        slide.setAttribute(`data-deck-slide`, String(i));
       });
 
       const total = this._slides.length || 1;
@@ -345,32 +351,41 @@
       if (this._totalEl) this._totalEl.textContent = String(total);
       this._slides.forEach((slide, i) => {
         const slideStr = pad2(i + 1);
-        slide.querySelectorAll('[data-deck-slide-fill]').forEach((el) => {
+        slide.querySelectorAll(`[data-deck-slide-fill]`).forEach(el => {
           el.textContent = slideStr;
         });
-        slide.querySelectorAll('[data-deck-total-fill]').forEach((el) => {
+        slide.querySelectorAll(`[data-deck-total-fill]`).forEach(el => {
           el.textContent = totalStr;
         });
       });
-      if (this._index >= this._slides.length) this._index = Math.max(0, this._slides.length - 1);
-    }
-
-    _restoreIndex() {
-      const h = (location.hash || '').match(/^#(\d+)$/);
-      if (h) {
-        const n = parseInt(h[1], 10) - 1;
-        if (n >= 0 && n < this._slides.length) this._index = n;
+      if (this._index >= this._slides.length) {
+        this._index = Math.max(0, this._slides.length - 1);
       }
     }
 
-    _applyIndex({ showOverlay = true, broadcast = true, reason = 'init' } = {}) {
+    _restoreIndex() {
+      const h = (location.hash || ``).match(/^#(\d+)$/);
+      if (h) {
+        const n = parseInt(h[1], 10) - 1;
+        if (n >= 0 && n < this._slides.length) {
+          this._index = n;
+        }
+      }
+    }
+
+    _applyIndex({showOverlay = true, broadcast = true, reason = `init`} = {}) {
       if (!this._slides.length) return;
       const prev = this._prevIndex == null ? -1 : this._prevIndex;
       const curr = this._index;
-      try { history.replaceState(null, '', '#' + (curr + 1)); } catch (e) {}
+      try {
+        history.replaceState(null, ``, `#${curr + 1}`);
+      } catch {}
       this._slides.forEach((s, i) => {
-        if (i === curr) s.setAttribute('data-deck-active', '');
-        else s.removeAttribute('data-deck-active');
+        if (i === curr) {
+          s.setAttribute(`data-deck-active`, ``);
+        } else {
+          s.removeAttribute(`data-deck-active`);
+        }
       });
       if (this._countEl) this._countEl.textContent = String(curr + 1);
 
@@ -383,7 +398,7 @@
           previousSlide: prev >= 0 ? (this._slides[prev] || null) : null,
           reason,
         };
-        this.dispatchEvent(new CustomEvent('slidechange', {
+        this.dispatchEvent(new CustomEvent(`slidechange`, {
           detail,
           bubbles: true,
           composed: true,
@@ -391,25 +406,31 @@
       }
 
       this._prevIndex = curr;
-      if (showOverlay) this._flashOverlay();
+      if (showOverlay) {
+        this._flashOverlay();
+      }
     }
 
     _flashOverlay() {
       if (!this._overlay) return;
       if (this._isPresenting) return;
-      this._overlay.setAttribute('data-visible', '');
+      this._overlay.setAttribute(`data-visible`, ``);
       if (this._hideTimer) clearTimeout(this._hideTimer);
       this._hideTimer = setTimeout(() => {
-        this._overlay.removeAttribute('data-visible');
+        this._overlay.removeAttribute(`data-visible`);
       }, OVERLAY_HIDE_MS);
     }
 
     _togglePresent() {
       if (document.fullscreenElement) {
-        if (document.exitFullscreen) document.exitFullscreen().catch(() => {});
+        if (document.exitFullscreen) {
+          document.exitFullscreen().catch(() => {});
+        }
       } else {
         const el = document.documentElement;
-        if (el && el.requestFullscreen) el.requestFullscreen().catch(() => {});
+        if (el && el.requestFullscreen) {
+          el.requestFullscreen().catch(() => {});
+        }
       }
     }
 
@@ -417,7 +438,7 @@
       this._isPresenting = !!document.fullscreenElement;
       if (!this._overlay) return;
       if (this._isPresenting) {
-        this._overlay.removeAttribute('data-visible');
+        this._overlay.removeAttribute(`data-visible`);
         if (this._hideTimer) {
           clearTimeout(this._hideTimer);
           this._hideTimer = null;
@@ -427,8 +448,8 @@
 
     _fit() {
       if (!this._canvas) return;
-      if (this.hasAttribute('noscale')) {
-        this._canvas.style.transform = 'none';
+      if (this.hasAttribute(`noscale`)) {
+        this._canvas.style.transform = `none`;
         return;
       }
       const vw = window.innerWidth;
@@ -437,7 +458,9 @@
       this._canvas.style.transform = `scale(${s})`;
     }
 
-    _onResize() { this._fit(); }
+    _onResize() {
+      this._fit();
+    }
 
     _onMouseMove() {
       this._flashOverlay();
@@ -445,12 +468,12 @@
 
     _onTapBack(e) {
       e.preventDefault();
-      this._go(this._index - 1, 'tap');
+      this._go(this._index - 1, `tap`);
     }
 
     _onTapForward(e) {
       e.preventDefault();
-      this._go(this._index + 1, 'tap');
+      this._go(this._index + 1, `tap`);
     }
 
     _onKey(e) {
@@ -461,21 +484,23 @@
       const key = e.key;
       let handled = true;
 
-      if (key === 'ArrowRight' || key === 'PageDown' || key === ' ' || key === 'Spacebar') {
-        this._go(this._index + 1, 'keyboard');
-      } else if (key === 'ArrowLeft' || key === 'PageUp') {
-        this._go(this._index - 1, 'keyboard');
-      } else if (key === 'Home') {
-        this._go(0, 'keyboard');
-      } else if (key === 'End') {
-        this._go(this._slides.length - 1, 'keyboard');
-      } else if (key === 'r' || key === 'R') {
-        this._go(0, 'keyboard');
-      } else if (key === 'p' || key === 'P') {
+      if (key === `ArrowRight` || key === `PageDown` || key === ` ` || key === `Spacebar`) {
+        this._go(this._index + 1, `keyboard`);
+      } else if (key === `ArrowLeft` || key === `PageUp`) {
+        this._go(this._index - 1, `keyboard`);
+      } else if (key === `Home`) {
+        this._go(0, `keyboard`);
+      } else if (key === `End`) {
+        this._go(this._slides.length - 1, `keyboard`);
+      } else if (key === `r` || key === `R`) {
+        this._go(0, `keyboard`);
+      } else if (key === `p` || key === `P`) {
         this._togglePresent();
       } else if (/^[0-9]$/.test(key)) {
-        const n = key === '0' ? 9 : parseInt(key, 10) - 1;
-        if (n < this._slides.length) this._go(n, 'keyboard');
+        const n = key === `0` ? 9 : parseInt(key, 10) - 1;
+        if (n < this._slides.length) {
+          this._go(n, `keyboard`);
+        }
       } else {
         handled = false;
       }
@@ -486,7 +511,7 @@
       }
     }
 
-    _go(i, reason = 'api') {
+    _go(i, reason = `api`) {
       if (!this._slides.length) return;
       const clamped = Math.max(0, Math.min(this._slides.length - 1, i));
       if (clamped === this._index) {
@@ -494,18 +519,30 @@
         return;
       }
       this._index = clamped;
-      this._applyIndex({ showOverlay: true, broadcast: true, reason });
+      this._applyIndex({showOverlay: true, broadcast: true, reason});
     }
 
-    get index() { return this._index; }
-    get length() { return this._slides.length; }
-    goTo(i) { this._go(i, 'api'); }
-    next() { this._go(this._index + 1, 'api'); }
-    prev() { this._go(this._index - 1, 'api'); }
-    reset() { this._go(0, 'api'); }
+    get index() {
+      return this._index;
+    }
+    get length() {
+      return this._slides.length;
+    }
+    goTo(i) {
+      this._go(i, `api`);
+    }
+    next() {
+      this._go(this._index + 1, `api`);
+    }
+    prev() {
+      this._go(this._index - 1, `api`);
+    }
+    reset() {
+      this._go(0, `api`);
+    }
   }
 
-  if (!customElements.get('deck-stage')) {
-    customElements.define('deck-stage', DeckStage);
+  if (!customElements.get(`deck-stage`)) {
+    customElements.define(`deck-stage`, DeckStage);
   }
 })();

--- a/website/public/docs/docs.js
+++ b/website/public/docs/docs.js
@@ -108,17 +108,6 @@
     btn.setAttribute(`aria-label`, `Copy code`);
     btn.innerHTML = `<svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.4"><rect x="3" y="3" width="7" height="7" rx="1"/><path d="M2 8V2h6" opacity="0.6"/></svg>`;
     btn.addEventListener(`click`, () => {
-      // Strip '$ ' prompt + '# ' from terminal, else raw text
-      const text = Array.from(el.querySelectorAll(`.term-line, pre code, pre`))
-        .map(line => {
-          if (line.classList && line.classList.contains(`term-line`)) {
-            if (line.classList.contains(`no-prompt`) || line.classList.contains(`out`)) return line.textContent;
-            if (line.classList.contains(`comment`)) return `# ${line.textContent}`;
-            return `$ ${line.textContent}`;
-          }
-          return line.textContent;
-        })
-        .join(`\n`) || el.textContent;
       const toCopy = el.classList.contains(`terminal`)
         ? Array.from(el.querySelectorAll(`.term-line`))
           .filter(l => !l.classList.contains(`out`) && !l.classList.contains(`comment`))
@@ -154,5 +143,4 @@
     window.addEventListener(`scroll`, onScroll, {passive: true});
     onScroll();
   }
-
 })();

--- a/website/public/quiz.js
+++ b/website/public/quiz.js
@@ -20,48 +20,42 @@ function shuffle(arr) {
 }
 
 function slugToIndex(slug) {
-  return QUESTIONS.findIndex(function(q) { return q.slug === slug; });
+  return QUESTIONS.findIndex(q => {
+    return q.slug === slug;
+  });
 }
 
 function buildOrder() {
-  var hash = (location.hash || '').replace(/^#/, '').trim();
-  var allIdx = QUESTIONS.map(function(_, i) { return i; });
+  var hash = (location.hash || ``).replace(/^#/, ``).trim();
+  var allIdx = QUESTIONS.map((_, i) => {
+    return i;
+  });
   if (hash) {
     var startIdx = slugToIndex(hash);
     if (startIdx >= 0) {
       state.startedFromSlug = hash;
-      var rest = shuffle(allIdx.filter(function(i) { return i !== startIdx; }));
+      var rest = shuffle(allIdx.filter(i => {
+        return i !== startIdx;
+      }));
       return [startIdx].concat(rest);
     }
   }
   return allIdx;
 }
 
-function showToast(msg) {
-  var el = document.getElementById('toast');
-  if (!el) {
-    el = document.createElement('div');
-    el.id = 'toast';
-    el.className = 'toast';
-    document.body.appendChild(el);
-  }
-  el.textContent = msg;
-  el.classList.add('show');
-  clearTimeout(showToast._t);
-  showToast._t = setTimeout(function() { el.classList.remove('show'); }, 1800);
-}
-
 function copyToClipboard(text) {
-  if (navigator.clipboard && navigator.clipboard.writeText) {
+  if (navigator.clipboard && navigator.clipboard.writeText)
     return navigator.clipboard.writeText(text);
-  }
-  var ta = document.createElement('textarea');
+
+  var ta = document.createElement(`textarea`);
   ta.value = text;
-  ta.style.position = 'fixed';
-  ta.style.opacity = '0';
+  ta.style.position = `fixed`;
+  ta.style.opacity = `0`;
   document.body.appendChild(ta);
   ta.select();
-  try { document.execCommand('copy'); } catch (e) {}
+  try {
+    document.execCommand(`copy`);
+  } catch {}
   document.body.removeChild(ta);
   return Promise.resolve();
 }
@@ -78,10 +72,10 @@ function updateProgress() {
   progressTotal.textContent = total;
   scoreNum.textContent = correct;
   var pct = (answered / total) * 100;
-  progressFill.style.width = pct + '%';
+  progressFill.style.width = `${pct}%`;
   if (shell) {
     var started = answered > 0 || state.cursor > 0;
-    shell.classList.toggle('compact', started);
+    shell.classList.toggle(`compact`, started);
   }
 }
 
@@ -93,37 +87,37 @@ function renderQuestion() {
     return;
   }
   var q = QUESTIONS[state.order[state.cursor]];
-  history.replaceState(null, '', '#' + q.slug);
+  history.replaceState(null, ``, `#${q.slug}`);
 
   var already = state.answers[q.slug];
 
-  var content = document.createElement('div');
-  content.className = 'quiz-stage';
+  var content = document.createElement(`div`);
+  content.className = `quiz-stage`;
   content.innerHTML =
-    '<div class="q-head">' +
-      '<div class="q-prompt-col">' +
-        '<div class="q-number">Question ' + (state.cursor + 1) + ' of ' + total + '</div>' +
-        '<h2 class="q-prompt">' + q.question + '</h2>' +
-      '</div>' +
-      '<div class="q-answers" role="group" aria-label="Answer">' +
-        '<button class="q-btn" data-answer="true">' +
-          '<span>Yes</span>' +
-          answerIcons() +
-        '</button>' +
-        '<button class="q-btn" data-answer="false">' +
-          '<span>No</span>' +
-          answerIcons() +
-        '</button>' +
-      '</div>' +
-    '</div>' +
-    '<div class="q-reveal" id="reveal" aria-live="polite"></div>';
+    `<div class="q-head">` +
+      `<div class="q-prompt-col">` +
+        `<div class="q-number">Question ${state.cursor + 1} of ${total}</div>` +
+        `<h2 class="q-prompt">${q.question}</h2>` +
+      `</div>` +
+      `<div class="q-answers" role="group" aria-label="Answer">` +
+        `<button class="q-btn" data-answer="true">` +
+          `<span>Yes</span>${
+            answerIcons()
+          }</button>` +
+        `<button class="q-btn" data-answer="false">` +
+          `<span>No</span>${
+            answerIcons()
+          }</button>` +
+      `</div>` +
+    `</div>` +
+    `<div class="q-reveal" id="reveal" aria-live="polite"></div>`;
   stage.replaceChildren(content);
 
-  var buttons = content.querySelectorAll('.q-btn');
-  buttons.forEach(function(btn) {
-    btn.addEventListener('click', function() {
-      btn.classList.add('pulse');
-      handleAnswer(q, btn.dataset.answer === 'true');
+  var buttons = content.querySelectorAll(`.q-btn`);
+  buttons.forEach(btn => {
+    btn.addEventListener(`click`, () => {
+      btn.classList.add(`pulse`);
+      handleAnswer(q, btn.dataset.answer === `true`);
     });
   });
 
@@ -133,157 +127,168 @@ function renderQuestion() {
 }
 
 function answerIcons() {
-  return '<svg class="q-icon q-icon-check" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 10.5 8.5 15 16 6"/></svg>' +
-    '<svg class="q-icon q-icon-cross" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 5 15 15M15 5 5 15"/></svg>';
+  return `<svg class="q-icon q-icon-check" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 10.5 8.5 15 16 6"/></svg>` +
+    `<svg class="q-icon q-icon-cross" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 5 15 15M15 5 5 15"/></svg>`;
 }
 
 function applyAnswerUI(root, q, picked) {
   var correct = picked === q.answer;
-  var buttons = root.querySelectorAll('.q-btn');
-  buttons.forEach(function(b) {
+  var buttons = root.querySelectorAll(`.q-btn`);
+  buttons.forEach(b => {
     b.disabled = true;
-    var btnAnswer = b.dataset.answer === 'true';
+    var btnAnswer = b.dataset.answer === `true`;
     var isPicked = btnAnswer === picked;
     var isCorrectAnswer = btnAnswer === q.answer;
     if (isPicked) {
-      b.classList.add('picked', correct ? 'correct' : 'wrong');
+      b.classList.add(`picked`, correct ? `correct` : `wrong`);
     } else if (isCorrectAnswer) {
-      b.classList.add('revealed-correct');
+      b.classList.add(`revealed-correct`);
     }
   });
 
   var line = correct ? q.rightLine : q.wrongLine;
-  var verdictLabel = correct ? 'Correct' : 'Not quite';
-  var verdictClass = correct ? 'right' : 'wrong';
+  var verdictLabel = correct ? `Correct` : `Not quite`;
+  var verdictClass = correct ? `right` : `wrong`;
 
-  var reveal = root.querySelector('#reveal');
+  var reveal = root.querySelector(`#reveal`);
   reveal.innerHTML =
-    '<div class="q-verdict ' + verdictClass + '">' +
-      dotIcon(verdictClass) +
-      '<span>' + verdictLabel + '</span>' +
-    '</div>' +
-    '<p class="q-verdict-line">' + line + '</p>' +
-    q.explain.map(function(p) { return '<p class="q-explain">' + p + '</p>'; }).join('') +
-    '<div class="q-actions">' +
-      '<button class="q-next" id="next-btn">' +
-        (state.cursor + 1 >= state.order.length ? 'See results' : 'Next question') +
-        ' <svg viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M3 7h8M8 4l3 3-3 3"/></svg>' +
-      '</button>' +
-      '<button class="q-share" id="share-btn" aria-label="Copy link to this question">' +
-        '<svg viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M5.5 8.5 L8.5 5.5 M6 4h2.5a2 2 0 0 1 0 4H7 M7 10H5.5a2 2 0 0 1 0-4H6"/></svg>' +
-        '<span id="share-label">Share question</span>' +
-      '</button>' +
-    '</div>';
-  reveal.classList.add('open');
+    `<div class="q-verdict ${verdictClass}">${
+      dotIcon(verdictClass)
+    }<span>${verdictLabel}</span>` +
+    `</div>` +
+    `<p class="q-verdict-line">${line}</p>${
+      q.explain.map(p => {
+        return `<p class="q-explain">${p}</p>`;
+      }).join(``)
+    }<div class="q-actions">` +
+      `<button class="q-next" id="next-btn">${
+        state.cursor + 1 >= state.order.length ? `See results` : `Next question`
+      } <svg viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M3 7h8M8 4l3 3-3 3"/></svg>` +
+      `</button>` +
+      `<button class="q-share" id="share-btn" aria-label="Copy link to this question">` +
+        `<svg viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M5.5 8.5 L8.5 5.5 M6 4h2.5a2 2 0 0 1 0 4H7 M7 10H5.5a2 2 0 0 1 0-4H6"/></svg>` +
+        `<span id="share-label">Share question</span>` +
+      `</button>` +
+    `</div>`;
+  reveal.classList.add(`open`);
 
-  reveal.querySelector('#next-btn').addEventListener('click', advance);
-  var shareBtn = reveal.querySelector('#share-btn');
-  shareBtn.addEventListener('click', function() {
-    var url = location.origin + location.pathname + '#' + q.slug;
-    copyToClipboard(url).then(function() {
-      shareBtn.classList.add('copied');
-      reveal.querySelector('#share-label').textContent = 'Link copied';
-      setTimeout(function() {
-        shareBtn.classList.remove('copied');
-        var lbl = reveal.querySelector('#share-label');
-        if (lbl) lbl.textContent = 'Share question';
+  reveal.querySelector(`#next-btn`).addEventListener(`click`, advance);
+  var shareBtn = reveal.querySelector(`#share-btn`);
+  shareBtn.addEventListener(`click`, () => {
+    var url = `${location.origin + location.pathname}#${q.slug}`;
+    copyToClipboard(url).then(() => {
+      shareBtn.classList.add(`copied`);
+      reveal.querySelector(`#share-label`).textContent = `Link copied`;
+      setTimeout(() => {
+        shareBtn.classList.remove(`copied`);
+        var lbl = reveal.querySelector(`#share-label`);
+        if (lbl) {
+          lbl.textContent = `Share question`;
+        }
       }, 1800);
     });
   });
 }
 
 function dotIcon(kind) {
-  var color = kind === 'right' ? 'var(--accent)' : 'var(--fg-mute)';
-  return '<span style="display:inline-block;width:7px;height:7px;border-radius:50%;background:' + color + '"></span>';
+  var color = kind === `right` ? `var(--accent)` : `var(--fg-mute)`;
+  return `<span style="display:inline-block;width:7px;height:7px;border-radius:50%;background:${color}"></span>`;
 }
 
 function handleAnswer(q, picked) {
   if (state.answers[q.slug]) return;
   var correct = picked === q.answer;
-  state.answers[q.slug] = { picked: picked, correct: correct };
+  state.answers[q.slug] = {picked, correct};
   updateProgress();
-  applyAnswerUI(stage.querySelector('.quiz-stage'), q, picked);
+  applyAnswerUI(stage.querySelector(`.quiz-stage`), q, picked);
 }
 
 function advance() {
   state.cursor += 1;
   renderQuestion();
-  requestAnimationFrame(function() {
-    window.scrollTo({ top: 0, behavior: 'smooth' });
+  requestAnimationFrame(() => {
+    window.scrollTo({top: 0, behavior: `smooth`});
   });
 }
 
 /* ────────── End screen ────────── */
 function renderEnd() {
-  history.replaceState(null, '', '#results');
+  history.replaceState(null, ``, `#results`);
   var total = state.order.length;
   var correct = 0;
   for (var k in state.answers) if (state.answers[k].correct) correct++;
   var level = LEVELS[0];
   for (var i = LEVELS.length - 1; i >= 0; i--) {
-    if (correct >= LEVELS[i].min) { level = LEVELS[i]; break; }
+    if (correct >= LEVELS[i].min) {
+      level = LEVELS[i]; break;
+    }
   }
 
-  var recap = state.order.map(function(idx) {
+
+  var recap = state.order.map(idx => {
     var q = QUESTIONS[idx];
     var a = state.answers[q.slug];
-    return '<a class="recap-row" href="#' + q.slug + '" data-slug="' + q.slug + '">' +
-      '<span class="recap-dot ' + (a && a.correct ? 'right' : '') + '"></span>' +
-      '<span class="recap-text">' + q.question + '</span>' +
-      '<svg class="recap-arrow" width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M3 7h8M8 4l3 3-3 3"/></svg>' +
-    '</a>';
-  }).join('');
+    return `<a class="recap-row" href="#${q.slug}" data-slug="${q.slug}">` +
+      `<span class="recap-dot ${a && a.correct ? `right` : ``}"></span>` +
+      `<span class="recap-text">${q.question}</span>` +
+      `<svg class="recap-arrow" width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M3 7h8M8 4l3 3-3 3"/></svg>` +
+    `</a>`;
+  }).join(``);
 
-  var content = document.createElement('div');
-  content.className = 'quiz-stage';
+  var content = document.createElement(`div`);
+  content.className = `quiz-stage`;
   content.innerHTML =
-    '<div class="end-screen">' +
-      '<div class="end-level-label">Your Yarn level</div>' +
-      '<h2 class="end-level">' + level.title + '</h2>' +
-      '<div class="end-score"><span class="num">' + correct + '</span><span class="total"> / ' + total + ' correct</span></div>' +
-      '<p class="end-tagline">' + level.tag + '</p>' +
-      '<div class="end-actions">' +
-        '<button class="q-next" id="restart-btn">' +
-          'Play again' +
-          ' <svg viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M12 6A5 5 0 1 0 11.5 9.5 M12 3v3h-3"/></svg>' +
-        '</button>' +
-        '<button class="q-share" id="share-score-btn">' +
-          '<svg viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M5.5 8.5 L8.5 5.5 M6 4h2.5a2 2 0 0 1 0 4H7 M7 10H5.5a2 2 0 0 1 0-4H6"/></svg>' +
-          '<span id="share-score-label">Copy shareable link</span>' +
-        '</button>' +
-      '</div>' +
-      '<div class="end-recap">' +
-        '<div class="end-recap-title">Your answers \u2014 tap to revisit a question</div>' +
-        recap +
-      '</div>' +
-    '</div>';
+    `<div class="end-screen">` +
+      `<div class="end-level-label">Your Yarn level</div>` +
+      `<h2 class="end-level">${level.title}</h2>` +
+      `<div class="end-score"><span class="num">${correct}</span><span class="total"> / ${total} correct</span></div>` +
+      `<p class="end-tagline">${level.tag}</p>` +
+      `<div class="end-actions">` +
+        `<button class="q-next" id="restart-btn">` +
+          `Play again` +
+          ` <svg viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M12 6A5 5 0 1 0 11.5 9.5 M12 3v3h-3"/></svg>` +
+        `</button>` +
+        `<button class="q-share" id="share-score-btn">` +
+          `<svg viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M5.5 8.5 L8.5 5.5 M6 4h2.5a2 2 0 0 1 0 4H7 M7 10H5.5a2 2 0 0 1 0-4H6"/></svg>` +
+          `<span id="share-score-label">Copy shareable link</span>` +
+        `</button>` +
+      `</div>` +
+      `<div class="end-recap">` +
+        `<div class="end-recap-title">Your answers \u2014 tap to revisit a question</div>${
+          recap
+        }</div>` +
+    `</div>`;
   stage.replaceChildren(content);
 
-  document.getElementById('restart-btn').addEventListener('click', restart);
-  var sb = document.getElementById('share-score-btn');
-  sb.addEventListener('click', function() {
+  document.getElementById(`restart-btn`).addEventListener(`click`, restart);
+  var sb = document.getElementById(`share-score-btn`);
+  sb.addEventListener(`click`, () => {
     var url = location.origin + location.pathname;
-    copyToClipboard(url).then(function() {
-      sb.classList.add('copied');
-      document.getElementById('share-score-label').textContent = 'Link copied';
-      setTimeout(function() {
-        sb.classList.remove('copied');
-        var lbl = document.getElementById('share-score-label');
-        if (lbl) lbl.textContent = 'Copy shareable link';
+    copyToClipboard(url).then(() => {
+      sb.classList.add(`copied`);
+      document.getElementById(`share-score-label`).textContent = `Link copied`;
+      setTimeout(() => {
+        sb.classList.remove(`copied`);
+        var lbl = document.getElementById(`share-score-label`);
+        if (lbl) {
+          lbl.textContent = `Copy shareable link`;
+        }
       }, 1800);
     });
   });
 
-  content.querySelectorAll('.recap-row').forEach(function(row) {
-    row.addEventListener('click', function(e) {
+  content.querySelectorAll(`.recap-row`).forEach(row => {
+    row.addEventListener(`click`, e => {
       e.preventDefault();
       var slug = row.dataset.slug;
-      var pos = state.order.findIndex(function(i) { return QUESTIONS[i].slug === slug; });
+      var pos = state.order.findIndex(i => {
+        return QUESTIONS[i].slug === slug;
+      });
       if (pos >= 0) {
         state.cursor = pos;
         renderQuestion();
-        requestAnimationFrame(function() {
-          window.scrollTo({ top: 0, behavior: 'smooth' });
+        requestAnimationFrame(() => {
+          window.scrollTo({top: 0, behavior: `smooth`});
         });
       }
     });
@@ -293,26 +298,28 @@ function renderEnd() {
 function restart() {
   state.answers = {};
   state.cursor = 0;
-  state.order = shuffle(QUESTIONS.map(function(_, i) { return i; }));
-  history.replaceState(null, '', location.pathname);
+  state.order = shuffle(QUESTIONS.map((_, i) => {
+    return i;
+  }));
+  history.replaceState(null, ``, location.pathname);
   renderQuestion();
-  requestAnimationFrame(function() {
-    window.scrollTo({ top: 0, behavior: 'smooth' });
+  requestAnimationFrame(() => {
+    window.scrollTo({top: 0, behavior: `smooth`});
   });
 }
 
 /* ────────── Init ────────── */
 function quizInit() {
-  stage = document.getElementById('stage');
-  shell = document.querySelector('.quiz-shell');
-  progressFill = document.getElementById('progress-fill');
-  progressNum = document.getElementById('progress-num');
-  scoreNum = document.getElementById('score-num');
-  progressTotal = document.getElementById('progress-total');
+  stage = document.getElementById(`stage`);
+  shell = document.querySelector(`.quiz-shell`);
+  progressFill = document.getElementById(`progress-fill`);
+  progressNum = document.getElementById(`progress-num`);
+  scoreNum = document.getElementById(`score-num`);
+  progressTotal = document.getElementById(`progress-total`);
 
   if (!stage) return;
   state.order = buildOrder();
   renderQuestion();
 }
 
-document.addEventListener('DOMContentLoaded', quizInit);
+document.addEventListener(`DOMContentLoaded`, quizInit);

--- a/website/scripts/generate-og.ts
+++ b/website/scripts/generate-og.ts
@@ -1,8 +1,8 @@
-import {createServer} from 'node:http';
 import {readdirSync, readFileSync, mkdirSync, existsSync} from 'node:fs';
-import {resolve, dirname, relative, extname, join} from 'node:path';
-import {fileURLToPath} from 'node:url';
-import puppeteer from 'puppeteer';
+import {createServer}                                     from 'node:http';
+import {resolve, dirname, relative, extname, join}        from 'node:path';
+import {fileURLToPath}                                    from 'node:url';
+import puppeteer                                          from 'puppeteer';
 
 const __dirname = fileURLToPath(new URL(`.`, import.meta.url));
 const distDir = resolve(__dirname, `..`, `dist`);
@@ -11,9 +11,9 @@ const CONCURRENCY = 4;
 const WIDTH = 1200;
 const HEIGHT = 630;
 
-function collectHtmlFiles(dir: string, base: string = dir): string[] {
+function collectHtmlFiles(dir: string, base: string = dir): Array<string> {
   const entries = readdirSync(dir, {withFileTypes: true});
-  const files: string[] = [];
+  const files: Array<string> = [];
 
   for (const entry of entries) {
     const full = join(dir, entry.name);
@@ -21,16 +21,17 @@ function collectHtmlFiles(dir: string, base: string = dir): string[] {
       files.push(...collectHtmlFiles(full, base));
     } else if (entry.name.endsWith(`.html`)) {
       const rel = relative(base, full);
-      if (!rel.startsWith(`presentation/`))
+      if (!rel.startsWith(`presentation/`)) {
         files.push(rel);
+      }
     }
   }
 
   return files;
 }
 
-function startStaticServer(root: string): Promise<{url: string; close: () => void}> {
-  return new Promise((resolve) => {
+function startStaticServer(root: string): Promise<{url: string, close: () => void}> {
+  return new Promise(resolve => {
     const mimeTypes: Record<string, string> = {
       '.html': `text/html`,
       '.css': `text/css`,
@@ -51,8 +52,9 @@ function startStaticServer(root: string): Promise<{url: string; close: () => voi
         const withHtml = filePath.endsWith(`/`)
           ? join(filePath, `index.html`)
           : `${filePath}.html`;
-        if (existsSync(withHtml))
+        if (existsSync(withHtml)) {
           filePath = withHtml;
+        }
       }
 
       if (!existsSync(filePath)) {
@@ -102,8 +104,9 @@ async function run() {
     await page.close();
 
     completed++;
-    if (completed % 10 === 0 || completed === htmlFiles.length)
+    if (completed % 10 === 0 || completed === htmlFiles.length) {
       console.log(`  ${completed}/${htmlFiles.length}`);
+    }
   }
 
   const queue = [...htmlFiles];
@@ -122,7 +125,7 @@ async function run() {
   console.log(`Generated ${completed} OG images in dist/og/`);
 }
 
-run().catch((err) => {
+run().catch(err => {
   console.error(err);
   process.exit(1);
 });

--- a/website/scripts/record-terminal.ts
+++ b/website/scripts/record-terminal.ts
@@ -1,7 +1,7 @@
-import {spawn} from 'node:child_process';
+import {spawn}                    from 'node:child_process';
 import {writeFileSync, mkdirSync} from 'node:fs';
-import {resolve, dirname} from 'node:path';
-import {platform} from 'node:os';
+import {platform}                 from 'node:os';
+import {resolve, dirname}         from 'node:path';
 
 const SGR_MAP: Record<number, string | null> = {
   0: null,
@@ -28,22 +28,24 @@ function ansiToHtml(line: string): string {
 
   while ((m = re.exec(line)) !== null) {
     const text = line.slice(last, m.index);
-    if (text) {
+    if (text)
       parts.push(cls ? `<span class="${cls}">${escapeHtml(text)}</span>` : escapeHtml(text));
-    }
+
+
     last = m.index + m[0].length;
 
     const codes = m[1] ? m[1].split(`;`).map(Number) : [0];
     for (const code of codes) {
-      if (code in SGR_MAP)
+      if (code in SGR_MAP) {
         cls = SGR_MAP[code];
+      }
     }
   }
 
   const tail = line.slice(last);
-  if (tail) {
+  if (tail)
     parts.push(cls ? `<span class="${cls}">${escapeHtml(tail)}</span>` : escapeHtml(tail));
-  }
+
 
   return parts.join(``);
 }
@@ -76,7 +78,7 @@ const args = process.argv.slice(ddIdx + 1);
 const cmd = args[0];
 const cmdArgs = args.slice(1);
 
-type Entry = {html: string; delay: number; clear?: number};
+type Entry = {html: string, delay: number, clear?: number};
 const entries: Array<Entry> = [];
 
 entries.push({
@@ -84,7 +86,7 @@ entries.push({
   delay: 0,
 });
 
-const env = {...process.env, FORCE_COLOR: `3`, CLICOLOR_FORCE: `1`};
+const env: Record<string, string | undefined> = {...process.env, FORCE_COLOR: `3`, CLICOLOR_FORCE: `1`};
 delete env.NO_COLOR;
 
 let spawnCmd: string;
@@ -173,7 +175,7 @@ child.on(`close`, () => {
     entries.push(entry);
   }
 
-  const json = JSON.stringify(entries, null, 2) + `\n`;
+  const json = `${JSON.stringify(entries, null, 2)}\n`;
 
   if (terminalId) {
     const outPath = resolve(import.meta.dirname!, `../src/data/terminals/${terminalId}.json`);

--- a/website/src/components/SearchModal.tsx
+++ b/website/src/components/SearchModal.tsx
@@ -1,5 +1,5 @@
+import octIconData                                          from '@iconify-json/octicon/icons.json';
 import {liteClient as algoliasearch}                        from 'algoliasearch/lite';
-import octIconData                                           from '@iconify-json/octicon/icons.json';
 import {useState, useEffect, useRef, useCallback, type JSX} from 'react';
 
 const docsClient = algoliasearch(`STXW7VT1S5`, `ecdfaea128fd901572b14543a2116eee`);
@@ -11,7 +11,7 @@ function octicon(name: string, size: number, className?: string) {
   const w = icon.width ?? 16;
   const h = icon.height ?? 16;
   return (
-    <svg width={size} height={size} viewBox={`0 0 ${w} ${h}`} fill="currentColor" aria-hidden="true" className={className}
+    <svg width={size} height={size} viewBox={`0 0 ${w} ${h}`} fill={`currentColor`} aria-hidden={`true`} className={className}
       dangerouslySetInnerHTML={{__html: icon.body}}/>
   );
 }
@@ -50,7 +50,7 @@ function ClockIcon() {
 
 function FlameIcon({color}: {color: string}) {
   return (
-    <span style={{color}} className="shrink-0 inline-flex">
+    <span style={{color}} className={`shrink-0 inline-flex`}>
       {octicon(`flame-16`, 10)}
     </span>
   );
@@ -98,7 +98,9 @@ const RECENTS_KEY = `yarn-search-recents`;
 function getRecents(): Array<{term: string, kind: string}> {
   try {
     const raw = localStorage.getItem(RECENTS_KEY);
-    if (raw) return JSON.parse(raw);
+    if (raw) {
+      return JSON.parse(raw);
+    }
   } catch {}
   return [];
 }
@@ -106,7 +108,9 @@ function getRecents(): Array<{term: string, kind: string}> {
 function addRecent(term: string, kind: string) {
   const recents = getRecents().filter(r => r.term !== term);
   recents.unshift({term, kind});
-  if (recents.length > 5) recents.length = 5;
+  if (recents.length > 5)
+    recents.length = 5;
+
   try {
     localStorage.setItem(RECENTS_KEY, JSON.stringify(recents));
   } catch {}
@@ -132,7 +136,7 @@ function getFlameColor(downloadsRaw?: number): string | null {
 function looksLikePackage(q: string): boolean {
   const t = q.trim();
   if (!t) return false;
-  return /^@?[a-z0-9][\w.\-]*(?:\/[a-z0-9][\w.\-]*)?$/i.test(t);
+  return /^@?[a-z0-9][\w.-]*(?:\/[a-z0-9][\w.-]*)?$/i.test(t);
 }
 
 interface ResultGroup {
@@ -153,14 +157,28 @@ function groupResults(results: Array<SearchItem>, scope: Scope, query: string): 
     if (looksLikePackage(query)) {
       const hotPkgs = pkgs.filter(r => getFlameColor(r.downloadsRaw) != null).slice(0, 2);
       const restPkgs = pkgs.filter(r => !hotPkgs.includes(r));
-      if (hotPkgs.length) groups.push({kind: `pkg`, label: `Popular packages`, items: hotPkgs});
-      if (docs.length) groups.push({kind: `docs`, label: KIND_LABELS.docs, items: docs});
-      if (cli.length) groups.push({kind: `cli`, label: KIND_LABELS.cli, items: cli});
-      if (restPkgs.length) groups.push({kind: `pkg`, label: KIND_LABELS.pkg, items: restPkgs});
+      if (hotPkgs.length)
+        groups.push({kind: `pkg`, label: `Popular packages`, items: hotPkgs});
+
+      if (docs.length)
+        groups.push({kind: `docs`, label: KIND_LABELS.docs, items: docs});
+
+      if (cli.length)
+        groups.push({kind: `cli`, label: KIND_LABELS.cli, items: cli});
+
+      if (restPkgs.length) {
+        groups.push({kind: `pkg`, label: KIND_LABELS.pkg, items: restPkgs});
+      }
     } else {
-      if (docs.length) groups.push({kind: `docs`, label: KIND_LABELS.docs, items: docs});
-      if (pkgs.length) groups.push({kind: `pkg`, label: KIND_LABELS.pkg, items: pkgs});
-      if (cli.length) groups.push({kind: `cli`, label: KIND_LABELS.cli, items: cli});
+      if (docs.length)
+        groups.push({kind: `docs`, label: KIND_LABELS.docs, items: docs});
+
+      if (pkgs.length)
+        groups.push({kind: `pkg`, label: KIND_LABELS.pkg, items: pkgs});
+
+      if (cli.length) {
+        groups.push({kind: `cli`, label: KIND_LABELS.cli, items: cli});
+      }
     }
   } else if (filtered.length) {
     groups.push({kind: scope as ResultKind, label: KIND_LABELS[scope as ResultKind], items: filtered});
@@ -177,7 +195,7 @@ function flattenGroups(groups: Array<ResultGroup>): Array<SearchItem> {
 
 function Kbd({children}: {children: React.ReactNode}) {
   return (
-    <kbd className="mono text-[10px] text-[var(--fg-dim)] bg-[color-mix(in_oklch,var(--fg)_5%,transparent)] border border-[var(--line-strong)] border-b-2 px-1.5 py-0.5 rounded-[4px] min-w-[18px] text-center">
+    <kbd className={`mono text-[10px] text-[var(--fg-dim)] bg-[color-mix(in_oklch,var(--fg)_5%,transparent)] border border-[var(--line-strong)] border-b-2 px-1.5 py-0.5 rounded-[4px] min-w-[18px] text-center`}>
       {children}
     </kbd>
   );
@@ -186,7 +204,7 @@ function Kbd({children}: {children: React.ReactNode}) {
 function ScopeChip({scope, active, count, onClick}: {scope: Scope, active: boolean, count: number, onClick: () => void}) {
   return (
     <button
-      role="tab"
+      role={`tab`}
       aria-selected={active}
       onClick={onClick}
       className={`font-sans text-xs bg-transparent border rounded-full px-2.5 py-1 cursor-pointer inline-flex items-center gap-1.5 transition-colors ${
@@ -207,7 +225,7 @@ function ScopeChip({scope, active, count, onClick}: {scope: Scope, active: boole
 
 function ResultGlyph({kind}: {kind: ResultKind}) {
   return (
-    <span className="w-8 h-8 border border-[var(--line-strong)] rounded-lg inline-flex items-center justify-center text-[var(--fg-dim)] bg-[color-mix(in_oklch,var(--fg)_3%,transparent)] shrink-0 group-hover:text-[var(--accent)] group-hover:border-[var(--accent-line)] group-hover:bg-[var(--accent-soft)] group-[.active]:text-[var(--accent)] group-[.active]:border-[var(--accent-line)] group-[.active]:bg-[var(--accent-soft)]">
+    <span className={`w-8 h-8 border border-[var(--line-strong)] rounded-lg inline-flex items-center justify-center text-[var(--fg-dim)] bg-[color-mix(in_oklch,var(--fg)_3%,transparent)] shrink-0 group-hover:text-[var(--accent)] group-hover:border-[var(--accent-line)] group-hover:bg-[var(--accent-soft)] group-[.active]:text-[var(--accent)] group-[.active]:border-[var(--accent-line)] group-[.active]:bg-[var(--accent-soft)]`}>
       {KIND_GLYPHS[kind]}
     </span>
   );
@@ -215,9 +233,9 @@ function ResultGlyph({kind}: {kind: ResultKind}) {
 
 function Crumbs({crumbs, separator = `›`}: {crumbs: Array<string>, separator?: string}) {
   return (
-    <span className="mono text-[10.5px] text-[var(--fg-mute)] tracking-[0.02em] whitespace-nowrap overflow-hidden text-ellipsis">
+    <span className={`mono text-[10.5px] text-[var(--fg-mute)] tracking-[0.02em] whitespace-nowrap overflow-hidden text-ellipsis`}>
       {crumbs.map((c, i) => (
-        <span key={i}>{i > 0 && <span className="opacity-40 px-1">{separator}</span>}{c}</span>
+        <span key={i}>{i > 0 && <span className={`opacity-40 px-1`}>{separator}</span>}{c}</span>
       ))}
     </span>
   );
@@ -225,10 +243,10 @@ function Crumbs({crumbs, separator = `›`}: {crumbs: Array<string>, separator?:
 
 function GroupHeader({label, count}: {label: string, count: number}) {
   return (
-    <div className="flex items-center gap-2.5 px-5 pt-3.5 pb-1.5 mono text-[10.5px] text-[var(--fg-mute)] tracking-[0.12em] uppercase">
+    <div className={`flex items-center gap-2.5 px-5 pt-3.5 pb-1.5 mono text-[10.5px] text-[var(--fg-mute)] tracking-[0.12em] uppercase`}>
       <span>{label}</span>
-      <span className="flex-1 h-px bg-[var(--line)]"/>
-      <span className="tabular-nums tracking-[0.04em]">{count}</span>
+      <span className={`flex-1 h-px bg-[var(--line)]`}/>
+      <span className={`tabular-nums tracking-[0.04em]`}>{count}</span>
     </div>
   );
 }
@@ -241,21 +259,23 @@ function DocResultRow({item, isActive, onMouseEnter, onClick}: {item: SearchItem
       } hover:bg-[color-mix(in_oklch,var(--fg)_5%,transparent)] hover:border-l-[var(--accent)]`}
       href={item.href}
       onMouseEnter={onMouseEnter}
-      onClick={e => { e.preventDefault(); onClick(); }}
-      role="option"
+      onClick={e => {
+        e.preventDefault(); onClick();
+      }}
+      role={`option`}
       aria-selected={isActive}
     >
       <ResultGlyph kind={item.kind}/>
 
-      <span className="min-w-0">
-        <span className="text-sm text-[var(--fg)] font-medium truncate block" dangerouslySetInnerHTML={{__html: item.titleHtml}}/>
+      <span className={`min-w-0`}>
+        <span className={`text-sm text-[var(--fg)] font-medium truncate block`} dangerouslySetInnerHTML={{__html: item.titleHtml}}/>
 
         {item.snippetHtml && (
-          <span className="search-snippet-clamp text-[12.5px] text-[var(--fg-dim)] mt-0.5 leading-[1.45]" dangerouslySetInnerHTML={{__html: item.snippetHtml}}/>
+          <span className={`search-snippet-clamp text-[12.5px] text-[var(--fg-dim)] mt-0.5 leading-[1.45]`} dangerouslySetInnerHTML={{__html: item.snippetHtml}}/>
         )}
       </span>
 
-      <span className="flex flex-col items-end gap-1.5 mono text-[10.5px] text-[var(--fg-mute)] whitespace-nowrap shrink-0">
+      <span className={`flex flex-col items-end gap-1.5 mono text-[10.5px] text-[var(--fg-mute)] whitespace-nowrap shrink-0`}>
         {item.crumbs && item.crumbs.length > 0 && <Crumbs crumbs={item.crumbs}/>}
         <span className={`inline-flex items-center gap-1.5 mono text-[10px] text-[var(--accent)] transition-opacity duration-150 ${isActive ? `opacity-100` : `opacity-0 group-hover:opacity-100`}`}>
           <Kbd>↵</Kbd> open
@@ -275,36 +295,38 @@ function PkgResultRow({item, isActive, onMouseEnter, onClick}: {item: SearchItem
       } hover:bg-[color-mix(in_oklch,var(--fg)_5%,transparent)] hover:border-l-[var(--accent)]`}
       href={item.href}
       onMouseEnter={onMouseEnter}
-      onClick={e => { e.preventDefault(); onClick(); }}
-      role="option"
+      onClick={e => {
+        e.preventDefault(); onClick();
+      }}
+      role={`option`}
       aria-selected={isActive}
     >
-      <ResultGlyph kind="pkg"/>
+      <ResultGlyph kind={`pkg`}/>
 
-      <span className="min-w-0">
-        <div className="flex items-baseline gap-2">
-          <span className="text-sm text-[var(--fg)] font-medium mono truncate" dangerouslySetInnerHTML={{__html: item.titleHtml}}/>
+      <span className={`min-w-0`}>
+        <div className={`flex items-baseline gap-2`}>
+          <span className={`text-sm text-[var(--fg)] font-medium mono truncate`} dangerouslySetInnerHTML={{__html: item.titleHtml}}/>
 
           {item.downloads && flameColor && (
-            <span className="mono text-[10.5px] tabular-nums inline-flex items-center gap-1">
+            <span className={`mono text-[10.5px] tabular-nums inline-flex items-center gap-1`}>
               <FlameIcon color={flameColor}/>
               {item.downloads}
             </span>
           )}
         </div>
 
-        <span className="search-snippet-clamp text-[12.5px] text-[var(--fg-dim)] mt-0.5 leading-[1.45]" dangerouslySetInnerHTML={{__html: item.snippetHtml || ``}}/>
+        <span className={`search-snippet-clamp text-[12.5px] text-[var(--fg-dim)] mt-0.5 leading-[1.45]`} dangerouslySetInnerHTML={{__html: item.snippetHtml || ``}}/>
 
-        <span className="mono text-[10.5px] text-[var(--fg-mute)] tracking-[0.02em] mt-0.5 block">
+        <span className={`mono text-[10.5px] text-[var(--fg-mute)] tracking-[0.02em] mt-0.5 block`}>
           <span>{item.author}</span>
-          <span className="opacity-40 px-1">·</span>
+          <span className={`opacity-40 px-1`}>·</span>
           <span>{item.license}</span>
         </span>
       </span>
 
-      <span className="flex flex-col items-end gap-1.5 mono text-[10.5px] text-[var(--fg-mute)] whitespace-nowrap shrink-0">
+      <span className={`flex flex-col items-end gap-1.5 mono text-[10.5px] text-[var(--fg-mute)] whitespace-nowrap shrink-0`}>
         {item.version && (
-          <span className="bg-[color-mix(in_oklch,var(--fg)_5%,transparent)] border border-[var(--line)] px-[7px] py-0.5 rounded-full text-[var(--fg-dim)]">
+          <span className={`bg-[color-mix(in_oklch,var(--fg)_5%,transparent)] border border-[var(--line)] px-[7px] py-0.5 rounded-full text-[var(--fg-dim)]`}>
             {item.version}
           </span>
         )}
@@ -348,36 +370,36 @@ function EmptyState({onSelect}: {onSelect: (term: string) => void}) {
   const recents = getRecents();
 
   return (
-    <div className="py-2 pb-4">
+    <div className={`py-2 pb-4`}>
       {recents.length > 0 && (
-        <div className="px-5 py-1.5 pb-2.5">
-          <div className="mono text-[10.5px] text-[var(--fg-mute)] tracking-[0.12em] uppercase mb-2">Recent</div>
+        <div className={`px-5 py-1.5 pb-2.5`}>
+          <div className={`mono text-[10.5px] text-[var(--fg-mute)] tracking-[0.12em] uppercase mb-2`}>Recent</div>
           {recents.map((r, i) => (
             <div
               key={i}
               onClick={() => onSelect(r.term)}
-              className="flex items-center gap-2.5 py-2 px-1 rounded-lg cursor-pointer text-[var(--fg-dim)] text-[13.5px] transition-colors hover:text-[var(--fg)] hover:bg-[color-mix(in_oklch,var(--fg)_4%,transparent)] hover:pl-2"
+              className={`flex items-center gap-2.5 py-2 px-1 rounded-lg cursor-pointer text-[var(--fg-dim)] text-[13.5px] transition-colors hover:text-[var(--fg)] hover:bg-[color-mix(in_oklch,var(--fg)_4%,transparent)] hover:pl-2`}
             >
-              <span className="text-[var(--fg-mute)] shrink-0"><ClockIcon/></span>
-              <span className="flex-1">{r.term}</span>
-              <span className="mono text-[10px] text-[var(--fg-mute)] tracking-[0.04em] uppercase">{r.kind}</span>
+              <span className={`text-[var(--fg-mute)] shrink-0`}><ClockIcon/></span>
+              <span className={`flex-1`}>{r.term}</span>
+              <span className={`mono text-[10px] text-[var(--fg-mute)] tracking-[0.04em] uppercase`}>{r.kind}</span>
             </div>
           ))}
         </div>
       )}
 
-      <div className="px-5 py-1.5 pb-2.5">
-        <div className="mono text-[10.5px] text-[var(--fg-mute)] tracking-[0.12em] uppercase mb-2">Suggested</div>
+      <div className={`px-5 py-1.5 pb-2.5`}>
+        <div className={`mono text-[10.5px] text-[var(--fg-mute)] tracking-[0.12em] uppercase mb-2`}>Suggested</div>
 
-        <div className="grid grid-cols-2 gap-2">
+        <div className={`grid grid-cols-2 gap-2`}>
           {SUGGESTED.map((term, i) => (
             <div
               key={i}
               onClick={() => onSelect(term)}
-              className="border border-[var(--line)] rounded-[10px] px-3 py-2.5 bg-[color-mix(in_oklch,var(--fg)_2%,transparent)] cursor-pointer flex items-center gap-2.5 transition-colors hover:border-[var(--accent-line)] hover:bg-[var(--accent-soft)] group"
+              className={`border border-[var(--line)] rounded-[10px] px-3 py-2.5 bg-[color-mix(in_oklch,var(--fg)_2%,transparent)] cursor-pointer flex items-center gap-2.5 transition-colors hover:border-[var(--accent-line)] hover:bg-[var(--accent-soft)] group`}
             >
-              <span className="mono text-[10px] text-[var(--fg-mute)] tracking-[0.08em]">{String(i + 1).padStart(2, `0`)}</span>
-              <span className="text-[13px] text-[var(--fg)] flex-1 group-hover:text-[var(--accent)]">{term}</span>
+              <span className={`mono text-[10px] text-[var(--fg-mute)] tracking-[0.08em]`}>{String(i + 1).padStart(2, `0`)}</span>
+              <span className={`text-[13px] text-[var(--fg)] flex-1 group-hover:text-[var(--accent)]`}>{term}</span>
             </div>
           ))}
         </div>
@@ -388,15 +410,15 @@ function EmptyState({onSelect}: {onSelect: (term: string) => void}) {
 
 function NoResults({query}: {query: string}) {
   return (
-    <div className="py-15 px-5 text-center">
-      <div className="w-11 h-11 border border-[var(--line-strong)] rounded-full inline-flex items-center justify-center text-[var(--fg-mute)] mb-3.5">
+    <div className={`py-15 px-5 text-center`}>
+      <div className={`w-11 h-11 border border-[var(--line-strong)] rounded-full inline-flex items-center justify-center text-[var(--fg-mute)] mb-3.5`}>
         <NoResultsIcon/>
       </div>
 
-      <div className="text-[var(--fg)] text-[15px] mb-1.5">No matches</div>
+      <div className={`text-[var(--fg)] text-[15px] mb-1.5`}>No matches</div>
 
-      <div className="text-[var(--fg-mute)] text-[13px]">
-        Nothing for <span className="text-[var(--fg-dim)] mono">"{query}"</span> in this scope.
+      <div className={`text-[var(--fg-mute)] text-[13px]`}>
+        Nothing for <span className={`text-[var(--fg-dim)] mono`}>"{query}"</span> in this scope.
       </div>
     </div>
   );
@@ -404,16 +426,16 @@ function NoResults({query}: {query: string}) {
 
 function Footer() {
   return (
-    <div className="flex items-center justify-between gap-4 px-4 py-2.5 border-t border-[var(--line)] bg-[color-mix(in_oklch,var(--bg-0)_30%,transparent)] text-[11.5px] text-[var(--fg-mute)]">
-      <div className="flex gap-3.5 items-center flex-wrap">
-        <span className="inline-flex items-center gap-1.5"><Kbd>↵</Kbd> open</span>
-        <span className="inline-flex items-center gap-1.5"><Kbd>↑</Kbd><Kbd>↓</Kbd> navigate</span>
-        <span className="inline-flex items-center gap-1.5"><Kbd>tab</Kbd> filter</span>
-        <span className="inline-flex items-center gap-1.5"><Kbd>esc</Kbd> close</span>
+    <div className={`flex items-center justify-between gap-4 px-4 py-2.5 border-t border-[var(--line)] bg-[color-mix(in_oklch,var(--bg-0)_30%,transparent)] text-[11.5px] text-[var(--fg-mute)]`}>
+      <div className={`flex gap-3.5 items-center flex-wrap`}>
+        <span className={`inline-flex items-center gap-1.5`}><Kbd>↵</Kbd> open</span>
+        <span className={`inline-flex items-center gap-1.5`}><Kbd>↑</Kbd><Kbd>↓</Kbd> navigate</span>
+        <span className={`inline-flex items-center gap-1.5`}><Kbd>tab</Kbd> filter</span>
+        <span className={`inline-flex items-center gap-1.5`}><Kbd>esc</Kbd> close</span>
       </div>
 
-      <span className="inline-flex items-center gap-1.5 mono">
-        <span className="w-1.5 h-1.5 rounded-full bg-[var(--accent)] shadow-[0_0_8px_var(--accent)]"/>
+      <span className={`inline-flex items-center gap-1.5 mono`}>
+        <span className={`w-1.5 h-1.5 rounded-full bg-[var(--accent)] shadow-[0_0_8px_var(--accent)]`}/>
         search by Algolia
       </span>
     </div>
@@ -452,8 +474,11 @@ export default function SearchModal() {
     const handleKeyDown = (e: KeyboardEvent) => {
       if ((e.metaKey || e.ctrlKey) && e.key === `k`) {
         e.preventDefault();
-        if (open) closeModal();
-        else openModal();
+        if (open) {
+          closeModal();
+        } else {
+          openModal();
+        }
       }
     };
     document.addEventListener(`keydown`, handleKeyDown);
@@ -463,7 +488,9 @@ export default function SearchModal() {
   // Wire nav search trigger
   useEffect(() => {
     const trigger = document.querySelector<HTMLElement>(`nav [role="search"]`);
-    if (!trigger) return;
+    if (!trigger)
+      return undefined;
+
 
     const handleClick = (e: Event) => {
       e.preventDefault();
@@ -499,8 +526,8 @@ export default function SearchModal() {
       const [docsResponse, pkgResponse] = await Promise.all([
         docsClient.search([{
           indexName: `yarnpkg_next`,
-          query: q,
           params: {
+            query: q,
             hitsPerPage: 15,
             attributesToHighlight: [`hierarchy.lvl0`, `hierarchy.lvl1`, `hierarchy.lvl2`, `hierarchy.lvl3`, `hierarchy.lvl4`, `hierarchy.lvl5`, `hierarchy.lvl6`, `content`],
             attributesToSnippet: [`content:30`],
@@ -508,8 +535,8 @@ export default function SearchModal() {
         }]),
         pkgClient.search([{
           indexName: `npm-search`,
-          query: q,
           params: {
+            query: q,
             hitsPerPage: 10,
             attributesToRetrieve: [`name`, `version`, `description`, `owner`, `humanDownloadsLast30Days`, `downloadsLast30Days`, `license`],
             attributesToHighlight: [`name`, `description`],
@@ -564,14 +591,18 @@ export default function SearchModal() {
 
   // Debounced search
   useEffect(() => {
-    if (debounceRef.current) clearTimeout(debounceRef.current);
+    if (debounceRef.current)
+      clearTimeout(debounceRef.current);
+
     if (!query.trim()) {
       setResults([]);
-      return;
+      return undefined;
     }
     debounceRef.current = setTimeout(() => search(query), 200);
     return () => {
-      if (debounceRef.current) clearTimeout(debounceRef.current);
+      if (debounceRef.current) {
+        clearTimeout(debounceRef.current);
+      }
     };
   }, [query, search]);
 
@@ -627,33 +658,39 @@ export default function SearchModal() {
 
   return (
     <div
-      className="fixed inset-0 z-200 flex items-start justify-center pt-[10vh] px-5 pb-5 bg-[color-mix(in_oklch,var(--bg-0)_65%,transparent)] backdrop-blur-[12px] backdrop-saturate-[140%]"
-      onClick={e => { if (e.target === e.currentTarget) closeModal(); }}
+      className={`fixed inset-0 z-200 flex items-start justify-center pt-[10vh] px-5 pb-5 bg-[color-mix(in_oklch,var(--bg-0)_65%,transparent)] backdrop-blur-[12px] backdrop-saturate-[140%]`}
+      onClick={e => {
+        if (e.target === e.currentTarget) {
+          closeModal();
+        }
+      }}
     >
       <div
-        className="w-[min(720px,100%)] bg-[color-mix(in_oklch,var(--bg-1)_80%,transparent)] border border-[var(--line-strong)] rounded-2xl shadow-[0_30px_80px_-20px_rgba(0,0,0,0.55),0_0_0_1px_color-mix(in_oklch,var(--accent)_14%,transparent),0_0_60px_-12px_color-mix(in_oklch,var(--accent)_30%,transparent)] backdrop-blur-[20px] backdrop-saturate-[160%] overflow-hidden flex flex-col max-h-[78vh] animate-[searchIn_0.18s_cubic-bezier(0.22,1,0.36,1)]"
-        role="combobox"
-        aria-expanded="true"
+        className={`w-[min(720px,100%)] bg-[color-mix(in_oklch,var(--bg-1)_80%,transparent)] border border-[var(--line-strong)] rounded-2xl shadow-[0_30px_80px_-20px_rgba(0,0,0,0.55),0_0_0_1px_color-mix(in_oklch,var(--accent)_14%,transparent),0_0_60px_-12px_color-mix(in_oklch,var(--accent)_30%,transparent)] backdrop-blur-[20px] backdrop-saturate-[160%] overflow-hidden flex flex-col max-h-[78vh] animate-[searchIn_0.18s_cubic-bezier(0.22,1,0.36,1)]`}
+        role={`combobox`}
+        aria-expanded={`true`}
         onKeyDown={handleKeyDown}
       >
         {/* Header */}
-        <div className="flex items-center gap-3.5 py-3.5 pl-5 pr-4 border-b border-[var(--line)]">
-          <SearchIcon className="text-[var(--fg-mute)] shrink-0"/>
+        <div className={`flex items-center gap-3.5 py-3.5 pl-5 pr-4 border-b border-[var(--line)]`}>
+          <SearchIcon className={`text-[var(--fg-mute)] shrink-0`}/>
 
           <input
             ref={inputRef}
-            type="search"
-            placeholder="Search docs, packages, commands…"
-            autoComplete="off"
+            type={`search`}
+            placeholder={`Search docs, packages, commands…`}
+            autoComplete={`off`}
             spellCheck={false}
             value={query}
             onChange={e => setQuery(e.target.value)}
-            className="flex-1 bg-transparent border-0 outline-0 text-[var(--fg)] font-sans text-[17px] tracking-[-0.005em] py-1 min-w-0 placeholder:text-[var(--fg-mute)]"
+            className={`flex-1 bg-transparent border-0 outline-0 text-[var(--fg)] font-sans text-[17px] tracking-[-0.005em] py-1 min-w-0 placeholder:text-[var(--fg-mute)]`}
           />
           {query && (
             <button
-              onClick={() => { setQuery(``); setResults([]); inputRef.current?.focus(); }}
-              className="bg-transparent border-0 text-[var(--fg-mute)] cursor-pointer w-[22px] h-[22px] rounded-[6px] inline-flex items-center justify-center p-0 transition-colors hover:text-[var(--fg)] hover:bg-[color-mix(in_oklch,var(--fg)_6%,transparent)]"
+              onClick={() => {
+                setQuery(``); setResults([]); inputRef.current?.focus();
+              }}
+              className={`bg-transparent border-0 text-[var(--fg-mute)] cursor-pointer w-[22px] h-[22px] rounded-[6px] inline-flex items-center justify-center p-0 transition-colors hover:text-[var(--fg)] hover:bg-[color-mix(in_oklch,var(--fg)_6%,transparent)]`}
             >
               <CloseIcon/>
             </button>
@@ -661,15 +698,15 @@ export default function SearchModal() {
 
           <button
             onClick={closeModal}
-            className="mono text-[10.5px] text-[var(--fg-mute)] border border-[var(--line-strong)] bg-[color-mix(in_oklch,var(--fg)_4%,transparent)] px-[7px] py-[3px] rounded-[5px] tracking-[0.04em] cursor-pointer transition-colors hover:text-[var(--fg)] hover:border-[var(--fg-mute)]"
+            className={`mono text-[10.5px] text-[var(--fg-mute)] border border-[var(--line-strong)] bg-[color-mix(in_oklch,var(--fg)_4%,transparent)] px-[7px] py-[3px] rounded-[5px] tracking-[0.04em] cursor-pointer transition-colors hover:text-[var(--fg)] hover:border-[var(--fg-mute)]`}
           >
             esc
           </button>
         </div>
 
         {/* Scope chips */}
-        <div className="flex gap-1 px-3.5 py-2.5 border-b border-[var(--line)] items-center" role="tablist">
-          <span className="mono text-[10.5px] text-[var(--fg-mute)] tracking-[0.1em] uppercase mr-2">scope</span>
+        <div className={`flex gap-1 px-3.5 py-2.5 border-b border-[var(--line)] items-center`} role={`tablist`}>
+          <span className={`mono text-[10.5px] text-[var(--fg-mute)] tracking-[0.1em] uppercase mr-2`}>scope</span>
 
           {SCOPES.map(s => (
             <ScopeChip
@@ -677,17 +714,19 @@ export default function SearchModal() {
               scope={s.key}
               active={scope === s.key}
               count={counts[s.key]}
-              onClick={() => { setScope(s.key); setActiveIdx(0); }}
+              onClick={() => {
+                setScope(s.key); setActiveIdx(0);
+              }}
             />
           ))}
         </div>
 
         {/* Results */}
-        <div className="flex-1 overflow-y-auto py-2 pb-1 search-results-scroll" ref={resultsRef} role="listbox">
+        <div className={`flex-1 overflow-y-auto py-2 pb-1 search-results-scroll`} ref={resultsRef} role={`listbox`}>
           {query.trim() === `` ? (
             <EmptyState onSelect={handleSelect}/>
           ) : loading && results.length === 0 ? (
-            <div className="py-10 px-5 text-center text-[var(--fg-mute)] text-[13px]">
+            <div className={`py-10 px-5 text-center text-[var(--fg-mute)] text-[13px]`}>
               Searching…
             </div>
           ) : flatItems.length === 0 ? (

--- a/website/src/components/benchmarks/BenchmarkChart.tsx
+++ b/website/src/components/benchmarks/BenchmarkChart.tsx
@@ -34,17 +34,23 @@ export function BenchmarkChart({scenario, project, data, seriesOrder, seriesMeta
 
   useEffect(() => {
     const el = containerRef.current;
-    if (!el) return;
+    if (!el)
+      return () => {};
+
     const ro = new ResizeObserver(entries => {
       const {width, height} = entries[0].contentRect;
       setSize({w: width, h: height});
     });
     ro.observe(el);
-    return () => ro.disconnect();
+    return () => {
+      ro.disconnect();
+    };
   }, []);
 
   const chartData = useMemo(() => {
-    if (!size) return null;
+    if (!size)
+      return null;
+
 
     const {w, h} = size;
     const pw = w - ML - MR;
@@ -57,11 +63,16 @@ export function BenchmarkChart({scenario, project, data, seriesOrder, seriesMeta
     const allVals: Array<number> = [];
     for (const sid of visible) {
       const vals = getSeriesValues(data, sid);
-      for (const v of vals)
-        if (v !== null) allVals.push(v);
+      for (const v of vals) {
+        if (v !== null) {
+          allVals.push(v);
+        }
+      }
     }
 
-    if (!allVals.length) return null;
+    if (!allVals.length)
+      return null;
+
 
     const yMin = 0;
     let yMax = Math.max(...allVals);
@@ -70,7 +81,9 @@ export function BenchmarkChart({scenario, project, data, seriesOrder, seriesMeta
 
     const points = data[seriesOrder[0]];
     const N = points?.length ?? 0;
-    if (!N) return null;
+    if (!N)
+      return null;
+
 
     const xScale = (i: number) => ML + (i / (N - 1)) * pw;
     const yScale = (v: number) => MT + ph - ((v - yMin) / (yMax - yMin)) * ph;
@@ -82,12 +95,20 @@ export function BenchmarkChart({scenario, project, data, seriesOrder, seriesMeta
       let iStart = -1, iEnd = -1;
       for (let ip = 0; ip < N; ip++) {
         const ts = points[ip].timestamp;
-        if (ts >= inc.start && iStart === -1) iStart = ip;
-        if (ts <= inc.end) iEnd = ip;
+        if (ts >= inc.start && iStart === -1)
+          iStart = ip;
+
+        if (ts <= inc.end) {
+          iEnd = ip;
+        }
       }
-      if (iStart === -1 || iEnd === -1 || iEnd < iStart) continue;
+      if (iStart === -1 || iEnd === -1 || iEnd < iStart)
+        continue;
+
       incidentRanges.push({start: iStart, end: iEnd, label: inc.label});
-      for (let ik = iStart; ik <= iEnd; ik++) incidentSet[ik] = true;
+      for (let ik = iStart; ik <= iEnd; ik++) {
+        incidentSet[ik] = true;
+      }
     }
 
     const drawOrder = seriesOrder.filter(s => s !== `zpm`).concat(`zpm`);
@@ -122,13 +143,17 @@ export function BenchmarkChart({scenario, project, data, seriesOrder, seriesMeta
       const zpmMed = median(zpmVals);
       const top = yScale(zpmMed * 1.08);
       const bot = yScale(zpmMed * 0.92);
-      if (bot > top) band = {x: ML, y: top, w: pw, h: bot - top};
+      if (bot > top) {
+        band = {x: ML, y: top, w: pw, h: bot - top};
+      }
     }
 
     const versionDots: Array<{cx: number, cy: number, r: number, color: string, cls: string, url: string | null}> = [];
     if (showVersions && versions) {
       for (const sid of drawOrder) {
-        if (mutedSeries[sid]) continue;
+        if (mutedSeries[sid])
+          continue;
+
         const vers = versions[sid] ?? [];
         const seriesP = data[sid];
         if (!seriesP || !vers.length) continue;
@@ -203,21 +228,28 @@ export function BenchmarkChart({scenario, project, data, seriesOrder, seriesMeta
 
     const medians: Array<{id: string, m: number}> = [];
     for (const sid of seriesOrder) {
-      if (mutedSeries[sid]) continue;
+      if (mutedSeries[sid])
+        continue;
+
       const m = median(getSeriesValues(data, sid));
-      if (m > 0) medians.push({id: sid, m});
+      if (m > 0) {
+        medians.push({id: sid, m});
+      }
     }
 
     const others = medians.filter(x => x.id !== `zpm`);
     if (!others.length)
       return {cls: `fastest`, text: `no comparison data`};
 
+
     const fastest = others.reduce((min, x) => x.m < min.m ? x : min, others[0]);
     const name = seriesMeta[fastest.id]?.name ?? fastest.id;
 
     if (zpmMedian <= fastest.m) {
       const diff = +(fastest.m - zpmMedian).toFixed(1);
-      if (diff === 0) return {cls: `contested`, text: `tied with ${name}`};
+      if (diff === 0)
+        return {cls: `contested`, text: `tied with ${name}`};
+
       return {cls: `fastest`, text: `${diff}s faster than ${name}`};
     }
 
@@ -230,7 +262,9 @@ export function BenchmarkChart({scenario, project, data, seriesOrder, seriesMeta
   const prevIdxRef = useRef<number | null>(null);
 
   const handleMouseMove = useCallback((e: React.MouseEvent) => {
-    if (!chartData || !svgRef.current) return;
+    if (!chartData || !svgRef.current)
+      return;
+
     const rect = svgRef.current.getBoundingClientRect();
     const sx = e.clientX - rect.left;
 
@@ -256,10 +290,12 @@ export function BenchmarkChart({scenario, project, data, seriesOrder, seriesMeta
 
     if (inIncident) {
       let incLabel = ``;
-      for (const ir of chartData.incidentRanges)
+      for (const ir of chartData.incidentRanges) {
         if (idx >= ir.start && idx <= ir.end) {
-          incLabel = ir.label; break;
+          incLabel = ir.label;
+          break;
         }
+      }
 
       onHover({
         mouseX: e.clientX, mouseY: e.clientY, index: idx,
@@ -312,7 +348,8 @@ export function BenchmarkChart({scenario, project, data, seriesOrder, seriesMeta
 
   useEffect(() => {
     const el = cellRef.current;
-    if (!el) return;
+    if (!el)
+      return () => {};
 
     const onTouch = (e: TouchEvent) => {
       const {chartData: cd, data: d, seriesOrder: so, seriesMeta: sm, mutedSeries: ms, scenario: sc, project: pr, versions: ver, showVersions: sv, onHover: oh} = touchDepsRef.current;
@@ -347,10 +384,12 @@ export function BenchmarkChart({scenario, project, data, seriesOrder, seriesMeta
 
       if (inIncident) {
         let incLabel = ``;
-        for (const ir of cd.incidentRanges)
+        for (const ir of cd.incidentRanges) {
           if (idx >= ir.start && idx <= ir.end) {
-            incLabel = ir.label; break;
+            incLabel = ir.label;
+            break;
           }
+        }
 
         oh({mouseX: touch.clientX, mouseY: touch.clientY, index: idx, dateStr, scenarioTitle: sc.title, projectName: pr.name, isIncident: true, incidentLabel: incLabel, rows: [], versionMap: null, showVersions: sv, seriesMeta: sm});
         return;
@@ -358,9 +397,13 @@ export function BenchmarkChart({scenario, project, data, seriesOrder, seriesMeta
 
       const rows: Array<{id: string, value: number}> = [];
       for (const sid of so) {
-        if (ms[sid]) continue;
+        if (ms[sid])
+          continue;
+
         const sp = d[sid];
-        if (!sp?.[idx] || sp[idx].value === null) continue;
+        if (!sp?.[idx] || sp[idx].value === null)
+          continue;
+
         rows.push({id: sid, value: sp[idx].value!});
       }
       rows.sort((a, b) => a.value - b.value);
@@ -370,10 +413,13 @@ export function BenchmarkChart({scenario, project, data, seriesOrder, seriesMeta
         versionMap = {};
         for (const sid of so) {
           const vs = ver[sid];
-          if (!vs?.length) continue;
+          if (!vs?.length)
+            continue;
+
           for (let i = vs.length - 1; i >= 0; i--) {
             if (vs[i].t <= ts) {
-              versionMap[sid] = vs[i].v; break;
+              versionMap[sid] = vs[i].v;
+              break;
             }
           }
         }

--- a/website/src/components/benchmarks/BenchmarkSummary.tsx
+++ b/website/src/components/benchmarks/BenchmarkSummary.tsx
@@ -1,9 +1,10 @@
-import {useMemo, type JSX} from 'react';
+import {useMemo, type JSX}                                                                      from 'react';
+
 import {SERIES_COLORS, median, getSeriesValues, type SeriesMeta, type Project, type BenchPoint} from './BenchmarksDashboard';
 
 interface Props {
   data: Record<string, Record<string, Record<string, Array<BenchPoint>>>>;
-  seriesOrder: readonly string[];
+  seriesOrder: ReadonlyArray<string>;
   seriesMeta: Record<string, SeriesMeta>;
   projects: Array<Project>;
   mutedSeries: Record<string, boolean>;
@@ -12,7 +13,7 @@ interface Props {
 function aggregate(
   scenarioId: string,
   data: Props[`data`],
-  seriesOrder: readonly string[],
+  seriesOrder: ReadonlyArray<string>,
   seriesMeta: Record<string, SeriesMeta>,
   projects: Array<Project>,
   mutedSeries: Record<string, boolean>,
@@ -37,10 +38,14 @@ function aggregate(
         break;
       }
     }
-    if (complete) rows.push(medians);
+    if (complete) {
+      rows.push(medians);
+    }
   }
 
-  if (visibleSeries.length === 0 || rows.length === 0) return [];
+  if (visibleSeries.length === 0 || rows.length === 0)
+    return [];
+
 
   // Geomean of absolute medians per series. Computed in log space for
   // numerical stability when projects span very different magnitudes.
@@ -67,15 +72,15 @@ function aggregate(
   return out;
 }
 
-function SummaryCard({title, agg}: {title: string; agg: ReturnType<typeof aggregate>}): JSX.Element {
+function SummaryCard({title, agg}: {title: string, agg: ReturnType<typeof aggregate>}): JSX.Element {
   return (
-    <div className="summary-card">
+    <div className={`summary-card`}>
       <h4>{title}</h4>
       <div>
         {agg.map(a => (
-          <div key={a.id} className="summary-bar">
+          <div key={a.id} className={`summary-bar`}>
             <div className={`lbl${a.accent ? ` self` : ``}`}>{a.name}</div>
-            <div className="track">
+            <div className={`track`}>
               <div
                 className={`fill${a.accent ? ` self` : ``}`}
                 style={{
@@ -104,16 +109,16 @@ export function BenchmarkSummary({data, seriesOrder, seriesMeta, projects, muted
 
   return (
     <>
-      <div className="mt-12 mb-6">
-        <div className="mono text-[11px] text-[var(--fg-mute)] tracking-[0.12em] uppercase mb-2">&sect; Aggregate</div>
-        <h2 className="text-[26px] font-medium tracking-[-0.015em] m-0">Median across all scenarios.</h2>
-        <p className="text-[14.5px] text-[var(--fg-dim)] leading-[1.6] mt-2 max-w-[680px] text-pretty">
+      <div className={`mt-12 mb-6`}>
+        <div className={`mono text-[11px] text-[var(--fg-mute)] tracking-[0.12em] uppercase mb-2`}>&sect; Aggregate</div>
+        <h2 className={`text-[26px] font-medium tracking-[-0.015em] m-0`}>Median across all scenarios.</h2>
+        <p className={`text-[14.5px] text-[var(--fg-dim)] leading-[1.6] mt-2 max-w-[680px] text-pretty`}>
           Geometric mean of per-project medians for each series, then normalized so the slowest series reads as 1.00&times;. Every other series is the ratio of its average run time to the slowest. Lower is faster.
         </p>
       </div>
-      <div className="summary">
-        <SummaryCard title="Cold install · normalized" agg={coldAgg} />
-        <SummaryCard title="Cache + lockfile · normalized" agg={warmAgg} />
+      <div className={`summary`}>
+        <SummaryCard title={`Cold install · normalized`} agg={coldAgg} />
+        <SummaryCard title={`Cache + lockfile · normalized`} agg={warmAgg} />
       </div>
     </>
   );

--- a/website/src/components/benchmarks/BenchmarkTooltip.tsx
+++ b/website/src/components/benchmarks/BenchmarkTooltip.tsx
@@ -1,5 +1,6 @@
 import {useRef, useLayoutEffect, type JSX} from 'react';
-import {SERIES_COLORS, type SeriesMeta} from './BenchmarksDashboard';
+
+import {SERIES_COLORS, type SeriesMeta}    from './BenchmarksDashboard';
 
 export interface HoverInfo {
   mouseX: number;
@@ -10,7 +11,7 @@ export interface HoverInfo {
   projectName: string;
   isIncident: boolean;
   incidentLabel?: string;
-  rows: Array<{id: string; value: number}>;
+  rows: Array<{id: string, value: number}>;
   versionMap: Record<string, string> | null;
   showVersions: boolean;
   seriesMeta: Record<string, SeriesMeta>;
@@ -48,31 +49,31 @@ export function BenchmarkTooltip({info}: {info: HoverInfo | null}): JSX.Element 
     <div className={`bench-tip show`} ref={ref}>
       {info.isIncident ? (
         <>
-          <div className="tip-x">{info.dateStr} &middot; {info.projectName}</div>
+          <div className={`tip-x`}>{info.dateStr} &middot; {info.projectName}</div>
           <div style={{color: `oklch(0.78 0.15 25)`, fontSize: `10px`, marginTop: `2px`}}>
             {info.incidentLabel}
           </div>
         </>
       ) : (
         <>
-          <div className="tip-x">
+          <div className={`tip-x`}>
             {info.dateStr} &middot; {info.scenarioTitle} &middot; {info.projectName}
           </div>
           {info.rows.map(r => {
-            let nameStr = info.seriesMeta[r.id].name;
+            const nameStr = info.seriesMeta[r.id].name;
             let verEl: JSX.Element | null = null;
             if (info.showVersions) {
               if (r.id === `zpm`) {
-                verEl = <span className="tip-ver"> main</span>;
+                verEl = <span className={`tip-ver`}> main</span>;
               } else if (info.versionMap?.[r.id]) {
-                verEl = <span className="tip-ver"> v{info.versionMap[r.id]}</span>;
+                verEl = <span className={`tip-ver`}> v{info.versionMap[r.id]}</span>;
               }
             }
             return (
-              <div key={r.id} className="tip-row" style={{[`--c` as any]: SERIES_COLORS[r.id]}}>
-                <span className="sw" />
-                <span className="nm">{nameStr}{verEl}</span>
-                <span className="vl">{r.value.toFixed(2)}s</span>
+              <div key={r.id} className={`tip-row`} style={{[`--c` as any]: SERIES_COLORS[r.id]}}>
+                <span className={`sw`} />
+                <span className={`nm`}>{nameStr}{verEl}</span>
+                <span className={`vl`}>{r.value.toFixed(2)}s</span>
               </div>
             );
           })}

--- a/website/src/components/benchmarks/useVersions.ts
+++ b/website/src/components/benchmarks/useVersions.ts
@@ -5,7 +5,7 @@ export interface VersionEntry {
   t: number;
 }
 
-const VERSION_PACKAGES: [string, string, string | null][] = [
+const VERSION_PACKAGES: Array<[string, string, string | null]> = [
   [`npm`, `npm`, null],
   [`pnpm`, `pnpm`, null],
   [`classic`, `yarn`, `1.`],
@@ -29,28 +29,38 @@ export function useVersions(benchMinTs: number, benchMaxTs: number, enabled: boo
         fetch(`https://registry.npmjs.org/${pkg}`)
           .then(r => r.ok ? r.json() : null)
           .then(data => {
-            if (!data?.time) return [pm, []] as const;
+            if (!data?.time) return [pm, [] as Array<VersionEntry>] as const;
             const entries: Array<VersionEntry> = [];
             let latestBefore: VersionEntry | null = null;
 
             for (const v in data.time) {
-              if (v === `created` || v === `modified`) continue;
-              if (v.includes(`-`)) continue;
-              if (prefix && !v.startsWith(prefix)) continue;
+              if (v === `created` || v === `modified`)
+                continue;
+
+              if (v.includes(`-`))
+                continue;
+
+              if (prefix && !v.startsWith(prefix))
+                continue;
+
 
               const t = Math.floor(new Date(data.time[v]).getTime() / 1000);
               if (t >= benchMinTs && t <= benchMaxTs) {
                 entries.push({v, t});
               } else if (t < benchMinTs) {
-                if (!latestBefore || t > latestBefore.t) latestBefore = {v, t};
+                if (!latestBefore || t > latestBefore.t) {
+                  latestBefore = {v, t};
+                }
               }
             }
 
-            if (latestBefore) entries.push(latestBefore);
+            if (latestBefore)
+              entries.push(latestBefore);
+
             entries.sort((a, b) => a.t - b.t);
             return [pm, entries] as const;
           })
-          .catch(() => [pm, []] as const),
+          .catch(() => [pm, [] as Array<VersionEntry>] as const),
       ),
     ).then(results => {
       const map: Record<string, Array<VersionEntry>> = {};

--- a/website/src/components/package/AuditPanel.tsx
+++ b/website/src/components/package/AuditPanel.tsx
@@ -1,5 +1,5 @@
 import {useIcons} from './contexts';
-import {OctIcon} from './icons';
+import {OctIcon}  from './icons';
 
 export function AuditPanel() {
   const {oct} = useIcons();

--- a/website/src/components/package/DownloadsCard.tsx
+++ b/website/src/components/package/DownloadsCard.tsx
@@ -1,4 +1,4 @@
-import type {DownloadDay} from './types';
+import type {DownloadDay}                from './types';
 import {formatNumberFull, sparklinePath} from './utils';
 
 export function DownloadsCard({downloads}: {downloads: Array<DownloadDay> | null}) {

--- a/website/src/components/package/FilesExplorer.tsx
+++ b/website/src/components/package/FilesExplorer.tsx
@@ -1,8 +1,8 @@
-import {useState, useEffect, useCallback, useRef, useMemo, lazy, Suspense} from 'react';
+import {useState, useEffect, useCallback, useRef, useMemo, lazy, Suspense}                                                                          from 'react';
 
-import type {FileEntry, Tab, TreeNode} from './types';
-import {useIcons} from './contexts';
-import {OctIcon} from './icons';
+import {useIcons}                                                                                                                                   from './contexts';
+import {OctIcon}                                                                                                                                    from './icons';
+import type {FileEntry, Tab, TreeNode}                                                                                                              from './types';
 import {formatBytes, timeAgo, langFromPath, setupMonacoTheme, buildFileTree, formatWithPrettier, canPrettify, compareSemverDesc, isNoisyPrerelease} from './utils';
 
 const MonacoEditor = lazy(() => import(`@monaco-editor/react`).then(m => ({default: m.default})));
@@ -131,40 +131,56 @@ export function FilesExplorer({
   useEffect(() => {
     if (!compareVersion || !name) {
       setCompareFiles(null);
-      return;
+      return undefined;
     }
     const abortCtrl = new AbortController();
     fetch(`https://data.jsdelivr.com/v1/package/npm/${name}@${compareVersion}/flat`, {signal: abortCtrl.signal})
       .then(r => r.ok ? r.json() : null)
       .then(data => {
-        if (data?.files) setCompareFiles(data.files);
+        if (data?.files) {
+          setCompareFiles(data.files);
+        }
       })
       .catch(err => {
-        if (err.name !== `AbortError`) setCompareFiles(null);
+        if (err.name !== `AbortError`) {
+          setCompareFiles(null);
+        }
       });
     return () => abortCtrl.abort();
   }, [compareVersion, name]);
 
   const changeMap = useMemo(() => {
-    if (!compareVersion || !files || !compareFiles) return null;
+    if (!compareVersion || !files || !compareFiles)
+      return null;
+
     const map = new Map<string, string>();
     const oldByPath = new Map(compareFiles.map(f => [f.name.replace(/^\//, ``), f.hash]));
     const newByPath = new Map(files.map(f => [f.name.replace(/^\//, ``), f.hash]));
 
     for (const [path, hash] of newByPath) {
       const oldHash = oldByPath.get(path);
-      if (!oldHash) map.set(path, `added`);
-      else if (oldHash !== hash) map.set(path, `modified`);
+      if (!oldHash) {
+        map.set(path, `added`);
+      } else if (oldHash !== hash) {
+        map.set(path, `modified`);
+      }
     }
-    for (const [path] of oldByPath)
-      if (!newByPath.has(path)) map.set(path, `removed`);
+    for (const [path] of oldByPath) {
+      if (!newByPath.has(path)) {
+        map.set(path, `removed`);
+      }
+    }
 
     return map;
   }, [compareVersion, files, compareFiles]);
 
   const displayFiles = useMemo(() => {
-    if (!files) return null;
-    if (!changeMap) return files;
+    if (!files)
+      return null;
+
+    if (!changeMap)
+      return files;
+
     const removedFiles: Array<FileEntry> = compareFiles
       ? compareFiles.filter(f => changeMap.get(f.name.replace(/^\//, ``)) === `removed`)
       : [];
@@ -178,14 +194,14 @@ export function FilesExplorer({
     if (!selectedFile || !name || !version) {
       setFileContent(null);
       setFileError(null);
-      return;
+      return undefined;
     }
     const changeType = changeMap?.get(selectedFile);
     if (changeType === `removed`) {
       setFileContent(``);
       setFileLoading(false);
       setFileError(null);
-      return;
+      return undefined;
     }
     const abortCtrl = new AbortController();
     setFileLoading(true);
@@ -210,12 +226,12 @@ export function FilesExplorer({
   useEffect(() => {
     if (!compareVersion || !selectedFile || !name) {
       setOrigContent(null);
-      return;
+      return undefined;
     }
     const changeType = changeMap?.get(selectedFile);
     if (changeType === `added`) {
       setOrigContent(``);
-      return;
+      return undefined;
     }
     const abortCtrl = new AbortController();
     setOrigLoading(true);
@@ -227,7 +243,9 @@ export function FilesExplorer({
       })
       .then(text => setOrigContent(text))
       .catch(err => {
-        if (err.name !== `AbortError`) setOrigContent(``);
+        if (err.name !== `AbortError`) {
+          setOrigContent(``);
+        }
       })
       .finally(() => setOrigLoading(false));
     return () => abortCtrl.abort();
@@ -236,25 +254,45 @@ export function FilesExplorer({
   useEffect(() => {
     if (!prettify || fileContent == null || !selectedFile) {
       setFormattedContent(null);
-      return;
+      return undefined;
     }
     let cancelled = false;
     formatWithPrettier(fileContent, selectedFile)
-      .then(result => { if (!cancelled) setFormattedContent(result); })
-      .catch(() => { if (!cancelled) setFormattedContent(null); });
-    return () => { cancelled = true; };
+      .then(result => {
+        if (!cancelled) {
+          setFormattedContent(result);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setFormattedContent(null);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
   }, [prettify, fileContent, selectedFile]);
 
   useEffect(() => {
     if (!prettify || origContent == null || !selectedFile) {
       setFormattedOrig(null);
-      return;
+      return undefined;
     }
     let cancelled = false;
     formatWithPrettier(origContent, selectedFile)
-      .then(result => { if (!cancelled) setFormattedOrig(result); })
-      .catch(() => { if (!cancelled) setFormattedOrig(null); });
-    return () => { cancelled = true; };
+      .then(result => {
+        if (!cancelled) {
+          setFormattedOrig(result);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setFormattedOrig(null);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
   }, [prettify, origContent, selectedFile]);
 
   const prevVersionRef = useRef(version);
@@ -386,8 +424,11 @@ export function FilesExplorer({
                         className={`fver-compare-btn${isCompareTarget ? ` active` : ``}`}
                         onClick={e => {
                           e.stopPropagation();
-                          if (isCompareTarget) exitCompare();
-                          else onCompareChange(v);
+                          if (isCompareTarget) {
+                            exitCompare();
+                          } else {
+                            onCompareChange(v);
+                          }
                         }}
                       >
                         {isCompareTarget ? `Comparing` : `Compare?`}

--- a/website/src/components/package/InstallCard.tsx
+++ b/website/src/components/package/InstallCard.tsx
@@ -1,9 +1,9 @@
 import {useState, useCallback} from 'react';
 
-import type {PmTab} from './types';
-import {useIcons} from './contexts';
-import {OctIcon, BrandIcon} from './icons';
-import {PM_COMMANDS} from './utils';
+import {useIcons}              from './contexts';
+import {OctIcon, BrandIcon}    from './icons';
+import type {PmTab}            from './types';
+import {PM_COMMANDS}           from './utils';
 
 export function InstallCard({name, pmTab, onPmTabChange}: {
   name: string; pmTab: PmTab; onPmTabChange: (t: PmTab) => void;

--- a/website/src/components/package/LeftRail.tsx
+++ b/website/src/components/package/LeftRail.tsx
@@ -1,6 +1,6 @@
-import {useIcons} from './contexts';
-import {OctIcon, BrandIcon} from './icons';
 import {NavLink, NavLinkExternal} from './NavLink';
+import {useIcons}                 from './contexts';
+import {OctIcon, BrandIcon}       from './icons';
 
 export function LeftRail({
   name, version, distTags, homepage, repoUrl,

--- a/website/src/components/package/PackagePage.tsx
+++ b/website/src/components/package/PackagePage.tsx
@@ -1,10 +1,9 @@
-import {RouterProvider}    from '@tanstack/react-router';
-import {useMemo}           from 'react';
+import {RouterProvider}            from '@tanstack/react-router';
+import {useMemo}                   from 'react';
 
-import {PackageCtx}        from './contexts';
-import {PackagePageInner}  from './PackagePageInner';
-import {splatRoute, getRouter} from './router';
-
+import {PackagePageInner}          from './PackagePageInner';
+import {PackageCtx}                from './contexts';
+import {splatRoute, getRouter}     from './router';
 import type {BrandIcons, Octicons} from './types';
 
 splatRoute.update({component: PackagePageInner});

--- a/website/src/components/package/PackagePageInner.tsx
+++ b/website/src/components/package/PackagePageInner.tsx
@@ -1,25 +1,24 @@
 import {useState, useEffect, useCallback, useMemo, useContext} from 'react';
 
-import {PackageCtx, IconCtx}       from './contexts';
-import {LeftRail}                  from './LeftRail';
-import {VersionSelector}           from './VersionSelector';
-import {TabBar}                    from './TabBar';
-import {StatGrid}                  from './StatGrid';
-import {InstallCard}               from './InstallCard';
-import {ReadmePanel}               from './ReadmePanel';
-import {VersionsTimeline}          from './VersionsTimeline';
-import {FilesExplorer}             from './FilesExplorer';
-import {AuditPanel}                from './AuditPanel';
-import {DownloadsCard}             from './DownloadsCard';
-import {VersionsCard}              from './VersionsCard';
-import {DependenciesCard}          from './DependenciesCard';
-import {MaintainersCard}           from './MaintainersCard';
-import {KeywordsCard}              from './KeywordsCard';
-import {OctIcon}                   from './icons';
-import {parseSplat, packagePath, getLicense, getRepoUrl} from './utils';
-import {usePackageNavigate, splatRoute} from './router';
-
+import {AuditPanel}                                            from './AuditPanel';
+import {DependenciesCard}                                      from './DependenciesCard';
+import {DownloadsCard}                                         from './DownloadsCard';
+import {FilesExplorer}                                         from './FilesExplorer';
+import {InstallCard}                                           from './InstallCard';
+import {KeywordsCard}                                          from './KeywordsCard';
+import {LeftRail}                                              from './LeftRail';
+import {MaintainersCard}                                       from './MaintainersCard';
+import {ReadmePanel}                                           from './ReadmePanel';
+import {StatGrid}                                              from './StatGrid';
+import {TabBar}                                                from './TabBar';
+import {VersionSelector}                                       from './VersionSelector';
+import {VersionsCard}                                          from './VersionsCard';
+import {VersionsTimeline}                                      from './VersionsTimeline';
+import {PackageCtx, IconCtx}                                   from './contexts';
+import {OctIcon}                                               from './icons';
+import {usePackageNavigate, splatRoute}                        from './router';
 import type {RegistryData, FileEntry, DownloadDay, Tab, PmTab} from './types';
+import {parseSplat, packagePath, getLicense, getRepoUrl}       from './utils';
 
 function LoadingSpinner() {
   return (
@@ -66,7 +65,8 @@ export function PackagePageInner() {
 
   useEffect(() => {
     if (!name) {
-      setLoading(false); return;
+      setLoading(false);
+      return () => {};
     }
 
     const abortCtrl = new AbortController();
@@ -80,18 +80,26 @@ export function PackagePageInner() {
       })
       .then((data: RegistryData) => {
         setRegistry(data);
-        if (data.readme) setReadme(data.readme);
+        if (data.readme)
+          setReadme(data.readme);
+
         document.title = `${data.name} — Yarn`;
       })
       .catch(err => {
-        if (err.name !== `AbortError`) setError(err.message);
+        if (err.name !== `AbortError`) {
+          setError(err.message);
+        }
       })
       .finally(() => setLoading(false));
-    return () => abortCtrl.abort();
+    return () => {
+      abortCtrl.abort();
+    };
   }, [name]);
 
   useEffect(() => {
-    if (!selectedVersion || !name) return;
+    if (!selectedVersion || !name)
+      return undefined;
+
 
     const abortCtrl = new AbortController();
     setFiles(null);
@@ -99,10 +107,14 @@ export function PackagePageInner() {
     fetch(`https://data.jsdelivr.com/v1/package/npm/${name}@${selectedVersion}/flat`, {signal: abortCtrl.signal})
       .then(r => r.ok ? r.json() : null)
       .then(data => {
-        if (data?.files) setFiles(data.files);
+        if (data?.files) {
+          setFiles(data.files);
+        }
       })
       .catch(err => {
-        if (err.name !== `AbortError`) setFiles(null);
+        if (err.name !== `AbortError`) {
+          setFiles(null);
+        }
       });
 
     fetch(`https://cdn.jsdelivr.net/npm/${name}@${selectedVersion}/README.md`, {signal: abortCtrl.signal})
@@ -112,11 +124,15 @@ export function PackagePageInner() {
       })
       .then(text => setReadme(text))
       .catch(err => {
-        if (err.name === `AbortError`) return;
+        if (err.name === `AbortError`)
+          return;
+
         fetch(`https://cdn.jsdelivr.net/npm/${name}@${selectedVersion}/readme.md`, {signal: abortCtrl.signal})
           .then(r => r.ok ? r.text() : ``)
           .then(text => {
-            if (text) setReadme(text);
+            if (text) {
+              setReadme(text);
+            }
           })
           .catch(() => {});
       });
@@ -125,15 +141,21 @@ export function PackagePageInner() {
   }, [name, selectedVersion]);
 
   useEffect(() => {
-    if (!name) return;
+    if (!name)
+      return undefined;
+
     const abortCtrl = new AbortController();
     fetch(`https://api.npmjs.org/downloads/range/last-month/${name}`, {signal: abortCtrl.signal})
       .then(r => r.ok ? r.json() : null)
       .then(data => {
-        if (data?.downloads) setDownloads(data.downloads);
+        if (data?.downloads) {
+          setDownloads(data.downloads);
+        }
       })
       .catch(err => {
-        if (err.name !== `AbortError`) setDownloads(null);
+        if (err.name !== `AbortError`) {
+          setDownloads(null);
+        }
       });
     return () => abortCtrl.abort();
   }, [name]);

--- a/website/src/components/package/ReadmePanel.tsx
+++ b/website/src/components/package/ReadmePanel.tsx
@@ -1,5 +1,5 @@
-import {useIcons} from './contexts';
-import {OctIcon} from './icons';
+import {useIcons}       from './contexts';
+import {OctIcon}        from './icons';
 import {renderMarkdown} from './utils';
 
 export function ReadmePanel({readme, name}: {readme: string, name: string}) {

--- a/website/src/components/package/StatGrid.tsx
+++ b/website/src/components/package/StatGrid.tsx
@@ -1,5 +1,5 @@
 import type {FileEntry, VersionManifest} from './types';
-import {formatBytes, formatDate} from './utils';
+import {formatBytes, formatDate}         from './utils';
 
 function StatCell({label, value, unit}: {label: string, value: string, unit?: string}) {
   const parts = value.match(/^([\d.,]+)\s*(.*)$/);
@@ -27,7 +27,6 @@ export function StatGrid({versionData, time, version, files}: {
 }) {
   const unpackedSize = versionData?.dist?.unpackedSize;
   const totalSize = files ? files.reduce((s, f) => s + f.size, 0) : unpackedSize;
-  const fileCount = files?.length ?? versionData?.dist?.fileCount;
   const depCount = versionData?.dependencies ? Object.keys(versionData.dependencies).length : 0;
   const pubDate = time[version];
 

--- a/website/src/components/package/VersionSelector.tsx
+++ b/website/src/components/package/VersionSelector.tsx
@@ -1,7 +1,7 @@
-import {useState, useEffect, useRef} from 'react';
+import {useState, useEffect, useRef}                                    from 'react';
 
-import {useIcons} from './contexts';
-import {OctIcon} from './icons';
+import {useIcons}                                                       from './contexts';
+import {OctIcon}                                                        from './icons';
 import {formatDateShort, timeAgo, compareSemverDesc, isNoisyPrerelease} from './utils';
 
 export function VersionSelector({
@@ -18,9 +18,13 @@ export function VersionSelector({
   const ref = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    if (!open) return;
+    if (!open)
+      return undefined;
+
     const handler = (e: MouseEvent) => {
-      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
     };
     document.addEventListener(`mousedown`, handler);
     return () => document.removeEventListener(`mousedown`, handler);

--- a/website/src/components/package/VersionsCard.tsx
+++ b/website/src/components/package/VersionsCard.tsx
@@ -1,4 +1,4 @@
-import {useState} from 'react';
+import {useState}                                              from 'react';
 
 import {formatDateShort, compareSemverDesc, isNoisyPrerelease} from './utils';
 

--- a/website/src/components/package/VersionsTimeline.tsx
+++ b/website/src/components/package/VersionsTimeline.tsx
@@ -1,7 +1,7 @@
-import {useState} from 'react';
+import {useState}                                                       from 'react';
 
-import {useIcons} from './contexts';
-import {OctIcon} from './icons';
+import {useIcons}                                                       from './contexts';
+import {OctIcon}                                                        from './icons';
 import {formatDate, versionLabel, compareSemverDesc, isNoisyPrerelease} from './utils';
 
 export function VersionsTimeline({versions, distTags, time}: {

--- a/website/src/components/package/router.ts
+++ b/website/src/components/package/router.ts
@@ -1,5 +1,5 @@
 import {createRouter, createRoute, createRootRoute, useRouter} from '@tanstack/react-router';
-import {useCallback}                                          from 'react';
+import {useCallback}                                           from 'react';
 
 const rootRoute = createRootRoute();
 

--- a/website/src/components/package/utils.ts
+++ b/website/src/components/package/utils.ts
@@ -55,7 +55,9 @@ export function packagePath(name: string, version?: string, tab?: Tab, filePath?
   let p = `/package/${name}`;
   if (version) {
     p += `/${version}`;
-    if (compareVersion) p += `..${compareVersion}`;
+    if (compareVersion) {
+      p += `..${compareVersion}`;
+    }
   }
   if (tab && tab !== `readme`) {
     if (tab === `files` && filePath) {
@@ -315,10 +317,16 @@ function parseVersion(v: string): {major: number, minor: number, patch: number, 
 
 export function isNoisyPrerelease(v: string): boolean {
   const pre = v.replace(/^\d+\.\d+\.\d+[-.]?/, ``);
-  if (!pre) return false;
+  if (!pre)
+    return false;
+
   for (const seg of pre.split(/[.-]/)) {
-    if (/[a-f0-9]{6,}/i.test(seg) && /[a-f]/i.test(seg) && /\d/.test(seg)) return true;
-    if (/^\d{8}$/.test(seg)) return true;
+    if (/[a-f0-9]{6,}/i.test(seg) && /[a-f]/i.test(seg) && /\d/.test(seg))
+      return true;
+
+    if (/^\d{8}$/.test(seg)) {
+      return true;
+    }
   }
   return false;
 }

--- a/website/src/components/sidebar.ts
+++ b/website/src/components/sidebar.ts
@@ -15,13 +15,13 @@ export type SidebarItem = SidebarLink | SidebarSubtitle;
 
 export interface SidebarGroup {
   title: string;
-  items: SidebarItem[];
+  items: Array<SidebarItem>;
 }
 
 const metaGlob = import.meta.glob<string>(`../docs/**/_meta.{yml,yaml}`, {eager: true, query: `?raw`, import: `default`});
 const docGlob = import.meta.glob<string>(`../docs/**/*.md`, {eager: true, query: `?raw`, import: `default`});
 
-const metaLookup = new Map<string, {label: string; order: number}>();
+const metaLookup = new Map<string, {label: string, order: number}>();
 
 for (const [filePath, content] of Object.entries(metaGlob)) {
   const relDir = filePath
@@ -29,7 +29,7 @@ for (const [filePath, content] of Object.entries(metaGlob)) {
     .replace(/\/_meta\.(yml|yaml)$/, ``);
   const label = content.match(/^label:\s*(.+)$/m)?.[1]?.trim();
   const order = parseInt(content.match(/^order:\s*(\d+)$/m)?.[1] ?? `99`, 10);
-  metaLookup.set(relDir, { label: label ?? relDir, order });
+  metaLookup.set(relDir, {label: label ?? relDir, order});
 }
 
 const slugToDir = new Map<string, string>();
@@ -54,7 +54,7 @@ export function getDirForSlug(slug: string): string | undefined {
   return slugToDir.get(slug);
 }
 
-export function getMetaForDir(dir: string): { label: string; order: number } | undefined {
+export function getMetaForDir(dir: string): {label: string, order: number} | undefined {
   return metaLookup.get(dir);
 }
 
@@ -66,10 +66,10 @@ export function getGroupLabelForSlug(slug: string): string | undefined {
 }
 
 export function buildSidebarGroups(
-  allDocs: Array<{data: {slug: string; title: string; sidebar?: {order?: number; hidden?: boolean}; sidebar_position?: number}}>,
+  allDocs: Array<{data: {slug: string, title: string, sidebar?: {order?: number, hidden?: boolean}, sidebar_position?: number}}>,
   section: string,
   activePage: string,
-): SidebarGroup[] {
+): Array<SidebarGroup> {
   const docs = allDocs.filter(doc => {
     const dir = getDirForSlug(doc.data.slug);
     if (!dir?.startsWith(section)) return false;
@@ -78,7 +78,7 @@ export function buildSidebarGroups(
     return true;
   });
 
-  const groupMap = new Map<string, {label: string; sortKey: number; docs: typeof docs}>();
+  const groupMap = new Map<string, {label: string, sortKey: number, docs: typeof docs}>();
 
   for (const doc of docs) {
     const fsDir = getDirForSlug(doc.data.slug) ?? `.`;
@@ -97,7 +97,7 @@ export function buildSidebarGroups(
 
   return [...groupMap.values()]
     .sort((a, b) => a.sortKey - b.sortKey)
-    .map(({ label, docs: groupDocs }) => ({
+    .map(({label, docs: groupDocs}) => ({
       title: label,
       items: groupDocs
         .sort((a, b) => {

--- a/website/src/content.config.ts
+++ b/website/src/content.config.ts
@@ -1,9 +1,10 @@
-import {fileURLToPath}                from 'url';
-import path                           from 'path';
-import {glob}                         from 'astro/loaders';
-import {clipanionLoaders}             from '@clipanion/astro';
-import {defineCollection, z}          from 'astro:content';
-import {cliBody}                      from './utils/cli';
+import {clipanionLoaders}    from '@clipanion/astro';
+import {glob}                from 'astro/loaders';
+import {defineCollection, z} from 'astro:content';
+import path                  from 'path';
+import {fileURLToPath}       from 'url';
+
+import {cliBody}             from './utils/cli';
 
 const docs = defineCollection({
   loader: glob({pattern: `**/*.{md,mdx}`, base: `./src/docs`}),

--- a/website/src/data/constellations.ts
+++ b/website/src/data/constellations.ts
@@ -2,19 +2,21 @@ type Point = [number, number];
 
 export interface Constellation {
   name: string;
-  stars: Point[];
-  edges: [number, number][];
+  stars: Array<Point>;
+  edges: Array<[number, number]>;
 }
 
-function compile(name: string, strokes: Point[][]): Constellation {
-  const stars: Point[] = [];
-  const edges: [number, number][] = [];
+function compile(name: string, strokes: Array<Array<Point>>): Constellation {
+  const stars: Array<Point> = [];
+  const edges: Array<[number, number]> = [];
   const EPS = 0.02;
 
   const findOrAdd = ([x, y]: Point): number => {
     for (let i = 0; i < stars.length; i++) {
       const [sx, sy] = stars[i];
-      if (Math.abs(sx - x) < EPS && Math.abs(sy - y) < EPS) return i;
+      if (Math.abs(sx - x) < EPS && Math.abs(sy - y) < EPS) {
+        return i;
+      }
     }
     stars.push([x, y]);
     return stars.length - 1;
@@ -23,66 +25,70 @@ function compile(name: string, strokes: Point[][]): Constellation {
   for (const stroke of strokes) {
     const idxs = stroke.map(findOrAdd);
     for (let i = 1; i < idxs.length; i++) {
-      if (idxs[i - 1] !== idxs[i]) edges.push([idxs[i - 1], idxs[i]]);
+      if (idxs[i - 1] !== idxs[i]) {
+        edges.push([idxs[i - 1], idxs[i]]);
+      }
     }
   }
 
-  return { name, stars, edges };
+  return {name, stars, edges};
 }
 
 const L = 0.15, R = 0.85, T = 0.10, B = 0.90, M = 0.50, MY = 0.50;
 
-const runes: Constellation[] = [
-  compile(`fehu`, [[[L,T],[L,B]], [[L,0.25],[R,0.10]], [[L,0.45],[R,0.30]]]),
-  compile(`uruz`, [[[L,B],[L,T],[R,0.30],[R,B]]]),
-  compile(`thurisaz`, [[[L,T],[L,B]], [[L,0.30],[R,MY],[L,0.70]]]),
-  compile(`ansuz`, [[[L,T],[L,B]], [[L,0.22],[R,0.08]], [[L,0.40],[0.60,0.30]]]),
-  compile(`raidho`, [[[L,T],[L,B]], [[L,T],[R,0.30],[L,MY]], [[L,MY],[R,B]]]),
-  compile(`kenaz`, [[[L,T],[R,MY],[L,B]]]),
-  compile(`gebo`, [[[L,T],[R,B]], [[R,T],[L,B]]]),
-  compile(`wunjo`, [[[L,T],[L,B]], [[L,T],[R,0.25],[L,MY]]]),
-  compile(`hagalaz`, [[[L,T],[L,B]], [[R,T],[R,B]], [[L,MY],[R,MY]]]),
-  compile(`nauthiz`, [[[L,T],[L,B]], [[L,0.30],[R,0.70]]]),
-  compile(`isa`, [[[M,T],[M,B]]]),
-  compile(`jera`, [[[L,0.30],[0.40,T],[M,0.30]], [[M,0.70],[0.60,B],[R,0.70]]]),
-  compile(`eihwaz`, [[[L,0.25],[M,T]], [[M,T],[M,B]], [[M,B],[R,0.75]]]),
-  compile(`perthro`, [[[R,T],[L,T],[L,B],[R,B]]]),
-  compile(`algiz`, [[[M,B],[M,MY]], [[M,MY],[L,T]], [[M,MY],[R,T]]]),
-  compile(`sowilo`, [[[R,T],[0.40,0.30],[0.60,0.70],[L,B]]]),
-  compile(`tiwaz`, [[[M,T],[M,B]], [[L,0.30],[M,T],[R,0.30]]]),
-  compile(`berkano`, [[[L,T],[L,B]], [[L,T],[R,0.28],[L,MY]], [[L,MY],[R,0.72],[L,B]]]),
-  compile(`ehwaz`, [[[L,B],[L,T]], [[L,T],[R,B]], [[R,B],[R,T]], [[L,0.30],[R,0.30]]]),
-  compile(`mannaz`, [[[L,B],[L,T]], [[R,B],[R,T]], [[L,T],[R,B]], [[R,T],[L,B]]]),
-  compile(`laguz`, [[[L,T],[L,B]], [[L,T],[0.55,0.25]]]),
-  compile(`ingwaz`, [[[M,T],[R,MY],[M,B],[L,MY],[M,T]]]),
-  compile(`dagaz`, [[[L,T],[L,B]], [[R,T],[R,B]], [[L,T],[R,B]], [[L,B],[R,T]]]),
-  compile(`othala`, [[[M,T],[R,0.35],[0.65,0.65],[M,MY],[0.35,0.65],[L,0.35],[M,T]], [[0.35,0.65],[0.25,B]], [[0.65,0.65],[0.75,B]]]),
+const runes: Array<Constellation> = [
+  compile(`fehu`, [[[L, T], [L, B]], [[L, 0.25], [R, 0.10]], [[L, 0.45], [R, 0.30]]]),
+  compile(`uruz`, [[[L, B], [L, T], [R, 0.30], [R, B]]]),
+  compile(`thurisaz`, [[[L, T], [L, B]], [[L, 0.30], [R, MY], [L, 0.70]]]),
+  compile(`ansuz`, [[[L, T], [L, B]], [[L, 0.22], [R, 0.08]], [[L, 0.40], [0.60, 0.30]]]),
+  compile(`raidho`, [[[L, T], [L, B]], [[L, T], [R, 0.30], [L, MY]], [[L, MY], [R, B]]]),
+  compile(`kenaz`, [[[L, T], [R, MY], [L, B]]]),
+  compile(`gebo`, [[[L, T], [R, B]], [[R, T], [L, B]]]),
+  compile(`wunjo`, [[[L, T], [L, B]], [[L, T], [R, 0.25], [L, MY]]]),
+  compile(`hagalaz`, [[[L, T], [L, B]], [[R, T], [R, B]], [[L, MY], [R, MY]]]),
+  compile(`nauthiz`, [[[L, T], [L, B]], [[L, 0.30], [R, 0.70]]]),
+  compile(`isa`, [[[M, T], [M, B]]]),
+  compile(`jera`, [[[L, 0.30], [0.40, T], [M, 0.30]], [[M, 0.70], [0.60, B], [R, 0.70]]]),
+  compile(`eihwaz`, [[[L, 0.25], [M, T]], [[M, T], [M, B]], [[M, B], [R, 0.75]]]),
+  compile(`perthro`, [[[R, T], [L, T], [L, B], [R, B]]]),
+  compile(`algiz`, [[[M, B], [M, MY]], [[M, MY], [L, T]], [[M, MY], [R, T]]]),
+  compile(`sowilo`, [[[R, T], [0.40, 0.30], [0.60, 0.70], [L, B]]]),
+  compile(`tiwaz`, [[[M, T], [M, B]], [[L, 0.30], [M, T], [R, 0.30]]]),
+  compile(`berkano`, [[[L, T], [L, B]], [[L, T], [R, 0.28], [L, MY]], [[L, MY], [R, 0.72], [L, B]]]),
+  compile(`ehwaz`, [[[L, B], [L, T]], [[L, T], [R, B]], [[R, B], [R, T]], [[L, 0.30], [R, 0.30]]]),
+  compile(`mannaz`, [[[L, B], [L, T]], [[R, B], [R, T]], [[L, T], [R, B]], [[R, T], [L, B]]]),
+  compile(`laguz`, [[[L, T], [L, B]], [[L, T], [0.55, 0.25]]]),
+  compile(`ingwaz`, [[[M, T], [R, MY], [M, B], [L, MY], [M, T]]]),
+  compile(`dagaz`, [[[L, T], [L, B]], [[R, T], [R, B]], [[L, T], [R, B]], [[L, B], [R, T]]]),
+  compile(`othala`, [[[M, T], [R, 0.35], [0.65, 0.65], [M, MY], [0.35, 0.65], [L, 0.35], [M, T]], [[0.35, 0.65], [0.25, B]], [[0.65, 0.65], [0.75, B]]]),
 ];
 
-const extensions: Constellation[] = [
-  compile(`ear`, [[[M,T],[M,B]], [[L,0.25],[M,T],[R,0.25]], [[L,0.50],[M,0.30]]]),
-  compile(`cweorth`, [[[M,B],[L,T]], [[M,B],[M,T]], [[M,B],[R,T]]]),
-  compile(`calc`, [[[M,T],[M,MY]], [[M,MY],[L,B]], [[M,MY],[R,B]]]),
-  compile(`stan`, [[[L,B],[L,0.30],[M,T],[R,0.30],[R,B]], [[L,0.30],[R,0.30]]]),
-  compile(`gar`, [[[M,T],[M,B]], [[L,MY],[R,MY]], [[L,T],[R,B]], [[R,T],[L,B]]]),
-  compile(`yr`, [[[M,T],[M,B]], [[L,B],[M,MY],[R,B]]]),
-  compile(`hagall`, [[[M,T],[M,B]], [[L,0.25],[R,0.75]], [[R,0.25],[L,0.75]]]),
-  compile(`bind-gebo-isa`, [[[L,T],[R,B]], [[R,T],[L,B]], [[M,T],[M,B]]]),
-  compile(`bind-tiwaz-stack`, [[[M,T],[M,B]], [[0.30,0.20],[M,0.10],[0.70,0.20]], [[0.30,0.60],[M,MY],[0.70,0.60]]]),
-  compile(`bind-algiz-isa`, [[[M,T],[M,B]], [[L,T],[M,0.35],[R,T]]]),
-  compile(`bind-fehu-2`, [[[L,T],[L,B]], [[L,0.22],[M,0.10]], [[L,0.40],[0.55,0.30]], [[R,T],[R,B]], [[R,0.22],[0.70,0.10]]]),
-  compile(`bind-othala`, [[[M,T],[R,MY],[M,B],[L,MY],[M,T]], [[L,MY],[0.05,0.80]], [[R,MY],[0.95,0.80]]]),
-  compile(`bind-ehwaz-rot`, [[[L,T],[L,B]], [[R,T],[R,B]], [[L,T],[R,B]], [[L,0.30],[R,0.30]], [[L,0.70],[R,0.70]]]),
-  compile(`aegishjalmr`, [[[M,T],[M,B]], [[L,MY],[R,MY]], [[0.25,0.25],[0.75,0.75]], [[0.75,0.25],[0.25,0.75]]]),
-  compile(`valknut`, [[[M,T],[L,B],[R,B],[M,T]], [[0.35,0.40],[M,B]]]),
-  compile(`vegvisir`, [[[M,T],[M,B]], [[L,MY],[R,MY]], [[M,0.20],[0.40,0.10]], [[M,0.20],[0.60,0.10]], [[M,0.80],[0.40,0.90]], [[M,0.80],[0.60,0.90]]]),
+const extensions: Array<Constellation> = [
+  compile(`ear`, [[[M, T], [M, B]], [[L, 0.25], [M, T], [R, 0.25]], [[L, 0.50], [M, 0.30]]]),
+  compile(`cweorth`, [[[M, B], [L, T]], [[M, B], [M, T]], [[M, B], [R, T]]]),
+  compile(`calc`, [[[M, T], [M, MY]], [[M, MY], [L, B]], [[M, MY], [R, B]]]),
+  compile(`stan`, [[[L, B], [L, 0.30], [M, T], [R, 0.30], [R, B]], [[L, 0.30], [R, 0.30]]]),
+  compile(`gar`, [[[M, T], [M, B]], [[L, MY], [R, MY]], [[L, T], [R, B]], [[R, T], [L, B]]]),
+  compile(`yr`, [[[M, T], [M, B]], [[L, B], [M, MY], [R, B]]]),
+  compile(`hagall`, [[[M, T], [M, B]], [[L, 0.25], [R, 0.75]], [[R, 0.25], [L, 0.75]]]),
+  compile(`bind-gebo-isa`, [[[L, T], [R, B]], [[R, T], [L, B]], [[M, T], [M, B]]]),
+  compile(`bind-tiwaz-stack`, [[[M, T], [M, B]], [[0.30, 0.20], [M, 0.10], [0.70, 0.20]], [[0.30, 0.60], [M, MY], [0.70, 0.60]]]),
+  compile(`bind-algiz-isa`, [[[M, T], [M, B]], [[L, T], [M, 0.35], [R, T]]]),
+  compile(`bind-fehu-2`, [[[L, T], [L, B]], [[L, 0.22], [M, 0.10]], [[L, 0.40], [0.55, 0.30]], [[R, T], [R, B]], [[R, 0.22], [0.70, 0.10]]]),
+  compile(`bind-othala`, [[[M, T], [R, MY], [M, B], [L, MY], [M, T]], [[L, MY], [0.05, 0.80]], [[R, MY], [0.95, 0.80]]]),
+  compile(`bind-ehwaz-rot`, [[[L, T], [L, B]], [[R, T], [R, B]], [[L, T], [R, B]], [[L, 0.30], [R, 0.30]], [[L, 0.70], [R, 0.70]]]),
+  compile(`aegishjalmr`, [[[M, T], [M, B]], [[L, MY], [R, MY]], [[0.25, 0.25], [0.75, 0.75]], [[0.75, 0.25], [0.25, 0.75]]]),
+  compile(`valknut`, [[[M, T], [L, B], [R, B], [M, T]], [[0.35, 0.40], [M, B]]]),
+  compile(`vegvisir`, [[[M, T], [M, B]], [[L, MY], [R, MY]], [[M, 0.20], [0.40, 0.10]], [[M, 0.20], [0.60, 0.10]], [[M, 0.80], [0.40, 0.90]], [[M, 0.80], [0.60, 0.90]]]),
 ];
 
 let seed = 0xbeefcafe;
-const rnd = (): number => { seed = (seed * 1664525 + 1013904223) | 0; return ((seed >>> 0) % 1e6) / 1e6; };
-const pick = <T>(arr: T[]): T => arr[Math.floor(rnd() * arr.length)];
+const rnd = (): number => {
+  seed = (seed * 1664525 + 1013904223) | 0; return ((seed >>> 0) % 1e6) / 1e6;
+};
+const pick = <T>(arr: Array<T>): T => arr[Math.floor(rnd() * arr.length)];
 
-const makeStroke = (kind: string): Point[] => {
+const makeStroke = (kind: string): Array<Point> => {
   switch (kind) {
     case `stave`: return [[M, T], [M, B]];
     case `hstave`: return [[L, MY], [R, MY]];
@@ -106,14 +112,14 @@ const makeStroke = (kind: string): Point[] => {
   return [[M, T], [M, B]];
 };
 
-const strokeKinds = [`stave`,`hstave`,`slash-dr`,`slash-ur`,`chevron-r`,`chevron-l`,`chevron-u`,`chevron-d`,`top-arm-r`,`top-arm-l`,`bot-arm-r`,`bot-arm-l`,`side-arm`,`diamond-s`,`triangle-r`,`triangle-l`,`half-x`,`half-x2`];
+const strokeKinds = [`stave`, `hstave`, `slash-dr`, `slash-ur`, `chevron-r`, `chevron-l`, `chevron-u`, `chevron-d`, `top-arm-r`, `top-arm-l`, `bot-arm-r`, `bot-arm-l`, `side-arm`, `diamond-s`, `triangle-r`, `triangle-l`, `half-x`, `half-x2`];
 
 const combined = [...runes, ...extensions];
 const needed = 80 - combined.length;
 
 for (let i = 0; i < needed; i++) {
   const count = 2 + Math.floor(rnd() * 2);
-  const strokes: Point[][] = [];
+  const strokes: Array<Array<Point>> = [];
   const used = new Set<string>();
   for (let j = 0; j < count; j++) {
     let k = pick(strokeKinds);
@@ -123,7 +129,7 @@ for (let i = 0; i < needed; i++) {
     strokes.push(makeStroke(k));
   }
   if (rnd() < 0.55 && !used.has(`stave`)) strokes.unshift(makeStroke(`stave`));
-  combined.push(compile(`bindrune-` + i, strokes));
+  combined.push(compile(`bindrune-${i}`, strokes));
 }
 
-export const CONSTELLATION_LIBRARY: Constellation[] = combined.slice(0, 80);
+export const CONSTELLATION_LIBRARY: Array<Constellation> = combined.slice(0, 80);

--- a/website/src/env.d.ts
+++ b/website/src/env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="astro/client" />

--- a/website/src/scripts/starfield.ts
+++ b/website/src/scripts/starfield.ts
@@ -29,34 +29,38 @@ interface ShootingStar {
   vy: number;
   life: number;
   maxLife: number;
-  trail: { x: number; y: number }[];
+  trail: Array<{x: number, y: number}>;
 }
 
 export function createStarfield(
   canvas: HTMLCanvasElement,
   state: StarfieldState,
-): { initStars: () => void } {
+): {initStars: () => void} {
   const ctx = canvas.getContext(`2d`)!;
-  let stars: Star[] = [];
-  let constellationStars: Star[] = [];
-  let constellations: [Star, Star][] = [];
-  let shootingStars: ShootingStar[] = [];
+  let stars: Array<Star> = [];
+  let constellationStars: Array<Star> = [];
+  let constellations: Array<[Star, Star]> = [];
+  let shootingStars: Array<ShootingStar> = [];
   let W = window.innerWidth, H = window.innerHeight, DPR = 1;
 
   let catImg: HTMLImageElement | null = null;
   let catImgReady = false;
-  let catRect: { x: number; y: number; w: number; h: number } | null = null;
+  let catRect: {x: number, y: number, w: number, h: number} | null = null;
 
   (function loadCat() {
     const im = new Image();
     im.crossOrigin = `anonymous`;
-    im.onload = () => { catImg = im; catImgReady = true; computeCatPath(); };
+    im.onload = () => {
+      catImg = im; catImgReady = true; computeCatPath();
+    };
     im.src = `cat.png`;
   })();
 
   function computeCatPath() {
     const el = document.getElementById(`cat-img`);
-    if (!el) { catRect = null; return; }
+    if (!el) {
+      catRect = null; return;
+    }
     const rect = el.getBoundingClientRect();
     if (catImg) {
       const iw = catImg.naturalWidth, ih = catImg.naturalHeight;
@@ -64,9 +68,9 @@ export function createStarfield(
       const dw = iw * scale, dh = ih * scale;
       const dx = rect.left + (rect.width - dw) / 2;
       const dy = rect.top + (rect.height - dh) / 2;
-      catRect = { x: dx, y: dy, w: dw, h: dh };
+      catRect = {x: dx, y: dy, w: dw, h: dh};
     } else {
-      catRect = { x: rect.left, y: rect.top, w: rect.width, h: rect.height };
+      catRect = {x: rect.left, y: rect.top, w: rect.width, h: rect.height};
     }
   }
 
@@ -76,8 +80,8 @@ export function createStarfield(
     H = window.innerHeight;
     canvas.width = W * DPR;
     canvas.height = H * DPR;
-    canvas.style.width = W + `px`;
-    canvas.style.height = H + `px`;
+    canvas.style.width = `${W}px`;
+    canvas.style.height = `${H}px`;
     ctx.setTransform(DPR, 0, 0, DPR, 0, 0);
     computeCatPath();
     initStars();
@@ -94,14 +98,14 @@ export function createStarfield(
       const u = Math.random(), v = Math.random();
       const theta = 2 * Math.PI * u;
       const phi = Math.acos(2 * v - 1);
-      stars.push({ theta, phi, r: Math.random()*1.2+0.25, baseAlpha: Math.random()*0.6+0.3, twinklePhase: Math.random()*Math.PI*2, twinkleSpeed: Math.random()*0.8+0.3 });
+      stars.push({theta, phi, r: Math.random() * 1.2 + 0.25, baseAlpha: Math.random() * 0.6 + 0.3, twinklePhase: Math.random() * Math.PI * 2, twinkleSpeed: Math.random() * 0.8 + 0.3});
     }
 
     constellations = [];
     constellationStars = [];
     const MIN_ANGLE = 0.42;
     const MIN_COS = Math.cos(MIN_ANGLE);
-    const anchors: { theta: number; phi: number }[] = [];
+    const anchors: Array<{theta: number, phi: number}> = [];
     const MAX_ATTEMPTS = 4000;
     let attempts = 0;
     while (anchors.length < 40 && attempts++ < MAX_ATTEMPTS) {
@@ -109,10 +113,12 @@ export function createStarfield(
       const theta0 = 2 * Math.PI * u;
       const phi0 = Math.acos(2 * v - 1);
       const ok = anchors.every(a => {
-        const dot = Math.sin(phi0)*Math.sin(a.phi)*Math.cos(theta0-a.theta) + Math.cos(phi0)*Math.cos(a.phi);
+        const dot = Math.sin(phi0) * Math.sin(a.phi) * Math.cos(theta0 - a.theta) + Math.cos(phi0) * Math.cos(a.phi);
         return dot < MIN_COS;
       });
-      if (ok) anchors.push({ theta: theta0, phi: phi0 });
+      if (ok) {
+        anchors.push({theta: theta0, phi: phi0});
+      }
     }
 
     const shuffled = CONSTELLATION_LIBRARY.slice().sort(() => Math.random() - 0.5);
@@ -122,29 +128,31 @@ export function createStarfield(
       const pattern = shuffled[idx];
       const sP = Math.sin(anchor.phi), cP = Math.cos(anchor.phi);
       const sT = Math.sin(anchor.theta), cT = Math.cos(anchor.theta);
-      const ex = { x: -sT, y: 0, z: cT };
-      const ey = { x: cP*cT, y: -sP, z: cP*sT };
-      const n = { x: sP*cT, y: cP, z: sP*sT };
+      const ex = {x: -sT, y: 0, z: cT};
+      const ey = {x: cP * cT, y: -sP, z: cP * sT};
+      const n = {x: sP * cT, y: cP, z: sP * sT};
       const sizeRad = 0.14 + Math.random() * 0.08;
       const rot = Math.random() * Math.PI * 2;
       const nodes = pattern.stars.map(([nx, ny]) => {
         const lx = (nx - 0.5) * 2 * sizeRad + (Math.random() - 0.5) * 0.008;
         const ly = (ny - 0.5) * 2 * sizeRad + (Math.random() - 0.5) * 0.008;
-        const rx = lx*Math.cos(rot) - ly*Math.sin(rot);
-        const ry = lx*Math.sin(rot) + ly*Math.cos(rot);
-        const px = n.x + rx*ex.x + ry*ey.x;
-        const py = n.y + rx*ex.y + ry*ey.y;
-        const pz = n.z + rx*ex.z + ry*ey.z;
+        const rx = lx * Math.cos(rot) - ly * Math.sin(rot);
+        const ry = lx * Math.sin(rot) + ly * Math.cos(rot);
+        const px = n.x + rx * ex.x + ry * ey.x;
+        const py = n.y + rx * ex.y + ry * ey.y;
+        const pz = n.z + rx * ex.z + ry * ey.z;
         const mag = Math.hypot(px, py, pz);
-        const ux = px/mag, uy = py/mag, uz = pz/mag;
+        const ux = px / mag, uy = py / mag, uz = pz / mag;
         const phi = Math.acos(Math.max(-1, Math.min(1, uy)));
         const theta = Math.atan2(uz, ux);
-        const star: Star = { theta, phi, r: 1.4+Math.random()*0.6, baseAlpha: 0.9+Math.random()*0.1, twinklePhase: Math.random()*Math.PI*2, twinkleSpeed: 0.6+Math.random()*0.5, isConstellation: true };
+        const star: Star = {theta, phi, r: 1.4 + Math.random() * 0.6, baseAlpha: 0.9 + Math.random() * 0.1, twinklePhase: Math.random() * Math.PI * 2, twinkleSpeed: 0.6 + Math.random() * 0.5, isConstellation: true};
         stars.push(star);
         constellationStars.push(star);
         return star;
       });
-      for (const [a, b] of pattern.edges) constellations.push([nodes[a], nodes[b]]);
+      for (const [a, b] of pattern.edges) {
+        constellations.push([nodes[a], nodes[b]]);
+      }
     }
   }
 
@@ -153,20 +161,22 @@ export function createStarfield(
     const startY = Math.random() * 300 + 40;
     const angle = Math.PI / 4 + (Math.random() - 0.5) * 0.3;
     const speed = 8 + Math.random() * 4;
-    shootingStars.push({ x: startX, y: startY, vx: Math.cos(angle)*speed, vy: Math.sin(angle)*speed, life: 0, maxLife: 60+Math.random()*30, trail: [] });
+    shootingStars.push({x: startX, y: startY, vx: Math.cos(angle) * speed, vy: Math.sin(angle) * speed, life: 0, maxLife: 60 + Math.random() * 30, trail: []});
   }
 
   let t = 0;
   let lastShoot = 0;
   let lastFrameTs = 0;
   let rotationAngle = 0;
-  const ROT_AXIS = (() => { const v = { x: 0.25, y: 0.92, z: 0.30 }; const m = Math.hypot(v.x, v.y, v.z); return { x: v.x/m, y: v.y/m, z: v.z/m }; })();
+  const ROT_AXIS = (() => {
+    const v = {x: 0.25, y: 0.92, z: 0.30}; const m = Math.hypot(v.x, v.y, v.z); return {x: v.x / m, y: v.y / m, z: v.z / m};
+  })();
 
-  function rotateAroundAxis(x: number, y: number, z: number, axis: { x: number; y: number; z: number }, ang: number) {
+  function rotateAroundAxis(x: number, y: number, z: number, axis: {x: number, y: number, z: number}, ang: number) {
     const c = Math.cos(ang), s = Math.sin(ang);
-    const { x: ux, y: uy, z: uz } = axis;
-    const dot = ux*x + uy*y + uz*z;
-    return { x: x*c+(uy*z-uz*y)*s+ux*dot*(1-c), y: y*c+(uz*x-ux*z)*s+uy*dot*(1-c), z: z*c+(ux*y-uy*x)*s+uz*dot*(1-c) };
+    const {x: ux, y: uy, z: uz} = axis;
+    const dot = ux * x + uy * y + uz * z;
+    return {x: x * c + (uy * z - uz * y) * s + ux * dot * (1 - c), y: y * c + (uz * x - ux * z) * s + uy * dot * (1 - c), z: z * c + (ux * y - uy * x) * s + uz * dot * (1 - c)};
   }
 
   function tick(ts: number) {
@@ -180,7 +190,7 @@ export function createStarfield(
     const conColor = isDark ? `200, 210, 255` : `12, 16, 48`;
     ctx.save();
     const opacityMul = Math.max(0, Math.min(1, (state.starOpacity ?? 100) / 100));
-    const cx = W/2, cy = H/2;
+    const cx = W / 2, cy = H / 2;
     const projScale = Math.hypot(W, H) * 0.55;
     for (const s of stars) {
       const sinPhi = Math.sin(s.phi);
@@ -193,7 +203,7 @@ export function createStarfield(
       s._sy = cy + p.y * projScale;
       s._depth = p.z;
       if (!s._visible) continue;
-      if (s._sx < -40 || s._sx > W+40 || s._sy < -40 || s._sy > H+40) continue;
+      if (s._sx < -40 || s._sx > W + 40 || s._sy < -40 || s._sy > H + 40) continue;
       const depthFade = Math.min(1, Math.max(0, (p.z + 0.1) / 0.4));
       const tw = 0.6 + 0.4 * Math.sin(t * s.twinkleSpeed + s.twinklePhase);
       const a = s.baseAlpha * tw * depthFade * opacityMul;
@@ -225,10 +235,12 @@ export function createStarfield(
       }
       ctx.globalAlpha = 1;
     }
-    if (ts - lastShoot > 5000 + Math.random() * 6000 && isDark) { spawnShootingStar(); lastShoot = ts; }
+    if (ts - lastShoot > 5000 + Math.random() * 6000 && isDark) {
+      spawnShootingStar(); lastShoot = ts;
+    }
     shootingStars = shootingStars.filter(ss => {
       ss.x += ss.vx; ss.y += ss.vy; ss.life++;
-      ss.trail.push({ x: ss.x, y: ss.y });
+      ss.trail.push({x: ss.x, y: ss.y});
       if (ss.trail.length > 18) ss.trail.shift();
       const alpha = 1 - (ss.life / ss.maxLife);
       for (let i = 0; i < ss.trail.length; i++) {
@@ -255,12 +267,12 @@ export function createStarfield(
   }
 
   window.addEventListener(`resize`, resize);
-  window.addEventListener(`scroll`, () => computeCatPath(), { passive: true });
+  window.addEventListener(`scroll`, () => computeCatPath(), {passive: true});
   window.addEventListener(`load`, () => setTimeout(computeCatPath, 200));
   document.fonts?.ready?.then(() => computeCatPath());
 
   resize();
   requestAnimationFrame(tick);
 
-  return { initStars };
+  return {initStars};
 }

--- a/website/src/utils/bluesky.ts
+++ b/website/src/utils/bluesky.ts
@@ -8,14 +8,14 @@ interface BskyFacetFeature {
 }
 
 interface BskyFacet {
-  index: { byteStart: number; byteEnd: number };
-  features: BskyFacetFeature[];
+  index: {byteStart: number, byteEnd: number};
+  features: Array<BskyFacetFeature>;
 }
 
 interface BskyPostRecord {
   text: string;
   createdAt: string;
-  facets?: BskyFacet[];
+  facets?: Array<BskyFacet>;
   reply?: unknown;
 }
 
@@ -46,7 +46,7 @@ export interface Skeet {
   likeCount: number;
 }
 
-function renderFacets(text: string, facets?: BskyFacet[]): string {
+function renderFacets(text: string, facets?: Array<BskyFacet>): string {
   if (!facets || facets.length === 0)
     return escapeHtml(text);
 
@@ -71,15 +71,15 @@ function renderFacets(text: string, facets?: BskyFacet[]): string {
     const mention = facet.features.find(f => f.$type === `app.bsky.richtext.facet#mention`);
     const tag = facet.features.find(f => f.$type === `app.bsky.richtext.facet#tag`);
 
-    if (link?.uri) {
+    if (link?.uri)
       html += `<a href="${escapeAttr(link.uri)}" target="_blank" rel="noopener">${segment}</a>`;
-    } else if (mention?.did) {
+    else if (mention?.did)
       html += `<a href="https://bsky.app/profile/${escapeAttr(mention.did)}" target="_blank" rel="noopener">${segment}</a>`;
-    } else if (tag?.tag) {
+    else if (tag?.tag)
       html += `<a href="https://bsky.app/hashtag/${escapeAttr(tag.tag)}" target="_blank" rel="noopener">${segment}</a>`;
-    } else {
+    else
       html += segment;
-    }
+
 
     cursor = byteEnd;
   }
@@ -109,14 +109,14 @@ function postUrlFromUri(uri: string, handle: string): string {
   return `https://bsky.app/profile/${handle}/post/${rkey}`;
 }
 
-export async function fetchSkeets(handle: string, limit = 5): Promise<Skeet[]> {
+export async function fetchSkeets(handle: string, limit = 5): Promise<Array<Skeet>> {
   try {
     const url = `${API_BASE}/app.bsky.feed.getAuthorFeed?actor=${encodeURIComponent(handle)}&limit=${limit * 2}`;
 
     const res = await fetch(url);
     if (!res.ok) return [];
 
-    const data = await res.json() as { feed: BskyFeedItem[] };
+    const data = await res.json() as {feed: Array<BskyFeedItem>};
 
     return data.feed
       .filter(item => !item.reason && !item.post.record.reply)

--- a/website/src/utils/cli.ts
+++ b/website/src/utils/cli.ts
@@ -1,25 +1,10 @@
-import type {BaseData} from '@clipanion/astro';
+import type {BaseData}  from '@clipanion/astro';
+import type {Component} from '@clipanion/tools';
 
-type DataEntry = {id: string; data: BaseData; filePath?: string};
+type DataEntry = {id: string, data: BaseData, filePath?: string};
 
-type OptionComponent = {
-  type: `option`;
-  primaryName: string;
-  aliases: string[];
-  documentation: {description: string; details: string | null} | null;
-  isHidden: boolean;
-  allowBinding: boolean;
-  allowBoolean: boolean;
-};
-
-type PositionalComponent = {
-  type: `positional`;
-  positionalType: `keyword` | `dynamic`;
-  name?: string;
-  expected?: string;
-  documentation?: {description: string; details: string | null} | null;
-  extra_len?: number | null;
-};
+type OptionComponent = Extract<Component, {type: `option`}>;
+type PositionalComponent = Extract<Component, {type: `positional`}>;
 
 function escapeDirective(s: string): string {
   return s.replace(/\\/g, `\\\\`).replace(/\[/g, `\\[`).replace(/\]/g, `\\]`);
@@ -58,7 +43,7 @@ function buildUsageLine(entry: DataEntry): string {
 
 export function cliBody(entry: DataEntry): string {
   const {commandSpec} = entry.data;
-  const lines: string[] = [];
+  const lines: Array<string> = [];
 
   lines.push(`\`\`\`terminal`);
   lines.push(buildUsageLine(entry));
@@ -71,7 +56,7 @@ export function cliBody(entry: DataEntry): string {
 
   const options = commandSpec.components.filter(
     (c): c is OptionComponent => c.type === `option` && !(c as OptionComponent).isHidden,
-  ) as OptionComponent[];
+  ) as Array<OptionComponent>;
 
   if (options.length > 0) {
     for (const option of options) {
@@ -82,8 +67,9 @@ export function cliBody(entry: DataEntry): string {
       lines.push(``);
       lines.push(`### \`${names}\` ${pills}`);
 
-      if (option.documentation?.description)
+      if (option.documentation?.description) {
         lines.push(``, option.documentation.description);
+      }
     }
   }
 

--- a/website/src/utils/highlight.ts
+++ b/website/src/utils/highlight.ts
@@ -1,8 +1,8 @@
-import { createHighlighter, createCssVariablesTheme } from 'shiki';
+import {createHighlighter, createCssVariablesTheme} from 'shiki';
 
 const cssVarsTheme = createCssVariablesTheme({
-  name: 'css-variables',
-  variablePrefix: '--shiki-',
+  name: `css-variables`,
+  variablePrefix: `--shiki-`,
   variableDefaults: {},
   fontStyle: true,
 });
@@ -14,16 +14,16 @@ async function getHighlighter() {
 
   highlighter = await createHighlighter({
     themes: [cssVarsTheme],
-    langs: ['javascript', 'typescript', 'json', 'yaml', 'bash', 'html', 'css', 'jsx', 'tsx', 'diff', 'shell'],
+    langs: [`javascript`, `typescript`, `json`, `yaml`, `bash`, `html`, `css`, `jsx`, `tsx`, `diff`, `shell`],
   });
 
   return highlighter;
 }
 
 const LANG_ALIASES: Record<string, string> = {
-  js: 'javascript',
-  ts: 'typescript',
-  sh: 'shell',
+  js: `javascript`,
+  ts: `typescript`,
+  sh: `shell`,
 };
 
 export async function highlight(code: string, lang: string): Promise<string> {
@@ -37,7 +37,7 @@ export async function highlight(code: string, lang: string): Promise<string> {
 
   const html = hl.codeToHtml(code, {
     lang: resolved,
-    theme: 'css-variables',
+    theme: `css-variables`,
   });
 
   const match = html.match(/<code>(.+?)<\/code>/s);
@@ -46,8 +46,8 @@ export async function highlight(code: string, lang: string): Promise<string> {
 
 function escapeHtml(str: string): string {
   return str
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;');
+    .replace(/&/g, `&amp;`)
+    .replace(/</g, `&lt;`)
+    .replace(/>/g, `&gt;`)
+    .replace(/"/g, `&quot;`);
 }

--- a/website/src/utils/render-markdown.ts
+++ b/website/src/utils/render-markdown.ts
@@ -1,11 +1,12 @@
-import {unified} from 'unified';
-import remarkParse from 'remark-parse';
-import remarkDirective from 'remark-directive';
-import remarkDocs from '../../plugins/remark-docs.mjs';
-import remarkRehype from 'remark-rehype';
-import rehypeRaw from 'rehype-raw';
-import rehypeDocs from '../../plugins/rehype-docs.mjs';
+import rehypeRaw       from 'rehype-raw';
 import rehypeStringify from 'rehype-stringify';
+import remarkDirective from 'remark-directive';
+import remarkParse     from 'remark-parse';
+import remarkRehype    from 'remark-rehype';
+import {unified}       from 'unified';
+
+import rehypeDocs      from '../../plugins/rehype-docs.mjs';
+import remarkDocs      from '../../plugins/remark-docs.mjs';
 
 const processor = unified()
   .use(remarkParse)

--- a/website/src/utils/schema.ts
+++ b/website/src/utils/schema.ts
@@ -82,7 +82,7 @@ function yamlComment(s: string): string {
 
 function exampleToYaml(name: string, example: any): string {
   const description = example?.description || `Example`;
-  const value = example !== null && typeof example === `object` && Object.prototype.hasOwnProperty.call(example, `value`)
+  const value = example !== null && typeof example === `object` && Object.hasOwn(example, `value`)
     ? example.value
     : example;
 
@@ -103,16 +103,19 @@ function propertyToMarkdown(name: string, prop: Record<string, any>): string {
   if (prop.title)
     lines.push(``, `**${prop.title}**`);
 
+
   if (prop.description)
     lines.push(``, prop.description);
 
-  if (Array.isArray(prop._examples) && prop._examples.length > 0)
+
+  if (Array.isArray(prop._examples) && prop._examples.length > 0) {
     lines.push(
       ``,
       `\`\`\`yaml`,
       prop._examples.map((example: any) => exampleToYaml(name, example)).join(`\n\n`),
       `\`\`\``,
     );
+  }
 
   return lines.join(`\n`);
 }
@@ -121,12 +124,13 @@ function isHidden(prop: Record<string, any>): boolean {
   return prop._hidden === true;
 }
 
-function flattenToMarkdown(properties: Record<string, any>, prefix = ``): string[] {
-  const sections: string[] = [];
+function flattenToMarkdown(properties: Record<string, any>, prefix = ``): Array<string> {
+  const sections: Array<string> = [];
 
   for (const [key, prop] of Object.entries(properties)) {
     if (isHidden(prop as Record<string, any>))
       continue;
+
 
     const name = prefix + key;
     sections.push(propertyToMarkdown(name, prop as Record<string, any>));
@@ -134,10 +138,12 @@ function flattenToMarkdown(properties: Record<string, any>, prefix = ``): string
     if ((prop as any).properties)
       sections.push(...flattenToMarkdown((prop as any).properties, `${name}.`));
 
+
     if ((prop as any).patternProperties) {
-      for (const patternProp of Object.values((prop as any).patternProperties) as any[]) {
-        if (patternProp.properties)
+      for (const patternProp of Object.values((prop as any).patternProperties) as Array<any>) {
+        if (patternProp.properties) {
           sections.push(...flattenToMarkdown(patternProp.properties, `${name}[name].`));
+        }
       }
     }
   }
@@ -145,16 +151,17 @@ function flattenToMarkdown(properties: Record<string, any>, prefix = ``): string
   return sections;
 }
 
-export function schemaFieldNames(schema: Record<string, any>): string[] {
+export function schemaFieldNames(schema: Record<string, any>): Array<string> {
   return flattenFieldNames(schema.properties);
 }
 
-function flattenFieldNames(properties: Record<string, any>, prefix = ``): string[] {
-  const names: string[] = [];
+function flattenFieldNames(properties: Record<string, any>, prefix = ``): Array<string> {
+  const names: Array<string> = [];
 
   for (const [key, prop] of Object.entries(properties)) {
     if (isHidden(prop as Record<string, any>))
       continue;
+
 
     const name = prefix + key;
     names.push(name);
@@ -162,10 +169,12 @@ function flattenFieldNames(properties: Record<string, any>, prefix = ``): string
     if ((prop as any).properties)
       names.push(...flattenFieldNames((prop as any).properties, `${name}.`));
 
+
     if ((prop as any).patternProperties) {
-      for (const patternProp of Object.values((prop as any).patternProperties) as any[]) {
-        if (patternProp.properties)
+      for (const patternProp of Object.values((prop as any).patternProperties) as Array<any>) {
+        if (patternProp.properties) {
           names.push(...flattenFieldNames(patternProp.properties, `${name}[name].`));
+        }
       }
     }
   }
@@ -174,7 +183,7 @@ function flattenFieldNames(properties: Record<string, any>, prefix = ``): string
 }
 
 export function schemaToMarkdown(schema: Record<string, any>): string {
-  const parts: string[] = [];
+  const parts: Array<string> = [];
 
   if (schema.description)
     parts.push(schema.description);

--- a/website/tsconfig.json
+++ b/website/tsconfig.json
@@ -1,3 +1,23 @@
 {
-  "extends": "astro/tsconfigs/strict"
+  "extends": "astro/tsconfigs/strict",
+  "compilerOptions": {
+    "composite": true,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "noEmit": false,
+    "outDir": "./dist/types"
+  },
+  "include": [
+    ".astro/**/*.d.ts",
+    "astro.config.mjs",
+    "config/**/*",
+    "plugins/**/*",
+    "public/**/*",
+    "scripts/**/*",
+    "src/**/*"
+  ],
+  "files": [
+    "config/manifest.json",
+    "config/yarnrc.json"
+  ]
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Lint and formatting with limited logic changes; docs terminal copy and quiz share toasts are the only small UX deltas to sanity-check.
> 
> **Overview**
> **Brings the Yarn website back in line with the repo ESLint setup** by extending root `eslint.config.mjs` with website-specific globals, default-export exceptions, and targeted rule disables (e.g. `no-control-regex` for terminal recording).
> 
> Across `website/`, the diff is mostly **mechanical lint/style fixes**: backtick strings, brace style, `Array<>` / `ReadonlyArray<>` types, import ordering, and explicit `useEffect` cleanups. Markdown plugins (`remark-docs`, `rehype-footnote-tooltips`, `rehype-docs`) get small control-flow tweaks (e.g. `visit` callbacks no longer return stale indices).
> 
> A few **behavioral tweaks** worth a quick look: **docs copy** now builds terminal clipboard text by skipping `out`/`comment` lines instead of re-prefixing prompts; **quiz** drops the shared `showToast` helper (share feedback is label-only); **package `StatGrid`** stops computing an unused file count.
> 
> **Tooling**: `website/tsconfig.json` enables composite declaration emit; adds `website/src/env.d.ts` for Astro client types; `cli.ts` types Clipanion components via `Extract` instead of hand-rolled shapes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa3ad8d98b09aab0f4ad4c4d41c58263a56d0661. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->