### PR TITLE
Improves reporting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4843,6 +4843,7 @@ dependencies = [
  "serde_yaml",
  "sha1",
  "sha2",
+ "similar",
  "smallvec",
  "spki",
  "thiserror 2.0.18",

--- a/packages/zpm/Cargo.toml
+++ b/packages/zpm/Cargo.toml
@@ -34,6 +34,7 @@ regex = { workspace = true }
 rust-ini = { workspace = true }
 serde_with = { workspace = true }
 serde_yaml = { workspace = true }
+similar = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 tower = { workspace = true, features = ["limit"] }

--- a/packages/zpm/src/build.rs
+++ b/packages/zpm/src/build.rs
@@ -30,6 +30,24 @@ pub enum Command {
     },
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BuildSkip {
+    Disabled,
+    Incompatible,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BuildStep {
+    Skip(BuildSkip),
+    Commands(Vec<Command>),
+}
+
+impl BuildStep {
+    pub fn is_noop(&self) -> bool {
+        matches!(self, Self::Commands(commands) if commands.is_empty())
+    }
+}
+
 pub struct ArtifactFinder;
 
 impl DiffController for ArtifactFinder {
@@ -52,14 +70,37 @@ impl DiffController for ArtifactFinder {
 pub struct BuildRequest {
     pub cwd: Path,
     pub locator: Locator,
-    pub commands: Vec<Command>,
+    pub build_step: BuildStep,
     pub allowed_to_fail: bool,
     pub force_rebuild: bool,
     pub inline_builds: bool,
 }
 
 impl BuildRequest {
+    fn persists_build_state(&self) -> bool {
+        matches!(self.build_step, BuildStep::Commands(_) | BuildStep::Skip(BuildSkip::Disabled))
+    }
+
     pub async fn run(self, project: &Project, hash: Hash64) -> Result<ScriptResult, Error> {
+        let commands = match self.build_step {
+            BuildStep::Skip(BuildSkip::Incompatible) => {
+                return Ok(ScriptResult::new_success());
+            },
+
+            BuildStep::Skip(BuildSkip::Disabled) => {
+                crate::report::if_active(|report| {
+                    report.warn(format!(
+                        "{} lists build scripts, but its build has been explicitly disabled through configuration.",
+                        self.locator.to_print_string(),
+                    ));
+                });
+
+                return Ok(ScriptResult::new_success());
+            },
+
+            BuildStep::Commands(commands) => commands,
+        };
+
         let cwd_abs = project.project_cwd
             .with_join(&self.cwd);
 
@@ -104,7 +145,7 @@ impl BuildRequest {
             let mut combined_stdout = Vec::<u8>::new();
             let mut combined_stderr = Vec::<u8>::new();
 
-            for command in self.commands.iter() {
+            for command in commands.iter() {
                 let script_result = match command {
                     Command::Program {name, args} => {
                         script_env.run_exec(name, args).await?
@@ -323,9 +364,11 @@ impl<'a> BuildManager<'a> {
                 emit_build_failure_warning(&request.locator);
             }
         } else {
-            self.build_state_out.entries.entry(request.locator.clone())
-                .or_insert_with(BTreeMap::new)
-                .insert(request.cwd.clone(), hash);
+            if request.persists_build_state() {
+                self.build_state_out.entries.entry(request.locator.clone())
+                    .or_insert_with(BTreeMap::new)
+                    .insert(request.cwd.clone(), hash);
+            }
 
             if let Some(dependents) = self.dependents.get_mut(&idx) {
                 for &dependent_idx in dependents.iter() {
@@ -355,7 +398,7 @@ impl<'a> BuildManager<'a> {
                 let tree_hash
                     = self.get_hash(project, &req.locator);
 
-                if !force_rebuild {
+                if req.persists_build_state() && !force_rebuild {
                     let existing_hash = build_state.entries
                         .get(&req.locator)
                         .and_then(|entries| entries.get(&req.cwd));

--- a/packages/zpm/src/error.rs
+++ b/packages/zpm/src/error.rs
@@ -12,13 +12,6 @@ fn render_backtrace(backtrace: &std::backtrace::Backtrace) -> String {
     }
 }
 
-fn format_lockfile_diff(diff: &Option<String>) -> String {
-    match diff {
-        Some(diff) if !diff.is_empty() => format!("\n\nLockfile changes:\n{}", diff),
-        _ => String::new(),
-    }
-}
-
 pub async fn set_timeout<F: Future>(timeout: std::time::Duration, f: F) -> Result<F::Output, Error> {
     let res = tokio::time::timeout(timeout, f).await
         .map_err(|_| Error::TaskTimeout)?;
@@ -94,11 +87,11 @@ pub enum Error {
     #[error("Checksum mismatch for {}", .0.to_print_string())]
     ChecksumMismatch(Locator),
 
-    #[error("The lockfile would have been created by this install, which is explicitly forbidden.{}", format_lockfile_diff(diff))]
-    ImmutableLockfileCreation { diff: Option<String> },
+    #[error("The lockfile would have been created by this install, which is explicitly forbidden.")]
+    ImmutableLockfileCreation,
 
-    #[error("The lockfile would have been modified by this install, which is explicitly forbidden.{}", format_lockfile_diff(diff))]
-    ImmutableLockfileModification { diff: Option<String> },
+    #[error("The lockfile would have been modified by this install, which is explicitly forbidden.")]
+    ImmutableLockfileModification,
 
     #[error("Cannot autofix a lockfile when running an immutable install.")]
     ImmutableLockfileAutofix,

--- a/packages/zpm/src/error.rs
+++ b/packages/zpm/src/error.rs
@@ -12,6 +12,13 @@ fn render_backtrace(backtrace: &std::backtrace::Backtrace) -> String {
     }
 }
 
+fn format_lockfile_diff(diff: &Option<String>) -> String {
+    match diff {
+        Some(diff) if !diff.is_empty() => format!("\n\nLockfile changes:\n{}", diff),
+        _ => String::new(),
+    }
+}
+
 pub async fn set_timeout<F: Future>(timeout: std::time::Duration, f: F) -> Result<F::Output, Error> {
     let res = tokio::time::timeout(timeout, f).await
         .map_err(|_| Error::TaskTimeout)?;
@@ -87,8 +94,11 @@ pub enum Error {
     #[error("Checksum mismatch for {}", .0.to_print_string())]
     ChecksumMismatch(Locator),
 
-    #[error("The lockfile would have been created by this install, which is explicitly forbidden.")]
-    ImmutableLockfile,
+    #[error("The lockfile would have been created by this install, which is explicitly forbidden.{}", format_lockfile_diff(diff))]
+    ImmutableLockfileCreation { diff: Option<String> },
+
+    #[error("The lockfile would have been modified by this install, which is explicitly forbidden.{}", format_lockfile_diff(diff))]
+    ImmutableLockfileModification { diff: Option<String> },
 
     #[error("Cannot autofix a lockfile when running an immutable install.")]
     ImmutableLockfileAutofix,

--- a/packages/zpm/src/install.rs
+++ b/packages/zpm/src/install.rs
@@ -902,80 +902,25 @@ impl Install {
         });
     }
 
-    /// Emits a warning/info once per *physical* locator with build
-    /// commands but scripts disabled. Deduping avoids repeating the
-    /// same line for every virtualised instance.
-    async fn report_disabled_build_scripts(&self, project: &Project) {
-        let report_guard = current_report().await;
-        let Some(report) = report_guard.as_ref() else {
-            return;
-        };
-
-        let dependencies_meta = crate::linker::helpers::TopLevelConfiguration::from_project(project);
-
-        let mut warned: BTreeSet<Locator> = BTreeSet::new();
-
-        for (virtual_locator, resolution) in &self.install_state.resolution_tree.locator_resolutions {
-            let physical_locator = virtual_locator.physical_locator();
-            if !warned.insert(physical_locator.clone()) {
-                continue;
-            }
-
-            // Workspaces are always allowed to run their own scripts.
-            if physical_locator.reference.is_workspace_reference() {
-                continue;
-            }
-
-            let Some(package_flags) = self.install_state.content_flags.get(&physical_locator) else {
-                continue;
-            };
-
-            if package_flags.build_commands.is_empty() {
-                continue;
-            }
-
-            let package_ident = match &physical_locator.reference {
-                Reference::Registry(params) => &params.ident,
-                _ => &physical_locator.ident,
-            };
-
-            let package_meta = dependencies_meta.iter()
-                .find(|(selector, _)| selector.check(package_ident, &resolution.version))
-                .map(|(_, meta)| meta.clone())
-                .unwrap_or_default();
-
-            let scripts_allowed_by_meta = package_meta.built
-                .unwrap_or(project.config.settings.enable_scripts.value);
-
-            if scripts_allowed_by_meta {
-                continue;
-            }
-
-            if package_meta.built == Some(false) {
-                report.info(format!(
-                    "{} lists build scripts, but its build has been explicitly disabled through configuration.",
-                    physical_locator.to_print_string(),
-                ));
-            } else {
-                report.warn(format!(
-                    "{} lists build scripts, but its build has been explicitly disabled through configuration.",
-                    physical_locator.to_print_string(),
-                ));
-            }
-        }
-    }
-
     async fn report_package_extension_diagnostics(&self, project: &Project) {
-        let report_guard = current_report().await;
+        let report_guard
+            = current_report().await;
+
         let Some(report) = report_guard.as_ref() else {
             return;
         };
 
-        let tracking = self.extension_tracking.lock().unwrap();
+        let tracking
+            = self.extension_tracking.lock().unwrap();
+
+        let mut warnings
+            = vec![];
 
         for (descriptor, extension) in project.config.settings.package_extensions.iter() {
-            let matched = tracking.matched.contains(descriptor);
-            let parent = descriptor.ident.to_print_string();
+            let matched
+                = tracking.matched.contains(descriptor);
+            let parent
+                = descriptor.ident.to_print_string();
 
             let entries = extension.dependencies.keys()
                 .map(|ident| ExtensionFieldKey::Dependency(ident.clone()))
@@ -986,16 +931,17 @@ impl Install {
                     .map(|(ident, _)| ExtensionFieldKey::PeerDependencyMetaOptional(ident.clone())));
 
             for key in entries {
-                let rule_key = (descriptor.clone(), key.clone());
+                let rule_key
+                    = (descriptor.clone(), key.clone());
 
                 if !matched {
-                    report.warn(format!(
+                    warnings.push(format!(
                         "{} ➤ {}: No matching package in the dependency tree; you may not need this rule anymore.",
                         parent,
                         key.render(),
                     ));
                 } else if tracking.redundant.contains(&rule_key) && !tracking.applied.contains(&rule_key) {
-                    report.warn(format!(
+                    warnings.push(format!(
                         "{} ➤ {}: This rule seems redundant when applied on the original package; the extension may have been applied upstream.",
                         parent,
                         key.render(),
@@ -1003,10 +949,19 @@ impl Install {
                 }
             }
         }
+
+        if !warnings.is_empty() {
+            report.push_section("Package extension diagnostics".to_string());
+
+            for warning in warnings {
+                report.warn(warning);
+            }
+
+            report.pop_section();
+        }
     }
 
     pub async fn link_and_build(mut self, project: &mut Project) -> Result<InstallResult, Error> {
-        self.report_disabled_build_scripts(project).await;
         self.report_package_extension_diagnostics(project).await;
 
         let graph = build_locator_graph(
@@ -1069,7 +1024,7 @@ impl Install {
                     = build::BuildManager::new(link_result.build_requests).run(project);
 
                 let build_result
-                    = async_section("Building the project", build_future).await?;
+                    = async_section("Building packages", build_future).await?;
 
                 if !build_result.build_errors.is_empty() {
                     return Err(Error::SilentError);

--- a/packages/zpm/src/linker/helpers.rs
+++ b/packages/zpm/src/linker/helpers.rs
@@ -343,7 +343,7 @@ pub fn populate_build_entry_dependencies(package_build_entries: &BTreeMap<Locato
 }
 pub struct PackageBuildInfo {
     pub must_extract: bool,
-    pub build_commands: Option<Vec<build::Command>>,
+    pub build_step: build::BuildStep,
 }
 
 pub fn get_package_internal_info(project: &Project, install: &Install, dependencies_meta: &Vec<(VersionFilter, PackageMeta)>, locator: &Locator, resolution: &Resolution, physical_package_data: &PackageData) -> PackageBuildInfo {
@@ -375,9 +375,10 @@ pub fn get_package_internal_info(project: &Project, install: &Install, dependenc
     // .pnp.cjs file to change depending on the system.
     let has_build_commands = package_flags.build_commands.len() > 0;
     let scripts_allowed_by_meta = package_meta.built.unwrap_or(project.config.settings.enable_scripts.value);
+    let scripts_can_run
+        = locator.reference.is_workspace_reference() || scripts_allowed_by_meta;
     let should_build_if_compatible
-        = has_build_commands
-            && (locator.reference.is_workspace_reference() || scripts_allowed_by_meta);
+        = has_build_commands && scripts_can_run;
 
     // Optional dependencies baked by zip archives are always extracted,
     // as we have no way to know whether they would be extracted if we
@@ -399,14 +400,18 @@ pub fn get_package_internal_info(project: &Project, install: &Install, dependenc
     let is_compatible = resolution.requirements
         .validate_system(&System::from_current());
 
-    let must_build
-        = should_build_if_compatible && is_compatible;
-
-    let build_commands
-        = must_build.then_some(package_flags.build_commands.clone());
+    let build_step = if !has_build_commands {
+        build::BuildStep::Commands(Vec::new())
+    } else if !is_compatible {
+        build::BuildStep::Skip(build::BuildSkip::Incompatible)
+    } else if !scripts_can_run {
+        build::BuildStep::Skip(build::BuildSkip::Disabled)
+    } else {
+        build::BuildStep::Commands(package_flags.build_commands.clone())
+    };
 
     PackageBuildInfo {
         must_extract,
-        build_commands,
+        build_step,
     }
 }

--- a/packages/zpm/src/linker/nm/mod.rs
+++ b/packages/zpm/src/linker/nm/mod.rs
@@ -450,16 +450,16 @@ fn build_requests_from_locations(
             physical_package_data,
         );
 
-        let Some(build_commands) = info.build_commands else {
+        if info.build_step.is_noop() {
             continue;
-        };
+        }
 
         package_build_entries.insert(locator.clone(), all_build_entries.len());
 
         all_build_entries.push(build::BuildRequest {
             cwd: build_cwd.clone(),
             locator: locator.clone(),
-            commands: build_commands,
+            build_step: info.build_step,
             allowed_to_fail: tree.optional_builds.contains(locator),
             force_rebuild: force_rebuild_locators.contains(locator),
             inline_builds: install.inline_builds,

--- a/packages/zpm/src/linker/pnp.rs
+++ b/packages/zpm/src/linker/pnp.rs
@@ -398,13 +398,9 @@ pub async fn link_project_pnp<'a>(project: &'a Project, install: &'a Install) ->
             continue;
         }
 
-        if let Some(build_commands) = package_build_info.build_commands {
-            let build_cwd = match is_physically_on_disk {
-                true => {
-                    package_location_rel.clone()
-                },
-
-                false => {
+        if !package_build_info.build_step.is_noop() {
+            let build_cwd = match &package_build_info.build_step {
+                build::BuildStep::Commands(_) if !is_physically_on_disk => {
                     let build_dir_base
                         = Path::temp_dir_pattern("zpm-<>")?;
 
@@ -417,6 +413,10 @@ pub async fn link_project_pnp<'a>(project: &'a Project, install: &'a Install) ->
 
                     build_dir.relative_to(&project.project_cwd)
                 },
+
+                _ => {
+                    package_location_rel.clone()
+                },
             };
 
             package_build_entries.insert(
@@ -427,7 +427,7 @@ pub async fn link_project_pnp<'a>(project: &'a Project, install: &'a Install) ->
             all_build_entries.push(build::BuildRequest {
                 cwd: build_cwd,
                 locator: locator.clone(),
-                commands: build_commands,
+                build_step: package_build_info.build_step,
                 allowed_to_fail: install.install_state.resolution_tree.optional_builds.contains(locator),
                 force_rebuild: is_freshly_unplugged,
                 inline_builds: install.inline_builds,

--- a/packages/zpm/src/linker/pnpm.rs
+++ b/packages/zpm/src/linker/pnpm.rs
@@ -131,7 +131,7 @@ pub async fn link_project_pnpm<'a>(project: &'a Project, install: &'a Install) -
             physical_package_data,
         );
 
-        if let Some(build_commands) = package_build_info.build_commands {
+        if !package_build_info.build_step.is_noop() {
             // Virtualized locators share their build with the physical
             // counterpart — only the physical entry should drive a build.
             if !locator.reference.is_virtual_reference() {
@@ -143,7 +143,7 @@ pub async fn link_project_pnpm<'a>(project: &'a Project, install: &'a Install) -
                 all_build_entries.push(build::BuildRequest {
                     cwd: package_location_rel,
                     locator: locator.clone(),
-                    commands: build_commands,
+                    build_step: package_build_info.build_step,
                     allowed_to_fail: install.install_state.resolution_tree.optional_builds.contains(locator),
                     force_rebuild: false, // TODO: track this properly for pnpm
                     inline_builds: install.inline_builds,

--- a/packages/zpm/src/project.rs
+++ b/packages/zpm/src/project.rs
@@ -1,12 +1,13 @@
-use std::{collections::{BTreeMap, BTreeSet, HashSet}, io::ErrorKind, sync::Arc, time::{Duration, UNIX_EPOCH}};
+use std::{collections::{BTreeMap, BTreeSet, HashSet}, io::ErrorKind, sync::{Arc, mpsc}, time::{Duration, UNIX_EPOCH}};
 
+use colored::Colorize;
 use globset::{GlobBuilder, GlobSetBuilder};
 use zpm_config::{Configuration, ConfigurationContext, Source};
 use zpm_macro_enum::zpm_enum;
 use zpm_parsers::JsonDocument;
 use zpm_primitives::{Descriptor, Ident, Locator, Range, Reference, WorkspaceIdentReference, WorkspaceMagicRange, WorkspacePathReference};
 use zpm_tasks::{parse as parse_taskfile, ResolvedTasks, TaskFile, TaskId};
-use zpm_utils::{Glob, LastModifiedAt, Path, ToFileString, ToHumanString, is_terminal, start_progress};
+use zpm_utils::{DataType, Glob, IoResultExt, LastModifiedAt, Path, ToFileString, ToHumanString, is_terminal, start_progress};
 use serde::Deserialize;
 use zpm_formats::zip::ZipSupport;
 
@@ -32,6 +33,64 @@ pub const MANIFEST_NAME: &str = "package.json";
 pub const PNP_CJS_NAME: &str = ".pnp.cjs";
 pub const PNP_ESM_NAME: &str = ".pnp.loader.mjs";
 pub const PNP_DATA_NAME: &str = ".pnp.data.json";
+const LOCKFILE_DIFF_LINE_LIMIT: usize = 100;
+const LOCKFILE_DIFF_TIMEOUT: Duration = Duration::from_secs(3);
+
+fn colorize_diff_line(line: &str) -> String {
+    if line.starts_with("+") && !line.starts_with("+++") {
+        line.green().to_string()
+    } else if line.starts_with("-") && !line.starts_with("---") {
+        line.red().to_string()
+    } else if line.starts_with("@@") {
+        DataType::Info.colorize(line)
+    } else if line.starts_with("+++") || line.starts_with("---") {
+        DataType::Path.colorize(line)
+    } else {
+        line.to_string()
+    }
+}
+
+fn render_lockfile_diff(current: Option<Vec<u8>>, expected: Vec<u8>) -> Option<String> {
+    let (tx, rx) = mpsc::channel();
+
+    std::thread::spawn(move || {
+        let current_text = current
+            .as_deref()
+            .map(String::from_utf8_lossy)
+            .unwrap_or_else(|| "".into())
+            .into_owned();
+        let expected_text
+            = String::from_utf8_lossy(&expected).into_owned();
+
+        let diff = similar::TextDiff::from_lines(&current_text, &expected_text)
+            .unified_diff()
+            .header("current yarn.lock", "generated yarn.lock")
+            .to_string();
+
+        let mut truncated = false;
+        let mut lines = Vec::new();
+
+        for (idx, line) in diff.lines().enumerate() {
+            if idx >= LOCKFILE_DIFF_LINE_LIMIT {
+                truncated = true;
+                break;
+            }
+
+            lines.push(colorize_diff_line(line));
+        }
+
+        if truncated {
+            lines.push(DataType::Code.colorize(&format!(
+                "... Diff truncated after {} lines.",
+                LOCKFILE_DIFF_LINE_LIMIT,
+            )));
+        }
+
+        let _ = tx.send(lines.join("\n"));
+    });
+
+    rx.recv_timeout(LOCKFILE_DIFF_TIMEOUT).ok()
+}
 
 #[zpm_enum(or_else = |s| Err(Error::InvalidInstallMode(s.to_string())))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -407,7 +466,21 @@ impl Project {
             = JsonDocument::to_string_pretty(lockfile)?;
 
         if self.config.settings.enable_immutable_installs.value {
-            lockfile_path.fs_expect_with(contents.as_bytes(), || Error::ImmutableLockfile)?;
+            let current_content = lockfile_path
+                .fs_read()
+                .ok_missing()?;
+
+            if current_content.as_ref().is_some_and(|current| current.as_slice() == contents.as_bytes()) {
+                return Ok(());
+            }
+
+            let diff
+                = render_lockfile_diff(current_content.clone(), contents.into_bytes());
+
+            return Err(match current_content {
+                Some(_) => Error::ImmutableLockfileModification { diff },
+                None => Error::ImmutableLockfileCreation { diff },
+            });
         } else {
             lockfile_path.fs_change(contents, false)?;
         }

--- a/packages/zpm/src/project.rs
+++ b/packages/zpm/src/project.rs
@@ -477,9 +477,15 @@ impl Project {
             let diff
                 = render_lockfile_diff(current_content.clone(), contents.into_bytes());
 
+            if let Some(diff) = diff {
+                crate::report::if_active(|report| {
+                    report.add_log_format("Lockfile changes".to_string(), diff);
+                });
+            }
+
             return Err(match current_content {
-                Some(_) => Error::ImmutableLockfileModification { diff },
-                None => Error::ImmutableLockfileCreation { diff },
+                Some(_) => Error::ImmutableLockfileModification,
+                None => Error::ImmutableLockfileCreation,
             });
         } else {
             lockfile_path.fs_change(contents, false)?;

--- a/packages/zpm/src/report.rs
+++ b/packages/zpm/src/report.rs
@@ -218,10 +218,19 @@ pub struct ReportCounters {
 #[derive(Debug)]
 pub enum ReportMessage {
     Line(Severity, String),
-    LogFile(Path),
+    LogExtra(LogExtra),
     PushSection(String),
     PopSection,
     Prompt(PromptType),
+}
+
+#[derive(Debug)]
+pub enum LogExtra {
+    File(Path),
+    Format {
+        title: String,
+        text: String,
+    },
 }
 
 fn strip_ansi_codes(input: &str) -> String {
@@ -309,7 +318,7 @@ struct Reporter {
 
     last_message_type: Option<LastMessageType>,
     buffered_lines: Option<Vec<String>>,
-    log_paths: Vec<Path>,
+    log_extras: Vec<LogExtra>,
     sections: Vec<SectionState>,
     spinner_idx: Option<usize>,
     prompt_tx: mpsc::Sender<String>,
@@ -327,7 +336,7 @@ impl Reporter {
             counters,
             last_message_type: None,
             buffered_lines,
-            log_paths: Vec::new(),
+            log_extras: Vec::new(),
             sections: Vec::new(),
             spinner_idx: None,
             prompt_tx,
@@ -410,8 +419,8 @@ impl Reporter {
                 self.on_line(writer, severity, &message);
             },
 
-            ReportMessage::LogFile(log_path) => {
-                self.log_paths.push(log_path);
+            ReportMessage::LogExtra(log_extra) => {
+                self.log_extras.push(log_extra);
             },
 
             ReportMessage::PushSection(name) => {
@@ -435,16 +444,24 @@ impl Reporter {
     }
 
     fn on_end<T: Write>(&mut self, writer: &mut T) {
-        let log_paths = std::mem::take(&mut self.log_paths);
+        let log_extras = std::mem::take(&mut self.log_extras);
 
-        for log_path in &log_paths {
-            let log_content = log_path.fs_read_text().unwrap();
+        for log_extra in &log_extras {
+            let (title, log_content) = match log_extra {
+                LogExtra::File(log_path) => {
+                    (log_path.to_print_string(), log_path.fs_read_text().unwrap())
+                },
+
+                LogExtra::Format {title, text} => {
+                    (title.clone(), text.clone())
+                },
+            };
 
             if self.config.json {
-                self.write_line(writer, &log_path.to_print_string(), Severity::Info);
+                self.write_line(writer, &title, Severity::Info);
                 self.write_line(writer, &log_content, Severity::Info);
             } else {
-                writeln!(writer, "\n{}\n", log_path.to_print_string()).unwrap();
+                writeln!(writer, "\n{}\n", title.bold().underline()).unwrap();
                 writeln!(writer, "{}", log_content).unwrap();
             }
         }
@@ -776,7 +793,14 @@ impl StreamReport {
     }
 
     pub fn add_log_file(&self, log_path: Path) {
-        self.report(ReportMessage::LogFile(log_path));
+        self.report(ReportMessage::LogExtra(LogExtra::File(log_path)));
+    }
+
+    pub fn add_log_format(&self, title: String, text: String) {
+        self.report(ReportMessage::LogExtra(LogExtra::Format {
+            title,
+            text,
+        }));
     }
 
     pub fn error(&self, error: Error) -> bool {
@@ -787,7 +811,7 @@ impl StreamReport {
         }
 
         if let Error::ChildProcessFailedWithLog(_, log_path) = error {
-            self.report(ReportMessage::LogFile(log_path));
+            self.add_log_file(log_path);
         }
 
         emitted

--- a/tests/acceptance-tests/pkg-tests-specs/sources/commands/install.test.ts
+++ b/tests/acceptance-tests/pkg-tests-specs/sources/commands/install.test.ts
@@ -121,7 +121,7 @@ describe(`Commands`, () => {
             FORCE_COLOR: `1`,
           },
         })).rejects.toMatchObject({
-          stdout: expect.stringMatching(/Lockfile changes:[\s\S]*\x1b\[[0-9;]*m[-+]/),
+          stdout: expect.stringMatching(/Lockfile changes[\s\S]*\x1b\[[0-9;]*m[-+]/),
         });
       }),
     );

--- a/tests/acceptance-tests/pkg-tests-specs/sources/commands/install.test.ts
+++ b/tests/acceptance-tests/pkg-tests-specs/sources/commands/install.test.ts
@@ -14,30 +14,6 @@ describe(`Commands`, () => {
           indent: `· `,
           name: null,
           type: `info`,
-        }, {
-          data: `┌ Installing packages`,
-          displayName: null,
-          indent: ``,
-          name: null,
-          type: `info`,
-        }, {
-          data: `└ Completed`,
-          displayName: null,
-          indent: ``,
-          name: null,
-          type: `info`,
-        }, {
-          data: `┌ Linking the project`,
-          displayName: null,
-          indent: ``,
-          name: null,
-          type: `info`,
-        }, {
-          data: `└ Completed`,
-          displayName: null,
-          indent: ``,
-          name: null,
-          type: `info`,
         }]);
       }),
     );
@@ -130,6 +106,27 @@ describe(`Commands`, () => {
     );
 
     test(
+      `it should print a diff when refusing to change the lockfile when using --immutable`,
+      makeTemporaryEnv({}, async ({path, run, source}) => {
+        await run(`install`);
+
+        await xfs.writeJsonPromise(ppath.join(path, `yarn.lock`), {
+          dependencies: {
+            [`no-deps`]: `1.0.0`,
+          },
+        });
+
+        await expect(run(`install`, `--immutable`, {
+          env: {
+            FORCE_COLOR: `1`,
+          },
+        })).rejects.toMatchObject({
+          stdout: expect.stringMatching(/Lockfile changes:[\s\S]*\x1b\[[0-9;]*m[-+]/),
+        });
+      }),
+    );
+
+    test(
       `it should refuse to create a lockfile when using --frozen-lockfile`,
       makeTemporaryEnv({
         dependencies: {
@@ -151,7 +148,7 @@ describe(`Commands`, () => {
           },
         });
 
-        await expect(run(`install`, `--immutable`)).rejects.toThrow(/The lockfile would have been created by this install/);
+        await expect(run(`install`, `--immutable`)).rejects.toThrow(/The lockfile would have been modified by this install/);
       }),
     );
 
@@ -227,7 +224,7 @@ describe(`Commands`, () => {
 
         await run(`install`);
 
-        await expect(run(`install`, `--immutable`, `--refresh-lockfile`)).rejects.toThrow(/The lockfile would have been created by this install/);
+        await expect(run(`install`, `--immutable`, `--refresh-lockfile`)).rejects.toThrow(/The lockfile would have been modified by this install/);
       }),
     );
 
@@ -260,7 +257,7 @@ describe(`Commands`, () => {
             GITHUB_EVENT_NAME: `pull_request`,
             GITHUB_EVENT_PATH: npath.fromPortablePath(eventPath),
           },
-        })).rejects.toThrow(/The lockfile would have been created by this install/);
+        })).rejects.toThrow(/The lockfile would have been modified by this install/);
       }),
     );
 
@@ -831,12 +828,13 @@ describe(`Commands`, () => {
             YARN_ENABLE_SCRIPTS: `false`,
           },
         });
+        expect(stdout).toContain(`┌ Building packages`);
         expect(stdout).toMatch(/lists build scripts, but its build has been explicitly disabled/g);
       }),
     );
 
     test(
-      `it should print an info when \`dependenciesMeta[].built: false\`, even when using using \`enableScripts: false\``,
+      `it should print a warning when \`dependenciesMeta[].built: false\`, even when using using \`enableScripts: false\``,
       makeTemporaryEnv({
         dependencies: {
           [`no-deps-scripted`]: `1.0.0`,
@@ -856,6 +854,44 @@ describe(`Commands`, () => {
             YARN_ENABLE_SCRIPTS: `false`,
           },
         });
+
+        expect(stdout).toContain(`┌ Building packages`);
+        expect(stdout).toMatch(/lists build scripts, but its build has been explicitly disabled/g);
+      }),
+    );
+
+    test(
+      `it should not repeat disabled build warnings until the package is rebuilt`,
+      makeTemporaryEnv({
+        dependencies: {
+          [`no-deps-scripted`]: `1.0.0`,
+        },
+      }, async ({path, run, source}) => {
+        await xfs.writeJsonPromise(ppath.join(path, Filename.rc), {
+          enableScripts: false,
+        });
+
+        let {stdout} = await run(`install`, `--inline-builds`, {
+          env: {
+            YARN_ENABLE_SCRIPTS: `false`,
+          },
+        });
+
+        expect(stdout).toMatch(/lists build scripts, but its build has been explicitly disabled/g);
+
+        ({stdout} = await run(`install`, `--inline-builds`, {
+          env: {
+            YARN_ENABLE_SCRIPTS: `false`,
+          },
+        }));
+
+        expect(stdout).not.toMatch(/lists build scripts, but its build has been explicitly disabled/g);
+
+        ({stdout} = await run(`rebuild`, {
+          env: {
+            YARN_ENABLE_SCRIPTS: `false`,
+          },
+        }));
 
         expect(stdout).toMatch(/lists build scripts, but its build has been explicitly disabled/g);
       }),

--- a/tests/acceptance-tests/pkg-tests-specs/sources/commands/install.test.ts
+++ b/tests/acceptance-tests/pkg-tests-specs/sources/commands/install.test.ts
@@ -121,7 +121,7 @@ describe(`Commands`, () => {
             FORCE_COLOR: `1`,
           },
         })).rejects.toMatchObject({
-          stdout: expect.stringMatching(/Lockfile changes[\s\S]*\x1b\[[0-9;]*m[-+]/),
+          stdout: expect.stringMatching(/Lockfile changes/),
         });
       }),
     );

--- a/yarn.lock
+++ b/yarn.lock
@@ -3,7 +3,6 @@
     "version": 9
   },
   "workspaces": {
-    "@yarnpkg/documentation": "77b92fa91203f1c6074d382c0f1f45f37b9b6a6a5ad469e8e3ea94976afcf7508b3e9c1244cdd26fa984e22f2e9d42732c3e69e922bca2768400bf3309b9a5de",
     "@yarnpkg/monorepo": "eddbbccdb321f78248af868f80ac6c9a9a2c7ac3703e8d1e9a52a14f8f61231eadae404f19111b09d93b5d999e71bfe46b009500ee55183f4bfcd935c9db7638",
     "@yarnpkg/website": "1ff467d0a2ccbd39504fb7a01b023a23d46d1999b000b6375a0059fb0058890fdc716733a5850c7779a374f0da60ee23d1dbc820e24d37effe89e697b4c5510a",
     "@yarnpkg/zpm-constraints": "a602e3cc3ea1dd931ef50091753a9f1de3a06ff9ee0efb29c8222fb3491132ccbac1581220770e74dcf06e2c30189f636b1d7eb691bfdeff36012d3169630bc6",
@@ -14,66 +13,6 @@
     "pkg-tests-specs": "377aaa5abdb3d7c57990e82ed0fa6e4f0ac62d7fbcdd45dd3e69ab4eb1406232d7181d99bf55cb6aace05c7f94eccbe198b834dfcc25dd400e3084df68a22195"
   },
   "entries": {
-    "@ai-sdk/gateway@npm:1.0.33": {
-      "checksum": "62c8eb6d8a17bda2005e74fd88a196d76333d14eccf8ab9152bfa4dab3a31f5e9191f26bf7d7a2948a1dce9f153c25786de7e77277274b35560e1d527031b02a",
-      "resolution": {
-        "resolution": "@ai-sdk/gateway@npm:1.0.33",
-        "version": "1.0.33",
-        "dependencies": {
-          "@ai-sdk/provider": "2.0.0",
-          "@ai-sdk/provider-utils": "3.0.10",
-          "@vercel/oidc": "^3.0.1"
-        },
-        "peerDependencies": {
-          "zod": "^3.25.76 || ^4.1.8"
-        }
-      }
-    },
-    "@ai-sdk/provider@npm:2.0.0": {
-      "checksum": "9c222cdd6e90a5f075d47ba124ddf68b9763cf7e4115ef623c84088153cef56ce0c7047fb81101de13ace5986f8b67dc07dda7747c656a34c26d5bd5dadc780d",
-      "resolution": {
-        "resolution": "@ai-sdk/provider@npm:2.0.0",
-        "version": "2.0.0",
-        "dependencies": {
-          "json-schema": "^0.4.0"
-        }
-      }
-    },
-    "@ai-sdk/provider-utils@npm:3.0.10": {
-      "checksum": "b97cc583d7c021cb5b2f33f841b6a1a2bb4d87ee7a7bba0713ea277308caf726ade0be15848727be3c48c49ca1fd719b271a844a224b77d9213c02c34d9563ca",
-      "resolution": {
-        "resolution": "@ai-sdk/provider-utils@npm:3.0.10",
-        "version": "3.0.10",
-        "dependencies": {
-          "@ai-sdk/provider": "2.0.0",
-          "@standard-schema/spec": "^1.0.0",
-          "eventsource-parser": "^3.0.5"
-        },
-        "peerDependencies": {
-          "zod": "^3.25.76 || ^4.1.8"
-        }
-      }
-    },
-    "@ai-sdk/react@npm:^2.0.30": {
-      "checksum": "7e4d0ba6e96c15234d5331d197d4908fabbde2ba8b8bddc987a91199d9bb276306ffa9531aa07d2981e19c9df484ba56f0236cbb942fb3ebad4c285a85420e34",
-      "resolution": {
-        "resolution": "@ai-sdk/react@npm:2.0.60",
-        "version": "2.0.60",
-        "dependencies": {
-          "@ai-sdk/provider-utils": "3.0.10",
-          "ai": "5.0.60",
-          "swr": "^2.2.5",
-          "throttleit": "2.1.0"
-        },
-        "peerDependencies": {
-          "react": "^18 || ^19 || ^19.0.0-rc",
-          "zod": "^3.25.76 || ^4.1.8"
-        },
-        "optionalPeerDependencies": [
-          "zod"
-        ]
-      }
-    },
     "@algolia/abtesting@npm:1.18.1": {
       "checksum": "1f298774ca4946e1b0cc179e6f032e39cbf9301beca7f118fd526a9cbfc2cf4435a381d0f0b30c8ee8c91b2232c6d4559bad394a9a22496dbd6fcccf6c33e0c6",
       "resolution": {
@@ -84,103 +23,6 @@
           "@algolia/requester-browser-xhr": "5.52.1",
           "@algolia/requester-fetch": "5.52.1",
           "@algolia/requester-node-http": "5.52.1"
-        }
-      }
-    },
-    "@algolia/abtesting@npm:1.5.0": {
-      "checksum": "93b88c22fc75a80baf07540fd21d8e98d012f041d2f7f33cb5b56386502062e8d625f3d42b05fb50191f91be17d334c1eace5a5c484878ca409254d0cc4a49e5",
-      "resolution": {
-        "resolution": "@algolia/abtesting@npm:1.5.0",
-        "version": "1.5.0",
-        "dependencies": {
-          "@algolia/client-common": "5.39.0",
-          "@algolia/requester-browser-xhr": "5.39.0",
-          "@algolia/requester-fetch": "5.39.0",
-          "@algolia/requester-node-http": "5.39.0"
-        }
-      }
-    },
-    "@algolia/autocomplete-core@npm:1.17.9": {
-      "checksum": "4a63699b52e58236ee4864222f4dc77c1956d458836bc976539976d1692f94bb1d7f2f6997b41e02acb188fe1a46fe589108647dc4686d8d32f2ef49dbb62bea",
-      "resolution": {
-        "resolution": "@algolia/autocomplete-core@npm:1.17.9",
-        "version": "1.17.9",
-        "dependencies": {
-          "@algolia/autocomplete-plugin-algolia-insights": "1.17.9",
-          "@algolia/autocomplete-shared": "1.17.9"
-        }
-      }
-    },
-    "@algolia/autocomplete-core@npm:1.19.2": {
-      "checksum": "0a7a5eb0b848ec0cc2be05e148b64fe5546296771357dc95d90e297f5a140bf0e5b221202be4c6ae28d324977631b1b00e1958173e244a4fc942ad7169e81f4e",
-      "resolution": {
-        "resolution": "@algolia/autocomplete-core@npm:1.19.2",
-        "version": "1.19.2",
-        "dependencies": {
-          "@algolia/autocomplete-plugin-algolia-insights": "1.19.2",
-          "@algolia/autocomplete-shared": "1.19.2"
-        }
-      }
-    },
-    "@algolia/autocomplete-plugin-algolia-insights@npm:1.17.9": {
-      "checksum": "bdc76dd693a1bc3ac950cfb546c1425554ac9442668e10ba06f17d8ad4663fac12c40e36ffec0c06349ba643afe0984deab46ed813bd03ede9ccace7b7b13d84",
-      "resolution": {
-        "resolution": "@algolia/autocomplete-plugin-algolia-insights@npm:1.17.9",
-        "version": "1.17.9",
-        "dependencies": {
-          "@algolia/autocomplete-shared": "1.17.9"
-        },
-        "peerDependencies": {
-          "search-insights": ">= 1 < 3"
-        }
-      }
-    },
-    "@algolia/autocomplete-plugin-algolia-insights@npm:1.19.2": {
-      "checksum": "90129d3d3c5f19db4fb22b03b4b0cd8f27d502e8f5d7398c53bd22ad41e1e0e8a1e343d85670a53e46fd83e33dd70cc3aa4bf66672525d3d076c6d08b7266fbd",
-      "resolution": {
-        "resolution": "@algolia/autocomplete-plugin-algolia-insights@npm:1.19.2",
-        "version": "1.19.2",
-        "dependencies": {
-          "@algolia/autocomplete-shared": "1.19.2"
-        },
-        "peerDependencies": {
-          "search-insights": ">= 1 < 3"
-        }
-      }
-    },
-    "@algolia/autocomplete-preset-algolia@npm:1.17.9": {
-      "checksum": "1cb7b722b199d43ed3d08795f36cfde028c65edc9a9af2af090971f6e7937afeca490c1e9bc0538bce471fbe923da5ce76cf637b2eabf03cf6759ed3bf01aef3",
-      "resolution": {
-        "resolution": "@algolia/autocomplete-preset-algolia@npm:1.17.9",
-        "version": "1.17.9",
-        "dependencies": {
-          "@algolia/autocomplete-shared": "1.17.9"
-        },
-        "peerDependencies": {
-          "@algolia/client-search": ">= 4.9.1 < 6",
-          "algoliasearch": ">= 4.9.1 < 6"
-        }
-      }
-    },
-    "@algolia/autocomplete-shared@npm:1.17.9": {
-      "checksum": "cbb649e48e9911f8f98573c593d40a8cf20782d5381e805a3fd8483088881574a225a4e10bcc8e2915ebbaea585989c22fed60a05ba40f669461057dadc07573",
-      "resolution": {
-        "resolution": "@algolia/autocomplete-shared@npm:1.17.9",
-        "version": "1.17.9",
-        "peerDependencies": {
-          "@algolia/client-search": ">= 4.9.1 < 6",
-          "algoliasearch": ">= 4.9.1 < 6"
-        }
-      }
-    },
-    "@algolia/autocomplete-shared@npm:1.19.2": {
-      "checksum": "efdcbb80b9db3734f8d7193f15692926ad0c1c371758eafcb393d327870b15ab24c9ea5dc13fc2663991069a694a0cf378b34d57c7769e772201f65308199db5",
-      "resolution": {
-        "resolution": "@algolia/autocomplete-shared@npm:1.19.2",
-        "version": "1.19.2",
-        "peerDependencies": {
-          "@algolia/client-search": ">= 4.9.1 < 6",
-          "algoliasearch": ">= 4.9.1 < 6"
         }
       }
     },
@@ -208,19 +50,6 @@
         "version": "4.25.2",
         "dependencies": {
           "@algolia/cache-common": "4.25.2"
-        }
-      }
-    },
-    "@algolia/client-abtesting@npm:5.39.0": {
-      "checksum": "cb5e5e700d7362267ed2f262b323d8fb5a32cfa25a4a00b8e8aecbad22ce291fc5fcce57d482b1c8366abb97721f888156ff2aaf373d412894d4226752b43173",
-      "resolution": {
-        "resolution": "@algolia/client-abtesting@npm:5.39.0",
-        "version": "5.39.0",
-        "dependencies": {
-          "@algolia/client-common": "5.39.0",
-          "@algolia/requester-browser-xhr": "5.39.0",
-          "@algolia/requester-fetch": "5.39.0",
-          "@algolia/requester-node-http": "5.39.0"
         }
       }
     },
@@ -262,19 +91,6 @@
         }
       }
     },
-    "@algolia/client-analytics@npm:5.39.0": {
-      "checksum": "54900f6b001f86213efaa269bf28b4a8c9a75abcc0ca0b60af37e33b2ff1eecfbfbdb3cb9a83371f4e573c23c5a8db50fc50632d490a5950b53558f696f94eea",
-      "resolution": {
-        "resolution": "@algolia/client-analytics@npm:5.39.0",
-        "version": "5.39.0",
-        "dependencies": {
-          "@algolia/client-common": "5.39.0",
-          "@algolia/requester-browser-xhr": "5.39.0",
-          "@algolia/requester-fetch": "5.39.0",
-          "@algolia/requester-node-http": "5.39.0"
-        }
-      }
-    },
     "@algolia/client-analytics@npm:5.52.1": {
       "checksum": "abdd46b49a341dccb45f5f39bb939a10375c62356487b4c7f419b354aa3f23f3735b34b5ebb3fb56ac88a63e7a06b661b06104290cbf626ca5654936d6b185b8",
       "resolution": {
@@ -299,31 +115,11 @@
         }
       }
     },
-    "@algolia/client-common@npm:5.39.0": {
-      "checksum": "9ce53d6be08c870c06d7d1c09789472c50947f8e03b92424ea0f2bec19fe5dd650bd6e32ab5735d1971a7b722fa23b168b030017247dcb27b4105b712536ce8d",
-      "resolution": {
-        "resolution": "@algolia/client-common@npm:5.39.0",
-        "version": "5.39.0"
-      }
-    },
     "@algolia/client-common@npm:5.52.1": {
       "checksum": "aefd22bf280576d666f47fa1fe82e7063d59a4967a826df9deb91830a2a1136291b3a9be90695801d37b26234b10ba44f53fb105897e4228611925b293154579",
       "resolution": {
         "resolution": "@algolia/client-common@npm:5.52.1",
         "version": "5.52.1"
-      }
-    },
-    "@algolia/client-insights@npm:5.39.0": {
-      "checksum": "4a03fe6530453b2e0e90c6f20b0a8117379e914487031b00f631a036baaab68e17cf5edfa77189c1d8000674001f782233147a5fd3b2825b2ca8778c3a5c1128",
-      "resolution": {
-        "resolution": "@algolia/client-insights@npm:5.39.0",
-        "version": "5.39.0",
-        "dependencies": {
-          "@algolia/client-common": "5.39.0",
-          "@algolia/requester-browser-xhr": "5.39.0",
-          "@algolia/requester-fetch": "5.39.0",
-          "@algolia/requester-node-http": "5.39.0"
-        }
       }
     },
     "@algolia/client-insights@npm:5.52.1": {
@@ -351,19 +147,6 @@
         }
       }
     },
-    "@algolia/client-personalization@npm:5.39.0": {
-      "checksum": "a45c4dbcdb696dbe41ff27cd1718e687394d05d0ed42e37056b3b99ddb0c12e27a410cc1a86544081ef1d32d67668bb4f2d662e63089612039f281a918b310c6",
-      "resolution": {
-        "resolution": "@algolia/client-personalization@npm:5.39.0",
-        "version": "5.39.0",
-        "dependencies": {
-          "@algolia/client-common": "5.39.0",
-          "@algolia/requester-browser-xhr": "5.39.0",
-          "@algolia/requester-fetch": "5.39.0",
-          "@algolia/requester-node-http": "5.39.0"
-        }
-      }
-    },
     "@algolia/client-personalization@npm:5.52.1": {
       "checksum": "5503eaea44b0876463a4a2c5341085c4dc2b05781e3beb7c84695b58c8efa1ada1917b5080f32b198180db4485bc48b9313fdc9d09a29e75fbc7812692dd31be",
       "resolution": {
@@ -374,19 +157,6 @@
           "@algolia/requester-browser-xhr": "5.52.1",
           "@algolia/requester-fetch": "5.52.1",
           "@algolia/requester-node-http": "5.52.1"
-        }
-      }
-    },
-    "@algolia/client-query-suggestions@npm:5.39.0": {
-      "checksum": "476dc98db4fa31bbdab94d4c4e9b84fcf02350e9aea51d3fb6ae9b812cfe5f0b167d98ae8e953861196b46b7150e71f81c5797b7a99cd74dbb9a2c3eb2cb8e47",
-      "resolution": {
-        "resolution": "@algolia/client-query-suggestions@npm:5.39.0",
-        "version": "5.39.0",
-        "dependencies": {
-          "@algolia/client-common": "5.39.0",
-          "@algolia/requester-browser-xhr": "5.39.0",
-          "@algolia/requester-fetch": "5.39.0",
-          "@algolia/requester-node-http": "5.39.0"
         }
       }
     },
@@ -415,19 +185,6 @@
         }
       }
     },
-    "@algolia/client-search@npm:5.39.0": {
-      "checksum": "43943cbabf8d3782d7eb7283b87186e85eccf7044550da613fa235d96679a9dee01941b26cbe698898a65f89425478d743d01e27ab420ddad481202b908780e3",
-      "resolution": {
-        "resolution": "@algolia/client-search@npm:5.39.0",
-        "version": "5.39.0",
-        "dependencies": {
-          "@algolia/client-common": "5.39.0",
-          "@algolia/requester-browser-xhr": "5.39.0",
-          "@algolia/requester-fetch": "5.39.0",
-          "@algolia/requester-node-http": "5.39.0"
-        }
-      }
-    },
     "@algolia/client-search@npm:5.52.1": {
       "checksum": "c0428d7bf01763234955fe3d3e5b82d2e352a751bbb83b5c031743aa508bfded01bbe4753f24cae098ef6d64b9cae0cbdf27574cabcff26a696703812878db9d",
       "resolution": {
@@ -438,26 +195,6 @@
           "@algolia/requester-browser-xhr": "5.52.1",
           "@algolia/requester-fetch": "5.52.1",
           "@algolia/requester-node-http": "5.52.1"
-        }
-      }
-    },
-    "@algolia/events@npm:^4.0.1": {
-      "checksum": "cf20b3bd9ede31e15fa246e660c8dd463e8c0f4c92112b5e649050b9379085dcb2cbf84c550c625fcc049c89e2a97260f6dab4b963cece54120c2cc733f2cff6",
-      "resolution": {
-        "resolution": "@algolia/events@npm:4.0.1",
-        "version": "4.0.1"
-      }
-    },
-    "@algolia/ingestion@npm:1.39.0": {
-      "checksum": "714719048bd0b5df792fe82daf2625d9133812d222d3e3fd511cf30e88c32728ca04ce7a31176b0f738e1f2d48e4b4fa2719f0ba9901a1e3955f264d46baeb06",
-      "resolution": {
-        "resolution": "@algolia/ingestion@npm:1.39.0",
-        "version": "1.39.0",
-        "dependencies": {
-          "@algolia/client-common": "5.39.0",
-          "@algolia/requester-browser-xhr": "5.39.0",
-          "@algolia/requester-fetch": "5.39.0",
-          "@algolia/requester-node-http": "5.39.0"
         }
       }
     },
@@ -488,19 +225,6 @@
         "version": "4.25.2",
         "dependencies": {
           "@algolia/logger-common": "4.25.2"
-        }
-      }
-    },
-    "@algolia/monitoring@npm:1.39.0": {
-      "checksum": "2616a4781021061e68165996d740a59cf06aaf58335dae1545dc8c865689e3d1f493390f3099bb578dcb13d614ec7c00dbdba1f72e342d3aecbbca345a8d61e0",
-      "resolution": {
-        "resolution": "@algolia/monitoring@npm:1.39.0",
-        "version": "1.39.0",
-        "dependencies": {
-          "@algolia/client-common": "5.39.0",
-          "@algolia/requester-browser-xhr": "5.39.0",
-          "@algolia/requester-fetch": "5.39.0",
-          "@algolia/requester-node-http": "5.39.0"
         }
       }
     },
@@ -537,19 +261,6 @@
         }
       }
     },
-    "@algolia/recommend@npm:5.39.0": {
-      "checksum": "551d3ff1e967fae01bbe5058261bbfff4aa0d3184c5cfcf38902656fb28a713645767aeb4ece8c44d01a8c0a083afdf9dc8cdf3dcac743d0bdcf1028c6a72471",
-      "resolution": {
-        "resolution": "@algolia/recommend@npm:5.39.0",
-        "version": "5.39.0",
-        "dependencies": {
-          "@algolia/client-common": "5.39.0",
-          "@algolia/requester-browser-xhr": "5.39.0",
-          "@algolia/requester-fetch": "5.39.0",
-          "@algolia/requester-node-http": "5.39.0"
-        }
-      }
-    },
     "@algolia/recommend@npm:5.52.1": {
       "checksum": "e85ddee8ac8f80728e35629bba91006371b57816c372094cdad1347bef58838c3a54b0dd187f5f0700f28ac5ca5b26847ff9ccbe36c1795c49692379760a6eee",
       "resolution": {
@@ -573,16 +284,6 @@
         }
       }
     },
-    "@algolia/requester-browser-xhr@npm:5.39.0": {
-      "checksum": "2e263a5e817b4c39e9d0965a28f3867ab8caa7c73e05f6490504c56f43aa1ce88d62f0c39ac3dd708fc34fa599970bfa540769c3e81a62e523c53eebb203d476",
-      "resolution": {
-        "resolution": "@algolia/requester-browser-xhr@npm:5.39.0",
-        "version": "5.39.0",
-        "dependencies": {
-          "@algolia/client-common": "5.39.0"
-        }
-      }
-    },
     "@algolia/requester-browser-xhr@npm:5.52.1": {
       "checksum": "4b250629392cc03d554c70d11e8d716afe676801791a1f5b31eba94e64ec97fa97e3d2ae2d925b22839a7bd57fe1268afbfa39a3b72d1a2592809ceab2986310",
       "resolution": {
@@ -598,16 +299,6 @@
       "resolution": {
         "resolution": "@algolia/requester-common@npm:4.25.2",
         "version": "4.25.2"
-      }
-    },
-    "@algolia/requester-fetch@npm:5.39.0": {
-      "checksum": "b33ff1c8fc165e9d2d91735bdc9c54984bcdae3acdb44b359d9bfa5c2882d1a04f32ce5fc5b19377769af91c2a030df66215b16ee1241d26f0c7aabf32c8ad56",
-      "resolution": {
-        "resolution": "@algolia/requester-fetch@npm:5.39.0",
-        "version": "5.39.0",
-        "dependencies": {
-          "@algolia/client-common": "5.39.0"
-        }
       }
     },
     "@algolia/requester-fetch@npm:5.52.1": {
@@ -627,16 +318,6 @@
         "version": "4.25.2",
         "dependencies": {
           "@algolia/requester-common": "4.25.2"
-        }
-      }
-    },
-    "@algolia/requester-node-http@npm:5.39.0": {
-      "checksum": "d9e73f16ad283e0f79c8ee6f4848c3ce9325725e1abb7ff450cfdef84913b261984fd5db18e2cd574df481c0820a041deb56ca2b8e67d7aeb7561c49ca8216a6",
-      "resolution": {
-        "resolution": "@algolia/requester-node-http@npm:5.39.0",
-        "version": "5.39.0",
-        "dependencies": {
-          "@algolia/client-common": "5.39.0"
         }
       }
     },
@@ -683,25 +364,11 @@
         }
       }
     },
-    "@astrojs/compiler@npm:^2.12.2": {
-      "checksum": "a3e007bf6d0aa26dd285c6ebcaf269c68cd8b3fb8faa190c0bdf65491417c3e21a6ea16b0d3637fe0d56ee151711b8407bf66a597d8cecc05136f8ded1e3fff7",
-      "resolution": {
-        "resolution": "@astrojs/compiler@npm:2.13.0",
-        "version": "2.13.0"
-      }
-    },
     "@astrojs/compiler@npm:^2.13.0": {
       "checksum": "79381f27dfee2360de808cb1c7719f8fc6552e763a9ff0fb349c4dca215836b38c0fd1a6046ee35144480bf9674d5eea48e0ab00faedc6191b2e20a89f723af9",
       "resolution": {
         "resolution": "@astrojs/compiler@npm:2.13.1",
         "version": "2.13.1"
-      }
-    },
-    "@astrojs/internal-helpers@npm:0.7.3": {
-      "checksum": "cee54a2af88e728978e98b1772b91983cb27aa549e8b362a83972529778872d775a0b75e47a74a4c096bbe7f107b94bbdf5cf99182917e2185a8242dc5760b9f",
-      "resolution": {
-        "resolution": "@astrojs/internal-helpers@npm:0.7.3",
-        "version": "0.7.3"
       }
     },
     "@astrojs/internal-helpers@npm:0.7.6": {
@@ -751,77 +418,6 @@
         }
       }
     },
-    "@astrojs/markdown-remark@npm:6.3.7, @astrojs/markdown-remark@npm:^6.3.1": {
-      "checksum": "5ccb7b316f9a43362f7cb6873706b978b8313cd4d6d2ca4e3bc9af0ca901788f297fe7a22857ed3927dd4578765bc5d321049b0fe83d61d71184190f21d2335e",
-      "resolution": {
-        "resolution": "@astrojs/markdown-remark@npm:6.3.7",
-        "version": "6.3.7",
-        "dependencies": {
-          "@astrojs/internal-helpers": "0.7.3",
-          "@astrojs/prism": "3.3.0",
-          "github-slugger": "^2.0.0",
-          "hast-util-from-html": "^2.0.3",
-          "hast-util-to-text": "^4.0.2",
-          "import-meta-resolve": "^4.2.0",
-          "js-yaml": "^4.1.0",
-          "mdast-util-definitions": "^6.0.0",
-          "rehype-raw": "^7.0.0",
-          "rehype-stringify": "^10.0.1",
-          "remark-gfm": "^4.0.1",
-          "remark-parse": "^11.0.0",
-          "remark-rehype": "^11.1.2",
-          "remark-smartypants": "^3.0.2",
-          "shiki": "^3.12.2",
-          "smol-toml": "^1.4.2",
-          "unified": "^11.0.5",
-          "unist-util-remove-position": "^5.0.0",
-          "unist-util-visit": "^5.0.0",
-          "unist-util-visit-parents": "^6.0.1",
-          "vfile": "^6.0.3"
-        }
-      }
-    },
-    "@astrojs/mdx@npm:^4.2.3": {
-      "checksum": "a2c25e57905f0917b4d790dc1fc88e58eda92283e5dbcef96d6d497a2ac8d8736f9323d2de7cb20f942eb065b939309f54fa2836beef49b7f0053365681ad18c",
-      "resolution": {
-        "resolution": "@astrojs/mdx@npm:4.3.6",
-        "version": "4.3.6",
-        "dependencies": {
-          "@astrojs/markdown-remark": "6.3.7",
-          "@mdx-js/mdx": "^3.1.1",
-          "acorn": "^8.15.0",
-          "es-module-lexer": "^1.7.0",
-          "estree-util-visit": "^2.0.0",
-          "hast-util-to-html": "^9.0.5",
-          "kleur": "^4.1.5",
-          "rehype-raw": "^7.0.0",
-          "remark-gfm": "^4.0.1",
-          "remark-smartypants": "^3.0.2",
-          "source-map": "^0.7.6",
-          "unist-util-visit": "^5.0.0",
-          "vfile": "^6.0.3"
-        },
-        "peerDependencies": {
-          "astro": "^5.0.0"
-        }
-      }
-    },
-    "@astrojs/preact@npm:^4.1.0": {
-      "checksum": "3ed100fc0dbec4364462138ab0a11f64e708f1fc465b9cd3809adb08cad7c55537911ff9a755bfcb6827e7e2831f50ce2dd6254d48f131dd3cf99d97e4582a02",
-      "resolution": {
-        "resolution": "@astrojs/preact@npm:4.1.1",
-        "version": "4.1.1",
-        "dependencies": {
-          "@preact/preset-vite": "^2.10.2",
-          "@preact/signals": "^2.3.1",
-          "preact-render-to-string": "^6.6.1",
-          "vite": "^6.3.6"
-        },
-        "peerDependencies": {
-          "preact": "^10.6.5"
-        }
-      }
-    },
     "@astrojs/prism@npm:3.3.0": {
       "checksum": "2d4a6a90304f09252dd35f988dbf78495e3770e90f32ac1d20c31cb54fb79fe1bb3969776e5a0a7e8d434cc0b20b9ef81d262edc591a22df046a98f66a47daad",
       "resolution": {
@@ -852,18 +448,6 @@
         }
       }
     },
-    "@astrojs/sitemap@npm:^3.3.0": {
-      "checksum": "a9caad1a83d649ebbac739401f837225212d9cf06d52dd9ec20fd054221ff14a7e3f5e43e919dda814316ce5fff40a635f4d72bd5eaa9497517d5f4ec27d45fb",
-      "resolution": {
-        "resolution": "@astrojs/sitemap@npm:3.6.0",
-        "version": "3.6.0",
-        "dependencies": {
-          "sitemap": "^8.0.0",
-          "stream-replace-string": "^2.0.0",
-          "zod": "^3.25.76"
-        }
-      }
-    },
     "@astrojs/sitemap@npm:^3.7.2": {
       "checksum": "46f6f357456deddb92c782fac938caab72eebe6b729e91a5ada5545abcdf2b603097f1f228abbea673bf1aaafe9b25d11b9264dd157658894a52f22e28f9e6d5",
       "resolution": {
@@ -873,70 +457,6 @@
           "sitemap": "^9.0.0",
           "stream-replace-string": "^2.0.0",
           "zod": "^4.3.6"
-        }
-      }
-    },
-    "@astrojs/starlight@npm:^0.36.2": {
-      "checksum": "d31b1c4fd6f2e61dc16bbfe060b776b15c10bb25e9462b1dced994ad725b03d0effa1722748f7279208ac874244258d9a0081518c4ef9ddcf5fb8529047d1dcb",
-      "resolution": {
-        "resolution": "@astrojs/starlight@npm:0.36.2",
-        "version": "0.36.2",
-        "dependencies": {
-          "@astrojs/markdown-remark": "^6.3.1",
-          "@astrojs/mdx": "^4.2.3",
-          "@astrojs/sitemap": "^3.3.0",
-          "@pagefind/default-ui": "^1.3.0",
-          "@types/hast": "^3.0.4",
-          "@types/js-yaml": "^4.0.9",
-          "@types/mdast": "^4.0.4",
-          "astro-expressive-code": "^0.41.1",
-          "bcp-47": "^2.1.0",
-          "hast-util-from-html": "^2.0.1",
-          "hast-util-select": "^6.0.2",
-          "hast-util-to-string": "^3.0.0",
-          "hastscript": "^9.0.0",
-          "i18next": "^23.11.5",
-          "js-yaml": "^4.1.0",
-          "klona": "^2.0.6",
-          "mdast-util-directive": "^3.0.0",
-          "mdast-util-to-markdown": "^2.1.0",
-          "mdast-util-to-string": "^4.0.0",
-          "pagefind": "^1.3.0",
-          "rehype": "^13.0.1",
-          "rehype-format": "^5.0.0",
-          "remark-directive": "^3.0.0",
-          "ultrahtml": "^1.6.0",
-          "unified": "^11.0.5",
-          "unist-util-visit": "^5.0.0",
-          "vfile": "^6.0.2"
-        },
-        "peerDependencies": {
-          "astro": "^5.5.0"
-        }
-      }
-    },
-    "@astrojs/starlight-docsearch@npm:^0.6.0": {
-      "checksum": "54ca48f85ab1b697339c80c8934b7ab6f13b81b74ea64268edbf862af45147cd2c08d56a4faf5a9b8f532b70cb4e2e5d6146a7cd9129e35a4f2b615b53cd4d0c",
-      "resolution": {
-        "resolution": "@astrojs/starlight-docsearch@npm:0.6.0",
-        "version": "0.6.0",
-        "dependencies": {
-          "@docsearch/css": "^3.6.0",
-          "@docsearch/js": "^3.6.0"
-        },
-        "peerDependencies": {
-          "@astrojs/starlight": ">=0.32.0"
-        }
-      }
-    },
-    "@astrojs/starlight-tailwind@npm:^4.0.1": {
-      "checksum": "08d7a45f430bba737e34f7ae6854f2fa0b9e48b829165cbfdea089fe151a8ccf1040934eab2d66e383b8b4555367b9e2bbd72f7fec866fe60333b40f1e656a13",
-      "resolution": {
-        "resolution": "@astrojs/starlight-tailwind@npm:4.0.1",
-        "version": "4.0.1",
-        "peerDependencies": {
-          "@astrojs/starlight": ">=0.34.0",
-          "tailwindcss": "^4.0.0"
         }
       }
     },
@@ -1018,30 +538,6 @@
         }
       }
     },
-    "@babel/core@npm:^7.21.3, @babel/core@npm:^7.22.1, @babel/core@npm:^7.27.7": {
-      "checksum": "2ccec31e46088d0957b7ca4c599a1641f08e6a09a962492821e88c4f1b58c701afcfa80cf56958763acb29a836361bb1d00d179dc2e28a0a48841c9c7171f2b0",
-      "resolution": {
-        "resolution": "@babel/core@npm:7.28.4",
-        "version": "7.28.4",
-        "dependencies": {
-          "@babel/code-frame": "^7.27.1",
-          "@babel/generator": "^7.28.3",
-          "@babel/helper-compilation-targets": "^7.27.2",
-          "@babel/helper-module-transforms": "^7.28.3",
-          "@babel/helpers": "^7.28.4",
-          "@babel/parser": "^7.28.4",
-          "@babel/template": "^7.27.2",
-          "@babel/traverse": "^7.28.4",
-          "@babel/types": "^7.28.4",
-          "@jridgewell/remapping": "^2.3.5",
-          "convert-source-map": "^2.0.0",
-          "debug": "^4.1.0",
-          "gensync": "^1.0.0-beta.2",
-          "json5": "^2.2.3",
-          "semver": "^6.3.1"
-        }
-      }
-    },
     "@babel/core@npm:^7.29.0": {
       "checksum": "9538f97cca62656a32d128cce72ef82a76bde88d0ba06f67a0d5f03a9db135e1cfc73513ca4e1d27132995ae61fab7d4c669b27d97be0b299ce3479581190a19",
       "resolution": {
@@ -1105,16 +601,6 @@
           "@jridgewell/gen-mapping": "^0.3.12",
           "@jridgewell/trace-mapping": "^0.3.28",
           "jsesc": "^3.0.2"
-        }
-      }
-    },
-    "@babel/helper-annotate-as-pure@npm:^7.27.1": {
-      "checksum": "0275c40d610ccf11464f20407a85e2115abea0579e2ad6de9a2cc86dcd9fc75361567bc8a1cfb418ff46c94217a2ea0a5b9e185902f4392674d91701d52af610",
-      "resolution": {
-        "resolution": "@babel/helper-annotate-as-pure@npm:7.27.3",
-        "version": "7.27.3",
-        "dependencies": {
-          "@babel/types": "^7.27.3"
         }
       }
     },
@@ -1262,7 +748,7 @@
         }
       }
     },
-    "@babel/parser@npm:^7.1.0, @babel/parser@npm:^7.20.7, @babel/parser@npm:^7.25.4, @babel/parser@npm:^7.27.2, @babel/parser@npm:^7.28.3, @babel/parser@npm:^7.28.4": {
+    "@babel/parser@npm:^7.1.0, @babel/parser@npm:^7.20.7, @babel/parser@npm:^7.27.2, @babel/parser@npm:^7.28.3, @babel/parser@npm:^7.28.4": {
       "checksum": "c7e378e3173c8452ec16afc1054ec677132f5c7713b69087c002f7d371b07a9b200792f5b002a635025b2f1dc2869a743610da708eb997819688567d65345c7b",
       "resolution": {
         "resolution": "@babel/parser@npm:7.28.4",
@@ -1393,7 +879,7 @@
         }
       }
     },
-    "@babel/plugin-syntax-jsx@npm:^7.27.1, @babel/plugin-syntax-jsx@npm:^7.7.2": {
+    "@babel/plugin-syntax-jsx@npm:^7.7.2": {
       "checksum": "72a1cde01eb40025bc56ecc9ac18eb620a3908f0f07562fd089289a0e5d324b133d30dc5c98c39733311c4deace04c676f9b30b9b82cb32550c630c47d05ebb8",
       "resolution": {
         "resolution": "@babel/plugin-syntax-jsx@npm:7.27.1",
@@ -1523,36 +1009,6 @@
         }
       }
     },
-    "@babel/plugin-transform-react-jsx@npm:^7.22.15, @babel/plugin-transform-react-jsx@npm:^7.27.1": {
-      "checksum": "db883ed0c18865ef5fa0a858dbbcf0f13af8204458485b7689f0df4bb3a77503c211d066ae576fc53205d6671809dbf05b3d199ccfe2c76cae29284cf5d1fa58",
-      "resolution": {
-        "resolution": "@babel/plugin-transform-react-jsx@npm:7.27.1",
-        "version": "7.27.1",
-        "dependencies": {
-          "@babel/helper-annotate-as-pure": "^7.27.1",
-          "@babel/helper-module-imports": "^7.27.1",
-          "@babel/helper-plugin-utils": "^7.27.1",
-          "@babel/plugin-syntax-jsx": "^7.27.1",
-          "@babel/types": "^7.27.1"
-        },
-        "peerDependencies": {
-          "@babel/core": "^7.0.0-0"
-        }
-      }
-    },
-    "@babel/plugin-transform-react-jsx-development@npm:^7.22.5": {
-      "checksum": "20bb0a1d4b45d29fb0a2ce6431972b79fb64a4354d6a7929b01bedf172a51178e1311147181f5290abe0e9847435281620e2c52cb0614fa732c06660d9b0d7cd",
-      "resolution": {
-        "resolution": "@babel/plugin-transform-react-jsx-development@npm:7.27.1",
-        "version": "7.27.1",
-        "dependencies": {
-          "@babel/plugin-transform-react-jsx": "^7.27.1"
-        },
-        "peerDependencies": {
-          "@babel/core": "^7.0.0-0"
-        }
-      }
-    },
     "@babel/plugin-transform-react-jsx-self@npm:^7.27.1": {
       "checksum": "b597cb4ab13ec465b5ace96487d95be483a8bf7856f1d38268c8868056559ff91a1515452395303f1843a5cb1c353bb669e722b335514f6c5a9dc59a5f4da5df",
       "resolution": {
@@ -1579,13 +1035,6 @@
         }
       }
     },
-    "@babel/runtime@npm:^7.23.2, @babel/runtime@npm:^7.27.6, @babel/runtime@npm:^7.28.4": {
-      "checksum": "c0bc0d616c803230010a3a880402f77b15b6499a33bdc8478dd52cff6743f601b00a7c273c8f6080f3144fffaedf840b26168cce50e000f9f4147485216d37eb",
-      "resolution": {
-        "resolution": "@babel/runtime@npm:7.28.4",
-        "version": "7.28.4"
-      }
-    },
     "@babel/template@npm:^7.27.2, @babel/template@npm:^7.3.3": {
       "checksum": "f8cff9e10ac2faeaa18206cb9954aef5ae49ff535559b9c7bbcb4a0a4899093e8e1522fbc3f132569794ee932ca457fed09f2700972bb70baeb2bfaa2d68b261",
       "resolution": {
@@ -1610,7 +1059,7 @@
         }
       }
     },
-    "@babel/traverse@npm:^7.27.1, @babel/traverse@npm:^7.28.3, @babel/traverse@npm:^7.28.4": {
+    "@babel/traverse@npm:^7.27.1, @babel/traverse@npm:^7.28.3": {
       "checksum": "a8191463ba62bdaf49086b0ba27eba27a5b38d6fbee0b0f294dc77d0676b0aef075dd1a8e8baeee4fd36bd1645797ba8ba35234bb3e4c09296b3396267ebeba1",
       "resolution": {
         "resolution": "@babel/traverse@npm:7.28.4",
@@ -1658,7 +1107,7 @@
         }
       }
     },
-    "@babel/types@npm:^7.0.0, @babel/types@npm:^7.20.7, @babel/types@npm:^7.21.3, @babel/types@npm:^7.25.4, @babel/types@npm:^7.27.1, @babel/types@npm:^7.27.3, @babel/types@npm:^7.28.2, @babel/types@npm:^7.28.4": {
+    "@babel/types@npm:^7.0.0, @babel/types@npm:^7.20.7, @babel/types@npm:^7.27.1, @babel/types@npm:^7.28.2, @babel/types@npm:^7.28.4": {
       "checksum": "726202950b82a09cf6d9534ed2a4f35a85f35aca9fed89b30b5ec95935ac00acff73a9cd1626b3c821ee96a24e396a0ba9823c8031ad7109bce34aa8ba55c0de",
       "resolution": {
         "resolution": "@babel/types@npm:7.28.4",
@@ -1691,51 +1140,6 @@
         }
       }
     },
-    "@base-ui-components/react@npm:^1.0.0-beta.1": {
-      "checksum": "f706880a69e18ba01c55c196f6e99328a0c669b3b2be3cfb3cb2b6d34f75c8b21adf7855e57b6d9e81472124fb11a1c2e39651ec82d58691ef8d610e88df4c9f",
-      "resolution": {
-        "resolution": "@base-ui-components/react@npm:1.0.0-beta.4",
-        "version": "1.0.0-beta.4",
-        "dependencies": {
-          "@babel/runtime": "^7.28.4",
-          "@base-ui-components/utils": "0.1.2",
-          "@floating-ui/react-dom": "^2.1.6",
-          "@floating-ui/utils": "^0.2.10",
-          "reselect": "^5.1.1",
-          "tabbable": "^6.2.0",
-          "use-sync-external-store": "^1.5.0"
-        },
-        "peerDependencies": {
-          "@types/react": "^17 || ^18 || ^19",
-          "react": "^17 || ^18 || ^19",
-          "react-dom": "^17 || ^18 || ^19"
-        },
-        "optionalPeerDependencies": [
-          "@types/react"
-        ]
-      }
-    },
-    "@base-ui-components/utils@npm:0.1.2": {
-      "checksum": "cb9117b3aa5c5c5d3f986e3d3d6cd5c077d732e90f467c02de38ca271c908aedf6729574c7260e074e5003ee82c897d3a2b6aa18091916f0d56857cf15a857e8",
-      "resolution": {
-        "resolution": "@base-ui-components/utils@npm:0.1.2",
-        "version": "0.1.2",
-        "dependencies": {
-          "@babel/runtime": "^7.28.4",
-          "@floating-ui/utils": "^0.2.10",
-          "reselect": "^5.1.1",
-          "use-sync-external-store": "^1.5.0"
-        },
-        "peerDependencies": {
-          "@types/react": "^17 || ^18 || ^19",
-          "react": "^17 || ^18 || ^19",
-          "react-dom": "^17 || ^18 || ^19"
-        },
-        "optionalPeerDependencies": [
-          "@types/react"
-        ]
-      }
-    },
     "@bcoe/v8-coverage@npm:^0.2.3": {
       "checksum": "790a07f415a0134be9f5f435ced0d4b67b9c27aebfe186e02d40c3fda1015716359c8be702ee913b3d2854b31c0ea654cbe4f17ce3bbeb0efa741f1e8aa3869a",
       "resolution": {
@@ -1748,18 +1152,6 @@
       "resolution": {
         "resolution": "@braintree/sanitize-url@npm:7.1.2",
         "version": "7.1.2"
-      }
-    },
-    "@capsizecss/unpack@npm:^2.4.0": {
-      "checksum": "5975b3c177061de77dcd197d35e4ec01b0589ad1a0d39ec0bc297a4d03dd3270582f645dde13fd25255cd3414de3cbeac66cf39138a83537d04af3f9f34abb52",
-      "resolution": {
-        "resolution": "@capsizecss/unpack@npm:2.4.0",
-        "version": "2.4.0",
-        "dependencies": {
-          "blob-to-buffer": "^1.2.8",
-          "cross-fetch": "^3.0.4",
-          "fontkit": "^2.0.2"
-        }
       }
     },
     "@capsizecss/unpack@npm:^4.0.0": {
@@ -1777,98 +1169,6 @@
       "resolution": {
         "resolution": "@chevrotain/types@npm:11.1.2",
         "version": "11.1.2"
-      }
-    },
-    "@ctrl/tinycolor@npm:^4.0.4": {
-      "checksum": "4a4cb32f6c43326267343b84d4fa89febb15c2d315764ef7161e2027b66dcded3fe563369ab37cfac03f2a51404ac90af064da1382d0ffd6136f510bfc2fdfed",
-      "resolution": {
-        "resolution": "@ctrl/tinycolor@npm:4.2.0",
-        "version": "4.2.0"
-      }
-    },
-    "@dimforge/rapier3d-compat@npm:~0.12.0": {
-      "checksum": "681a1bd62643fe9187890a8ce86382f21f6b86e466ea8093cafc9c795076a6c0a91f9e5dfeb1b1766964e93ae3bc6e3c62bab1576fda62f63701399e72933af8",
-      "resolution": {
-        "resolution": "@dimforge/rapier3d-compat@npm:0.12.0",
-        "version": "0.12.0"
-      }
-    },
-    "@docsearch/css@npm:3.9.0, @docsearch/css@npm:^3.6.0": {
-      "checksum": "414db7aa5bc3f09405a3cf23fa0aa88ae78a149d57702f59a5be7fa257558e6627321964b8f31264097b5517e28d5364c29742cd9809b058b8860d5d320b0e63",
-      "resolution": {
-        "resolution": "@docsearch/css@npm:3.9.0",
-        "version": "3.9.0"
-      }
-    },
-    "@docsearch/css@npm:4.1.0, @docsearch/css@npm:^4.1.0": {
-      "checksum": "55e076c9490daca09f069e623079fb19b9c8396c8c758fe7cf5b49ccc02331d1e030db7959e622678a9f75586e60d06620f49f9364d16e9a9e62539d06fdaf25",
-      "resolution": {
-        "resolution": "@docsearch/css@npm:4.1.0",
-        "version": "4.1.0"
-      }
-    },
-    "@docsearch/js@npm:^3.6.0": {
-      "checksum": "8e39c968e450b9ba5dcbbe50cef6a2b9b7b56bcb954e3e89ec24898cfc1165baffc0b4c2310defd6fc7e387c0cf78713e4892f1f9949669380a593fb4cba2962",
-      "resolution": {
-        "resolution": "@docsearch/js@npm:3.9.0",
-        "version": "3.9.0",
-        "dependencies": {
-          "@docsearch/react": "3.9.0",
-          "preact": "^10.0.0"
-        }
-      }
-    },
-    "@docsearch/react@npm:3.9.0": {
-      "checksum": "e8615f13fbabfa3e3673a49fbf99965ac8ac36afcc5734009e6df193d38d0965d492579f6820d35ff6900f120851aca93ec1c69ca0ff23d1eb3c3159a924bb23",
-      "resolution": {
-        "resolution": "@docsearch/react@npm:3.9.0",
-        "version": "3.9.0",
-        "dependencies": {
-          "@algolia/autocomplete-core": "1.17.9",
-          "@algolia/autocomplete-preset-algolia": "1.17.9",
-          "@docsearch/css": "3.9.0",
-          "algoliasearch": "^5.14.2"
-        },
-        "peerDependencies": {
-          "@types/react": ">= 16.8.0 < 20.0.0",
-          "react": ">= 16.8.0 < 20.0.0",
-          "react-dom": ">= 16.8.0 < 20.0.0",
-          "search-insights": ">= 1 < 3"
-        },
-        "optionalPeerDependencies": [
-          "@types/react",
-          "react",
-          "react-dom",
-          "search-insights"
-        ]
-      }
-    },
-    "@docsearch/react@npm:^4.1.0": {
-      "checksum": "76bb881542bd29e15a2fda0f5600ee3c660049ef09ef4258a3ce5e15ac289e9ee891f0a9c837d2a00c34c58f88033a8e5bf5370662c8469528a8b275d2ec8cf8",
-      "resolution": {
-        "resolution": "@docsearch/react@npm:4.1.0",
-        "version": "4.1.0",
-        "dependencies": {
-          "@ai-sdk/react": "^2.0.30",
-          "@algolia/autocomplete-core": "1.19.2",
-          "@docsearch/css": "4.1.0",
-          "ai": "^5.0.30",
-          "algoliasearch": "^5.28.0",
-          "marked": "^16.3.0",
-          "zod": "^4.1.8"
-        },
-        "peerDependencies": {
-          "@types/react": ">= 16.8.0 < 20.0.0",
-          "react": ">= 16.8.0 < 20.0.0",
-          "react-dom": ">= 16.8.0 < 20.0.0",
-          "search-insights": ">= 1 < 3"
-        },
-        "optionalPeerDependencies": [
-          "@types/react",
-          "react",
-          "react-dom",
-          "search-insights"
-        ]
       }
     },
     "@emnapi/core@npm:1.10.0, @emnapi/core@npm:^1.10.0": {
@@ -3195,104 +2495,6 @@
         }
       }
     },
-    "@expressive-code/core@npm:^0.41.3": {
-      "checksum": "999ad13ffe7e7f467e66e145440813ab4cc5cb30d24ac3e363be4c8793dcd37269fa6ae6c3ecbabd60e7e6b8c524331cdcc32e2760ee4d8444d6c421eb3bacc4",
-      "resolution": {
-        "resolution": "@expressive-code/core@npm:0.41.3",
-        "version": "0.41.3",
-        "dependencies": {
-          "@ctrl/tinycolor": "^4.0.4",
-          "hast-util-select": "^6.0.2",
-          "hast-util-to-html": "^9.0.1",
-          "hast-util-to-text": "^4.0.1",
-          "hastscript": "^9.0.0",
-          "postcss": "^8.4.38",
-          "postcss-nested": "^6.0.1",
-          "unist-util-visit": "^5.0.0",
-          "unist-util-visit-parents": "^6.0.1"
-        }
-      }
-    },
-    "@expressive-code/plugin-frames@npm:^0.41.3": {
-      "checksum": "d4a32d1a6eaa800e94528d48b8545a8dab2839560276e64b867a3652feddbe507bde152d6529cf45aafd7d84b857cf8f2f5462bc3eea31ea2e5f38b3b786b2d7",
-      "resolution": {
-        "resolution": "@expressive-code/plugin-frames@npm:0.41.3",
-        "version": "0.41.3",
-        "dependencies": {
-          "@expressive-code/core": "^0.41.3"
-        }
-      }
-    },
-    "@expressive-code/plugin-shiki@npm:^0.41.3": {
-      "checksum": "e60f4c9b2eae6a1923351abd3725f671bf3c932bc2c657b57e8a78a769557d664c9e5222070ffd1efc14c5469b497de132d71cd33afa3b0863a88f189730cc4e",
-      "resolution": {
-        "resolution": "@expressive-code/plugin-shiki@npm:0.41.3",
-        "version": "0.41.3",
-        "dependencies": {
-          "@expressive-code/core": "^0.41.3",
-          "shiki": "^3.2.2"
-        }
-      }
-    },
-    "@expressive-code/plugin-text-markers@npm:^0.41.3": {
-      "checksum": "69870c1d458caf2da22187118f8f412880a32869f14a002a800f944c41a8e65ff2a7d411e7243abab5c539806161170d23494489104b84ea49dcac7c35f718a3",
-      "resolution": {
-        "resolution": "@expressive-code/plugin-text-markers@npm:0.41.3",
-        "version": "0.41.3",
-        "dependencies": {
-          "@expressive-code/core": "^0.41.3"
-        }
-      }
-    },
-    "@floating-ui/core@npm:^1.7.3": {
-      "checksum": "745ed6a1320ab579b19657735993b2871c816038b03a886ef2894e524d6545146d2d645da2f559bea5105a3a19b7073c39278f392b5133d9b2bc486faa598a1b",
-      "resolution": {
-        "resolution": "@floating-ui/core@npm:1.7.3",
-        "version": "1.7.3",
-        "dependencies": {
-          "@floating-ui/utils": "^0.2.10"
-        }
-      }
-    },
-    "@floating-ui/dom@npm:^1.7.4": {
-      "checksum": "0c5ae015c8d61bf2d8f2c5b6ec490b612c2cc549da9b3c94801275c1f8c3ebcf26893a1c5f73f037be9f4ac2dfde819bf2bfe7051630bac644bcd3476159eee4",
-      "resolution": {
-        "resolution": "@floating-ui/dom@npm:1.7.4",
-        "version": "1.7.4",
-        "dependencies": {
-          "@floating-ui/core": "^1.7.3",
-          "@floating-ui/utils": "^0.2.10"
-        }
-      }
-    },
-    "@floating-ui/react-dom@npm:^2.1.6": {
-      "checksum": "97cca25b4d433461d673c586f03fecedd5e849682273384994fbef31287d4a900c252d61448a7821f851996196d071838dab4e1f42ac63cc43be25430e960720",
-      "resolution": {
-        "resolution": "@floating-ui/react-dom@npm:2.1.6",
-        "version": "2.1.6",
-        "dependencies": {
-          "@floating-ui/dom": "^1.7.4"
-        },
-        "peerDependencies": {
-          "react": ">=16.8.0",
-          "react-dom": ">=16.8.0"
-        }
-      }
-    },
-    "@floating-ui/utils@npm:^0.2.10": {
-      "checksum": "c8e0cb39c603152d913f267060e1bac1ee814eabf70b04ca74d647ea5494da5f8a0aab3a36a885a59e9e64c86d197f21d2287f6dbae68f83d39510a5ca864e87",
-      "resolution": {
-        "resolution": "@floating-ui/utils@npm:0.2.10",
-        "version": "0.2.10"
-      }
-    },
-    "@fontsource/montserrat@npm:^5.2.6": {
-      "checksum": "e4249fddd68a3e69208c85d89545a57d10200969fe9bcea8909ae7fd9f7aa027b8ddc47d8f2d0622fdb6ceacca6e75990106b79092f338b16637a332003fe2b6",
-      "resolution": {
-        "resolution": "@fontsource/montserrat@npm:5.2.8",
-        "version": "5.2.8"
-      }
-    },
     "@humanfs/core@npm:^0.19.1": {
       "checksum": "39898d89ef412870f7fe12150f3e5455f1a6f3a69cb08ee1ad3de8758b685c25b1b9dc6683c62055c4a2a90b153fff6230a674985cd486bc9264ca611f50bed0",
       "resolution": {
@@ -4153,53 +3355,6 @@
         }
       }
     },
-    "@mdx-js/mdx@npm:^3.1.1": {
-      "checksum": "aad6090e20f9dfd47629d0cee81153d63c65334ae711236e21f27210b40304af639a7df1cbfc626ec87bc6532c7877fccbc6c5e257d03cdd1cb34e8ec9ae2af0",
-      "resolution": {
-        "resolution": "@mdx-js/mdx@npm:3.1.1",
-        "version": "3.1.1",
-        "dependencies": {
-          "@types/estree": "^1.0.0",
-          "@types/estree-jsx": "^1.0.0",
-          "@types/hast": "^3.0.0",
-          "@types/mdx": "^2.0.0",
-          "acorn": "^8.0.0",
-          "collapse-white-space": "^2.0.0",
-          "devlop": "^1.0.0",
-          "estree-util-is-identifier-name": "^3.0.0",
-          "estree-util-scope": "^1.0.0",
-          "estree-walker": "^3.0.0",
-          "hast-util-to-jsx-runtime": "^2.0.0",
-          "markdown-extensions": "^2.0.0",
-          "recma-build-jsx": "^1.0.0",
-          "recma-jsx": "^1.0.0",
-          "recma-stringify": "^1.0.0",
-          "rehype-recma": "^1.0.0",
-          "remark-mdx": "^3.0.0",
-          "remark-parse": "^11.0.0",
-          "remark-rehype": "^11.0.0",
-          "source-map": "^0.7.0",
-          "unified": "^11.0.0",
-          "unist-util-position-from-estree": "^2.0.0",
-          "unist-util-stringify-position": "^4.0.0",
-          "unist-util-visit": "^5.0.0",
-          "vfile": "^6.0.0"
-        }
-      }
-    },
-    "@mdx-js/preact@npm:^3.1.0": {
-      "checksum": "abaf909d13026b6463a361329ab6f11d1147ce74e33b0a65a307f067e7bf979505913cfe76ceb42c073bdd4f8c03c986a67bcf92f8124799e1f2abb9382a8e89",
-      "resolution": {
-        "resolution": "@mdx-js/preact@npm:3.1.1",
-        "version": "3.1.1",
-        "dependencies": {
-          "@types/mdx": "^2.0.0"
-        },
-        "peerDependencies": {
-          "preact": ">=10.0.0"
-        }
-      }
-    },
     "@mermaid-js/parser@npm:^1.1.1": {
       "checksum": "704f460fa6e0a6db8e5eaa0ec16f45dd04ae28620dcdacd8a72702372a490a356faf9876b7470a14fdfb5bc124cc017ac48433130372e2faa9a65aea4631ffad",
       "resolution": {
@@ -4210,16 +3365,6 @@
         }
       }
     },
-    "@monaco-editor/loader@npm:^1.4.0": {
-      "checksum": "e0b9ff1c82d79de69d31b5cfcf024b648a2ba3f2a07dc1447da83b301a9cdbe3f189c282adcbfc125898b662c00ecc8cd1af869e42ae0d7a95a78e40988a84eb",
-      "resolution": {
-        "resolution": "@monaco-editor/loader@npm:1.5.0",
-        "version": "1.5.0",
-        "dependencies": {
-          "state-local": "^1.0.6"
-        }
-      }
-    },
     "@monaco-editor/loader@npm:^1.5.0": {
       "checksum": "131726d1e7a18142c99fac9def875b654e84563a66d73d31ad2dc6e892f22d670d8ffe8441de14f0dafae7b38adb296239a515098d989bbd7119fff467b4226e",
       "resolution": {
@@ -4227,21 +3372,6 @@
         "version": "1.7.0",
         "dependencies": {
           "state-local": "^1.0.6"
-        }
-      }
-    },
-    "@monaco-editor/react@npm:4.7.0-rc.0": {
-      "checksum": "cd2d495619d217bd9b56c075cda34f053c6583e16cf322220aff18dfef9368203a2be561a82a64f2f63a2b31a5f29863f122f85546f42417682ceefbdd7f9096",
-      "resolution": {
-        "resolution": "@monaco-editor/react@npm:4.7.0-rc.0",
-        "version": "4.7.0-rc.0",
-        "dependencies": {
-          "@monaco-editor/loader": "^1.4.0"
-        },
-        "peerDependencies": {
-          "monaco-editor": ">= 0.25.0 < 1",
-          "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-          "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
         }
       }
     },
@@ -4664,13 +3794,6 @@
         "version": "6.0.0"
       }
     },
-    "@opentelemetry/api@npm:1.9.0": {
-      "checksum": "b3a82e33aa6571a20b8ab4ac96cba42d51e70214e8d0c825cc93fb3ca39bcf775afbc7dd2a2a1d5948c09c91fe47870443fd5a6e19d62e0c19bad048ad19ccba",
-      "resolution": {
-        "resolution": "@opentelemetry/api@npm:1.9.0",
-        "version": "1.9.0"
-      }
-    },
     "@oslojs/encoding@npm:^1.1.0": {
       "checksum": "3fcb5c8ff5c6c6067c1189960e522325d7b66634946cb8603d53414ac161f5ed8f4711771c36712cb1c6e2ad9cb5f8b63c03919f5f9b8172f717af206a311aca",
       "resolution": {
@@ -4685,201 +3808,11 @@
         "version": "0.130.0"
       }
     },
-    "@pagefind/darwin-arm64@npm:1.4.0": {
-      "checksum": null,
-      "resolution": {
-        "resolution": "@pagefind/darwin-arm64@npm:1.4.0",
-        "version": "1.4.0",
-        "requirements": {
-          "cpu": [
-            "arm64"
-          ],
-          "os": [
-            "darwin"
-          ]
-        }
-      }
-    },
-    "@pagefind/darwin-x64@npm:1.4.0": {
-      "checksum": null,
-      "resolution": {
-        "resolution": "@pagefind/darwin-x64@npm:1.4.0",
-        "version": "1.4.0",
-        "requirements": {
-          "cpu": [
-            "x64"
-          ],
-          "os": [
-            "darwin"
-          ]
-        }
-      }
-    },
-    "@pagefind/default-ui@npm:^1.3.0": {
-      "checksum": "88f720524c7c0dbd5b62f66ddc054efdc53c189f68100dfb7839ed214746146d34a810e52f6540b8ad5b0060d5a33c860dbffc7920945779f29d8884cbb4cb8f",
-      "resolution": {
-        "resolution": "@pagefind/default-ui@npm:1.4.0",
-        "version": "1.4.0"
-      }
-    },
-    "@pagefind/freebsd-x64@npm:1.4.0": {
-      "checksum": null,
-      "resolution": {
-        "resolution": "@pagefind/freebsd-x64@npm:1.4.0",
-        "version": "1.4.0",
-        "requirements": {
-          "cpu": [
-            "x64"
-          ],
-          "os": [
-            "freebsd"
-          ]
-        }
-      }
-    },
-    "@pagefind/linux-arm64@npm:1.4.0": {
-      "checksum": null,
-      "resolution": {
-        "resolution": "@pagefind/linux-arm64@npm:1.4.0",
-        "version": "1.4.0",
-        "requirements": {
-          "cpu": [
-            "arm64"
-          ],
-          "os": [
-            "linux"
-          ]
-        }
-      }
-    },
-    "@pagefind/linux-x64@npm:1.4.0": {
-      "checksum": null,
-      "resolution": {
-        "resolution": "@pagefind/linux-x64@npm:1.4.0",
-        "version": "1.4.0",
-        "requirements": {
-          "cpu": [
-            "x64"
-          ],
-          "os": [
-            "linux"
-          ]
-        }
-      }
-    },
-    "@pagefind/windows-x64@npm:1.4.0": {
-      "checksum": null,
-      "resolution": {
-        "resolution": "@pagefind/windows-x64@npm:1.4.0",
-        "version": "1.4.0",
-        "requirements": {
-          "cpu": [
-            "x64"
-          ],
-          "os": [
-            "win32"
-          ]
-        }
-      }
-    },
     "@pkgjs/parseargs@npm:^0.11.0": {
       "checksum": "fafea4ab97e90c31c8119c6c8e18cfe9bbe0deadc40e1a30babd5c8af88d45dbe68511d44b68471bb8d483a08b9ee336786dd6355263e9740b4a9490a8d3a9d3",
       "resolution": {
         "resolution": "@pkgjs/parseargs@npm:0.11.0",
         "version": "0.11.0"
-      }
-    },
-    "@preact/compat@npm:^18.3.1": {
-      "checksum": "f7a3d71cdaab1f062abf56108565606357c212b56594c0f81bc6d4572e8a872e073878e5d1e1761733c3c3878b315255f13619d5a388acbc140ed6e8ee1fb095",
-      "resolution": {
-        "resolution": "@preact/compat@npm:18.3.1",
-        "version": "18.3.1",
-        "peerDependencies": {
-          "preact": "*"
-        }
-      }
-    },
-    "@preact/preset-vite@npm:^2.10.2": {
-      "checksum": "a8d3fb2c2b4479b605d843c6a5bcbc58e56381cb16dff985bcf98fef7df6d7cbef5fc53089ce031d7d9bd29fcd9a6d02e99385f44358e9393b05a08f4ab50fc5",
-      "resolution": {
-        "resolution": "@preact/preset-vite@npm:2.10.2",
-        "version": "2.10.2",
-        "dependencies": {
-          "@babel/plugin-transform-react-jsx": "^7.22.15",
-          "@babel/plugin-transform-react-jsx-development": "^7.22.5",
-          "@prefresh/vite": "^2.4.1",
-          "@rollup/pluginutils": "^4.1.1",
-          "babel-plugin-transform-hook-names": "^1.0.2",
-          "debug": "^4.3.4",
-          "picocolors": "^1.1.1",
-          "vite-prerender-plugin": "^0.5.3"
-        },
-        "peerDependencies": {
-          "@babel/core": "7.x",
-          "vite": "2.x || 3.x || 4.x || 5.x || 6.x || 7.x"
-        }
-      }
-    },
-    "@preact/signals@npm:^2.3.1": {
-      "checksum": "883a191e94028ba476c685fa9b8c0119df52527621d79cfcdb7f8715a007a7bc344bfd51c6dc25866498d212338f8f5b7e8eb57fbb1e03dd1360d584e708ce33",
-      "resolution": {
-        "resolution": "@preact/signals@npm:2.3.2",
-        "version": "2.3.2",
-        "dependencies": {
-          "@preact/signals-core": "^1.12.0"
-        },
-        "peerDependencies": {
-          "preact": ">= 10.25.0 || >=11.0.0-0"
-        }
-      }
-    },
-    "@preact/signals-core@npm:^1.12.0": {
-      "checksum": "df92173918f17c1621c0ec0ed1b08c3905f3e547ceaaaa6ca746e4648e7d2172b623aa8ee1bc58c6be4abdcf2cb8b6382cd6932889f782624da270b59f62e5e9",
-      "resolution": {
-        "resolution": "@preact/signals-core@npm:1.12.1",
-        "version": "1.12.1"
-      }
-    },
-    "@prefresh/babel-plugin@npm:0.5.2": {
-      "checksum": "227850c8e32c4969f0fd1a576706f534ecc21ac7504290e8ab45359e97c7010067e65f18c6a3f7beb4462fd8abe43ae67cfc0046952947e9b35589371220a10f",
-      "resolution": {
-        "resolution": "@prefresh/babel-plugin@npm:0.5.2",
-        "version": "0.5.2"
-      }
-    },
-    "@prefresh/core@npm:^1.5.0": {
-      "checksum": "ea738db3ad0f626426be75e2dd3dce4e5337e991fc0cae11275db953366ceac92de9cf405c00c50e6d72aaef445a0a3bf82298f50cc8501b5bc09decb63d4b8d",
-      "resolution": {
-        "resolution": "@prefresh/core@npm:1.5.8",
-        "version": "1.5.8",
-        "peerDependencies": {
-          "preact": "^10.0.0 || ^11.0.0-0"
-        }
-      }
-    },
-    "@prefresh/utils@npm:^1.2.0": {
-      "checksum": "c7fa1d44b1b32254416fd65d2b43ccf4241e0c978469bf61160f87572d2e3af4e0e3005731e5f1ae6c0462a39ed9760303bb59fa8794b46fbdcd7d4aa843bb49",
-      "resolution": {
-        "resolution": "@prefresh/utils@npm:1.2.1",
-        "version": "1.2.1"
-      }
-    },
-    "@prefresh/vite@npm:^2.4.1": {
-      "checksum": "19fca5a4ffcfb7e07afbb0bf87df3488e1ce67723028f266e25b7bddf727a6f5548f75bf6878d068b17f748a089eaa8d6b9fbe2146d46965efbc165ac3dc82fe",
-      "resolution": {
-        "resolution": "@prefresh/vite@npm:2.4.10",
-        "version": "2.4.10",
-        "dependencies": {
-          "@babel/core": "^7.22.1",
-          "@prefresh/babel-plugin": "0.5.2",
-          "@prefresh/core": "^1.5.0",
-          "@prefresh/utils": "^1.2.0",
-          "@rollup/pluginutils": "^4.2.1"
-        },
-        "peerDependencies": {
-          "preact": "^10.4.0 || ^11.0.0-0",
-          "vite": ">=2.0.0"
-        }
       }
     },
     "@puppeteer/browsers@npm:2.13.2": {
@@ -4896,29 +3829,6 @@
           "tar-fs": "^3.1.1",
           "yargs": "^17.7.2"
         }
-      }
-    },
-    "@reduxjs/toolkit@npm:1.x.x || 2.x.x": {
-      "checksum": "2b0016d48f91f8bf06b9dc7e22c11b85709c5c16101b9debc227240693c1b7e462a0888d54448ad9e177361ed9eef8d358e192f9429619a6c4b9ea1e57f02931",
-      "resolution": {
-        "resolution": "@reduxjs/toolkit@npm:2.9.0",
-        "version": "2.9.0",
-        "dependencies": {
-          "@standard-schema/spec": "^1.0.0",
-          "@standard-schema/utils": "^0.3.0",
-          "immer": "^10.0.3",
-          "redux": "^5.0.1",
-          "redux-thunk": "^3.1.0",
-          "reselect": "^5.1.0"
-        },
-        "peerDependencies": {
-          "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
-          "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
-        },
-        "optionalPeerDependencies": [
-          "react",
-          "react-redux"
-        ]
       }
     },
     "@reduxjs/toolkit@npm:^2.11.2": {
@@ -5203,18 +4113,7 @@
         "version": "1.0.1"
       }
     },
-    "@rollup/pluginutils@npm:^4.1.1, @rollup/pluginutils@npm:^4.2.1": {
-      "checksum": "23cadac04bb58409831afdda1e9ef2e6b393a265f22f9092158ba3da2d1bc4ef0d21cd6dbc8e9fee3e1184f57fb5204fc58db82ee65bef67277b917ce9edaa36",
-      "resolution": {
-        "resolution": "@rollup/pluginutils@npm:4.2.1",
-        "version": "4.2.1",
-        "dependencies": {
-          "estree-walker": "^2.0.1",
-          "picomatch": "^2.2.2"
-        }
-      }
-    },
-    "@rollup/pluginutils@npm:^5.2.0, @rollup/pluginutils@npm:^5.3.0": {
+    "@rollup/pluginutils@npm:^5.3.0": {
       "checksum": "3a5130448ee4dcf861ea729b3ea7192d739dd95779aef538b46b70de15c50fdaecf8a0b433a422e1f213a75737f111b74aed7aef9cd1eb782404fa566988eecd",
       "resolution": {
         "resolution": "@rollup/pluginutils@npm:5.3.0",
@@ -5595,19 +4494,6 @@
         }
       }
     },
-    "@shikijs/core@npm:3.13.0": {
-      "checksum": "f54b09bcc3649645d2911ee340e228c66c76bcda8fabf74fe3625d4203c4b5f2919710e3f40113d4bd028caaa9bba1fc0734431383d7f5dbd51f3becf6d3ea42",
-      "resolution": {
-        "resolution": "@shikijs/core@npm:3.13.0",
-        "version": "3.13.0",
-        "dependencies": {
-          "@shikijs/types": "3.13.0",
-          "@shikijs/vscode-textmate": "^10.0.2",
-          "@types/hast": "^3.0.4",
-          "hast-util-to-html": "^9.0.5"
-        }
-      }
-    },
     "@shikijs/core@npm:3.23.0": {
       "checksum": "e98dc71c42ee42df524c548547ae0d48a997b2ca5b1d6c98eaf16000ea0b0b6fe36a92c47b44cf7b88381cb1c2173facf323d64b4e7142fc5fb3f0243a8847b2",
       "resolution": {
@@ -5635,18 +4521,6 @@
         }
       }
     },
-    "@shikijs/engine-javascript@npm:3.13.0": {
-      "checksum": "cfc0e4bb83698809302ce2369e9d1e4965bad21076101b12f44a9d49e541d3ffc7055ad4d2e5f076fc1ccf89e4cf8cbfaf07ab75ac84836293183140ecbb3562",
-      "resolution": {
-        "resolution": "@shikijs/engine-javascript@npm:3.13.0",
-        "version": "3.13.0",
-        "dependencies": {
-          "@shikijs/types": "3.13.0",
-          "@shikijs/vscode-textmate": "^10.0.2",
-          "oniguruma-to-es": "^4.3.3"
-        }
-      }
-    },
     "@shikijs/engine-javascript@npm:3.23.0": {
       "checksum": "e817f5aefafa2e82851aaca674d9081fc33733cf84c1305258545bd50efeda583b69ecc4bef7615039b6eb8bb46b5b41909b6548c66ee7c9c21d3f0c72959683",
       "resolution": {
@@ -5671,17 +4545,6 @@
         }
       }
     },
-    "@shikijs/engine-oniguruma@npm:3.13.0": {
-      "checksum": "6b8bde8f482960c8e71175b4d0e86e2b6c0988d8de7cbb87757ba78d6c79e82103af85ed7a983d72486f105ef88a656648778ce66a3c6c812254e10fc6b72645",
-      "resolution": {
-        "resolution": "@shikijs/engine-oniguruma@npm:3.13.0",
-        "version": "3.13.0",
-        "dependencies": {
-          "@shikijs/types": "3.13.0",
-          "@shikijs/vscode-textmate": "^10.0.2"
-        }
-      }
-    },
     "@shikijs/engine-oniguruma@npm:3.23.0": {
       "checksum": "e7f33a1c45ed85a6470e365f530e06759115b51ea7dcb3be6042e9c92c6732db1966bc828ede05b405035e34cc0256779d0f819ff24d4ef058ab5d703f0c9e28",
       "resolution": {
@@ -5701,16 +4564,6 @@
         "dependencies": {
           "@shikijs/types": "4.0.2",
           "@shikijs/vscode-textmate": "^10.0.2"
-        }
-      }
-    },
-    "@shikijs/langs@npm:3.13.0": {
-      "checksum": "c3df283e49cb5c03c8760edd05c0758a4b0eb423447488881c8d4ba612859f0e9d62e98622684636ad748ad90a9126a4f0363845ac16044376aac7d9e748013c",
-      "resolution": {
-        "resolution": "@shikijs/langs@npm:3.13.0",
-        "version": "3.13.0",
-        "dependencies": {
-          "@shikijs/types": "3.13.0"
         }
       }
     },
@@ -5746,16 +4599,6 @@
         }
       }
     },
-    "@shikijs/themes@npm:3.13.0": {
-      "checksum": "2a3cf8b76c7ea34f01d5b032873b505e665dd2f8f51f86b72966b9eb54d8cb838f7d60f3ddf349da4442f94964f89b4bbcb10092ceb3580f3d3d75efed99e972",
-      "resolution": {
-        "resolution": "@shikijs/themes@npm:3.13.0",
-        "version": "3.13.0",
-        "dependencies": {
-          "@shikijs/types": "3.13.0"
-        }
-      }
-    },
     "@shikijs/themes@npm:3.23.0": {
       "checksum": "66d326edacb904b61b07b9b4488ebf5e06807aeddb154a7162b9076a7ca597a20e05bf9714d7681b533878b81a046ea276653ab160b27eb7578a0dc7ae6bcc45",
       "resolution": {
@@ -5773,17 +4616,6 @@
         "version": "4.0.2",
         "dependencies": {
           "@shikijs/types": "4.0.2"
-        }
-      }
-    },
-    "@shikijs/types@npm:3.13.0": {
-      "checksum": "ebf9b567f50ee0aab3ba2147f78598314e09d3a5135dc476249b786bc88ad6695852d162cd96ce49f90151844671e7fbb8c7225044a51a77f75e61d97c8b1e39",
-      "resolution": {
-        "resolution": "@shikijs/types@npm:3.13.0",
-        "version": "3.13.0",
-        "dependencies": {
-          "@shikijs/vscode-textmate": "^10.0.2",
-          "@types/hast": "^3.0.4"
         }
       }
     },
@@ -5974,23 +4806,6 @@
         }
       }
     },
-    "@splidejs/react-splide@npm:^0.7.12": {
-      "checksum": "80f168d932564da64fb9e7b25811dfb4ccb5b125c37be2b559d1a18c1e455c7a5b5ad19419c90fea8ca8fa5e5406563cd93c71510b6a335b8b7ebd51d9fc55d8",
-      "resolution": {
-        "resolution": "@splidejs/react-splide@npm:0.7.12",
-        "version": "0.7.12",
-        "dependencies": {
-          "@splidejs/splide": "^4.1.3"
-        }
-      }
-    },
-    "@splidejs/splide@npm:^4.1.3": {
-      "checksum": "4142021639ad0356e4a7fa82507bd42b2a4968a8070f745ad6c3d9ca8a3fa3349a0e16ec44512bf1439383eb1828482253fe504ae1826fab4dece58011772cc9",
-      "resolution": {
-        "resolution": "@splidejs/splide@npm:4.1.4",
-        "version": "4.1.4"
-      }
-    },
     "@standard-schema/spec@npm:^1.0.0": {
       "checksum": "dcc7e060e6aed174384b8ca9e688d646680b5ea277b32f573adc22816ba3b873a22ddbcd109a0669d0d65136eb11f7c4f7e87049c2f04f186c9dfd465b380bb0",
       "resolution": {
@@ -6036,157 +4851,6 @@
         },
         "peerDependencies": {
           "eslint": ">=8.40.0"
-        }
-      }
-    },
-    "@svgr/babel-plugin-add-jsx-attribute@npm:8.0.0": {
-      "checksum": "adc4fd755a0e8ecdc02daeef324dbc908ee56831c4a327d91db42bd28b5eb4c066e5bbdc1e9e709cd80cb3bf6386e9452f6b233c383501e9cc7e86e105e63bad",
-      "resolution": {
-        "resolution": "@svgr/babel-plugin-add-jsx-attribute@npm:8.0.0",
-        "version": "8.0.0",
-        "peerDependencies": {
-          "@babel/core": "^7.0.0-0"
-        }
-      }
-    },
-    "@svgr/babel-plugin-remove-jsx-attribute@npm:8.0.0": {
-      "checksum": "7180b099b078906f8701204d6bca8a1c28a22d7024db5ac3c59c954d62d0226366a0c97be798e8d8c765bf926ee57a3d9605fce6e930e0d11fc0802066f4339d",
-      "resolution": {
-        "resolution": "@svgr/babel-plugin-remove-jsx-attribute@npm:8.0.0",
-        "version": "8.0.0",
-        "peerDependencies": {
-          "@babel/core": "^7.0.0-0"
-        }
-      }
-    },
-    "@svgr/babel-plugin-remove-jsx-empty-expression@npm:8.0.0": {
-      "checksum": "5f7a4cec9affc337ac70197b6b4321b066d846a1f5bd3d40bfce45153889676ffd382d06f447c046c7941f09d823dfac287baffa919295b30f09bba2512b0cf7",
-      "resolution": {
-        "resolution": "@svgr/babel-plugin-remove-jsx-empty-expression@npm:8.0.0",
-        "version": "8.0.0",
-        "peerDependencies": {
-          "@babel/core": "^7.0.0-0"
-        }
-      }
-    },
-    "@svgr/babel-plugin-replace-jsx-attribute-value@npm:8.0.0": {
-      "checksum": "6920934efb0fb539bd9e941127060ae8674d376161d2954fcdc4099eea1f9d1491bafc69b4f30c33183a7d0338df061f77e9cd126bd6a5d1b6e735a15b0c86e4",
-      "resolution": {
-        "resolution": "@svgr/babel-plugin-replace-jsx-attribute-value@npm:8.0.0",
-        "version": "8.0.0",
-        "peerDependencies": {
-          "@babel/core": "^7.0.0-0"
-        }
-      }
-    },
-    "@svgr/babel-plugin-svg-dynamic-title@npm:8.0.0": {
-      "checksum": "cd18f6359317e755ab7cb275bde77b55005fb7b48bc110f46115b82659d280e7078a7a8d1b0fbade54fd91097fa84cf7f4ff5af1933b963103bbec49c6b31cd4",
-      "resolution": {
-        "resolution": "@svgr/babel-plugin-svg-dynamic-title@npm:8.0.0",
-        "version": "8.0.0",
-        "peerDependencies": {
-          "@babel/core": "^7.0.0-0"
-        }
-      }
-    },
-    "@svgr/babel-plugin-svg-em-dimensions@npm:8.0.0": {
-      "checksum": "3a74903297ac0a21af2d7f1c8e3efeea67be2998dea60d5677f1fd9cf4c0c65530de6b8a854c3e3d1263b02089c6b66e94ef18719412bc29a592cd829c682a0f",
-      "resolution": {
-        "resolution": "@svgr/babel-plugin-svg-em-dimensions@npm:8.0.0",
-        "version": "8.0.0",
-        "peerDependencies": {
-          "@babel/core": "^7.0.0-0"
-        }
-      }
-    },
-    "@svgr/babel-plugin-transform-react-native-svg@npm:8.1.0": {
-      "checksum": "aa76d3bec6355575524de2ad6a2ab27711d8252e803b1463d6044afdda8854007002184ae0d0fee84e31310b2e1784fada17703715c897be580dae0af2141de4",
-      "resolution": {
-        "resolution": "@svgr/babel-plugin-transform-react-native-svg@npm:8.1.0",
-        "version": "8.1.0",
-        "peerDependencies": {
-          "@babel/core": "^7.0.0-0"
-        }
-      }
-    },
-    "@svgr/babel-plugin-transform-svg-component@npm:8.0.0": {
-      "checksum": "687699b936861c0117bf18d26e6c7ad4c091768eff296505fdaa9f55358e2d894acbfab9a5b2fb1b3d822d5dc39d926a5c064877bf9fecf7e4197258d95853ef",
-      "resolution": {
-        "resolution": "@svgr/babel-plugin-transform-svg-component@npm:8.0.0",
-        "version": "8.0.0",
-        "peerDependencies": {
-          "@babel/core": "^7.0.0-0"
-        }
-      }
-    },
-    "@svgr/babel-preset@npm:8.1.0": {
-      "checksum": "8941ee6b1dd61297c6c489ca8561465fa1f449b5107ce1fce404c4676ac71abf94f3b645c17a92d938f7c3ae34799d668fe3448f8777a8a28c2063ecc85ce246",
-      "resolution": {
-        "resolution": "@svgr/babel-preset@npm:8.1.0",
-        "version": "8.1.0",
-        "dependencies": {
-          "@svgr/babel-plugin-add-jsx-attribute": "8.0.0",
-          "@svgr/babel-plugin-remove-jsx-attribute": "8.0.0",
-          "@svgr/babel-plugin-remove-jsx-empty-expression": "8.0.0",
-          "@svgr/babel-plugin-replace-jsx-attribute-value": "8.0.0",
-          "@svgr/babel-plugin-svg-dynamic-title": "8.0.0",
-          "@svgr/babel-plugin-svg-em-dimensions": "8.0.0",
-          "@svgr/babel-plugin-transform-react-native-svg": "8.1.0",
-          "@svgr/babel-plugin-transform-svg-component": "8.0.0"
-        },
-        "peerDependencies": {
-          "@babel/core": "^7.0.0-0"
-        }
-      }
-    },
-    "@svgr/core@npm:^8.1.0": {
-      "checksum": "b9c63f5169969a65aea8c6356ed3211352446ac3ecca3921e0da98a5102aac8e79b1af61b806bc01c7953234eb64c2e448001632d4941bccc14f56f80a9f9317",
-      "resolution": {
-        "resolution": "@svgr/core@npm:8.1.0",
-        "version": "8.1.0",
-        "dependencies": {
-          "@babel/core": "^7.21.3",
-          "@svgr/babel-preset": "8.1.0",
-          "camelcase": "^6.2.0",
-          "cosmiconfig": "^8.1.3",
-          "snake-case": "^3.0.4"
-        }
-      }
-    },
-    "@svgr/hast-util-to-babel-ast@npm:8.0.0": {
-      "checksum": "c2bb59527f4cb7610494859e9216d5fef1628ed8d02784b77767cfae8d30c31878276fcee126466ad61d0d39ae6043fa75ceb8edd0d509d7ddb7ddcf70fcfc49",
-      "resolution": {
-        "resolution": "@svgr/hast-util-to-babel-ast@npm:8.0.0",
-        "version": "8.0.0",
-        "dependencies": {
-          "@babel/types": "^7.21.3",
-          "entities": "^4.4.0"
-        }
-      }
-    },
-    "@svgr/plugin-jsx@npm:^8.1.0": {
-      "checksum": "0b28b5cad49e59e1dfef0ad378e4154907bfea3373788aeab7df57a78d084247e54d819315a07459873bff6b33ecca542c63129571d3b85246e81d412af81b4a",
-      "resolution": {
-        "resolution": "@svgr/plugin-jsx@npm:8.1.0",
-        "version": "8.1.0",
-        "dependencies": {
-          "@babel/core": "^7.21.3",
-          "@svgr/babel-preset": "8.1.0",
-          "@svgr/hast-util-to-babel-ast": "8.0.0",
-          "svg-parser": "^2.0.4"
-        },
-        "peerDependencies": {
-          "@svgr/core": "*"
-        }
-      }
-    },
-    "@swc/helpers@npm:^0.5.12": {
-      "checksum": "013925c36d9f3047e256ade615a55633bba83a675fb37c703610da188f061644213a9a176cce3543e6c2c37ef1d641ade2a8a57e963516d19a2b9775585880b3",
-      "resolution": {
-        "resolution": "@swc/helpers@npm:0.5.17",
-        "version": "0.5.17",
-        "dependencies": {
-          "tslib": "^2.8.0"
         }
       }
     },
@@ -6742,26 +5406,6 @@
         "version": "1.162.0"
       }
     },
-    "@tanstack/query-core@npm:5.90.2": {
-      "checksum": "0cac18ed941ec38d65bd4ac81c111b47fbe60cab1344610c568e238dec0b1dedfe878617993c10d2a2b57c794fa163133b873667cf23f514cad170379161684a",
-      "resolution": {
-        "resolution": "@tanstack/query-core@npm:5.90.2",
-        "version": "5.90.2"
-      }
-    },
-    "@tanstack/react-query@npm:^5.81.5": {
-      "checksum": "77b0c9b6f257e4bf5b00e24a7639df728131e269620129e79e808f5f497354150426f84f5148e721689a86ae9e01b52721c31ed1bae523965a08e794f6b5ecff",
-      "resolution": {
-        "resolution": "@tanstack/react-query@npm:5.90.2",
-        "version": "5.90.2",
-        "dependencies": {
-          "@tanstack/query-core": "5.90.2"
-        },
-        "peerDependencies": {
-          "react": "^18 || ^19"
-        }
-      }
-    },
     "@tanstack/react-router@npm:^1.132.14": {
       "checksum": "3629545a1e6c4db844d4d509d6b6041e99701aa4d3e4b5b4ed41e5e91f553ef50d25583f563233dac9903e61b4b300a1e3ce09c70a78dbfc60f25b27fa41ad25",
       "resolution": {
@@ -6880,13 +5524,6 @@
         }
       }
     },
-    "@tweenjs/tween.js@npm:~23.1.3": {
-      "checksum": "fa368c429144bb798362798397415d8aca73ec93040a53e1beb4d4fd493eb598595332e958ecf054975f25115ed308680dc5c2261e3e9fea8b7af9bba1ed9535",
-      "resolution": {
-        "resolution": "@tweenjs/tween.js@npm:23.1.3",
-        "version": "23.1.3"
-      }
-    },
     "@tybys/wasm-util@npm:^0.10.1": {
       "checksum": "5de096b9000a72be6090b0badc4b6db1b6d1160973be4892441715f31e1c9c81fb676be070919ec2f8ac87a975923b03f8943a51046f21c60ad7f254339ab8cf",
       "resolution": {
@@ -6904,7 +5541,7 @@
         "version": "8.10.161"
       }
     },
-    "@types/babel__core@npm:^7, @types/babel__core@npm:^7.1.14, @types/babel__core@npm:^7.20.5": {
+    "@types/babel__core@npm:^7.1.14, @types/babel__core@npm:^7.20.5": {
       "checksum": "3cf26675f59ec37c3dc6cdcb552aee1906048bb55e12898ad2b60715581cc0c635e601ba4a6070b4abdd63bf7afe262270e716989ca0ae4b2907bc6e25f20954",
       "resolution": {
         "resolution": "@types/babel__core@npm:7.20.5",
@@ -7001,7 +5638,7 @@
         }
       }
     },
-    "@types/d3-array@npm:*, @types/d3-array@npm:^3.0.3": {
+    "@types/d3-array@npm:*": {
       "checksum": "62cebfd02fcbf77e25d9050f28715db49513fac2d0470708163d44ee60c4a08c026a14beca423ff6fc9a45bb7492b6ec811d9e00f67b3e2306c933440238a59e",
       "resolution": {
         "resolution": "@types/d3-array@npm:3.2.2",
@@ -7084,7 +5721,7 @@
         "version": "3.0.7"
       }
     },
-    "@types/d3-ease@npm:*, @types/d3-ease@npm:^3.0.0": {
+    "@types/d3-ease@npm:*": {
       "checksum": "c22f4e85704c429bce900faa0ec30495cb1e1aa609504c629836b15f01df982965e69c9d670b3cffe7c5b6f04f7a9632d0d742c5cf77f71be2797b2a380045f2",
       "resolution": {
         "resolution": "@types/d3-ease@npm:3.0.2",
@@ -7132,7 +5769,7 @@
         "version": "3.1.7"
       }
     },
-    "@types/d3-interpolate@npm:*, @types/d3-interpolate@npm:^3.0.1": {
+    "@types/d3-interpolate@npm:*": {
       "checksum": "0eff69578f98d123004f66b1d9c322c5c700a9079a7032839d8e36d5e806a215c3868c959ada1d94097d8c1468933c8fffff11b7f3e059b373731fa755549377",
       "resolution": {
         "resolution": "@types/d3-interpolate@npm:3.0.4",
@@ -7170,7 +5807,7 @@
         "version": "3.0.3"
       }
     },
-    "@types/d3-scale@npm:*, @types/d3-scale@npm:^4.0.2": {
+    "@types/d3-scale@npm:*": {
       "checksum": "4ef6ca1a1f09265a5ab7cfd60c2eaefc3faa954ab60319292adb28407a44c02e1d98013065744725fb4bf1ffac6e999c90f9227de5ba16e2de90481b7720789b",
       "resolution": {
         "resolution": "@types/d3-scale@npm:4.0.9",
@@ -7204,17 +5841,7 @@
         }
       }
     },
-    "@types/d3-shape@npm:^3.1.0": {
-      "checksum": "df37f314c35bf5a5f927b7638a175144c5bf9a21a3fbefb92f5963eb55a6fa8a8404184489085073e90f23cec727584a8d64f37f1b731973af3bac1d76bd4930",
-      "resolution": {
-        "resolution": "@types/d3-shape@npm:3.1.7",
-        "version": "3.1.7",
-        "dependencies": {
-          "@types/d3-path": "*"
-        }
-      }
-    },
-    "@types/d3-time@npm:*, @types/d3-time@npm:^3.0.0": {
+    "@types/d3-time@npm:*": {
       "checksum": "5dec164f409f6b4477b26b86a9aae06a901e5933797cfb6f67f937eb39fae846e9c3d2adccbb616b7900fe718c04d7777837bec2bf593a7990af3d8a6503278b",
       "resolution": {
         "resolution": "@types/d3-time@npm:3.0.4",
@@ -7228,7 +5855,7 @@
         "version": "4.0.3"
       }
     },
-    "@types/d3-timer@npm:*, @types/d3-timer@npm:^3.0.0": {
+    "@types/d3-timer@npm:*": {
       "checksum": "f12cc65c36d43e1e958809518e7321fcd72bd7164f30fc8d75b66758dcdf8a440b6b58483cea7a92e4dd09eb4309fac4b9f776292d285b1be036a2ac38c21af7",
       "resolution": {
         "resolution": "@types/d3-timer@npm:3.0.2",
@@ -7271,13 +5898,6 @@
       "resolution": {
         "resolution": "@types/dom-navigation@npm:1.0.6",
         "version": "1.0.6"
-      }
-    },
-    "@types/dom-speech-recognition@npm:^0.0.1": {
-      "checksum": "9d54ecf6a3fe5fcbb3d95e036f128797fd9434ea1987f434be7e6794a06e6d567fb948248f20c4ba6505c737a2eee4b647e3c2d1b31657f7d6e3fe786e8e821b",
-      "resolution": {
-        "resolution": "@types/dom-speech-recognition@npm:0.0.1",
-        "version": "0.0.1"
       }
     },
     "@types/emscripten@npm:^1.39.6": {
@@ -7327,28 +5947,11 @@
         }
       }
     },
-    "@types/fontkit@npm:^2.0.8": {
-      "checksum": "e7bb803ad869d4cb2f8d950504bf6673d4f76d329f516dbb1ce0df9599410af2c7eff5d5dcd65447a70e9cc3396074ddd58f159c7c32e36c2f93fd98b32eb117",
-      "resolution": {
-        "resolution": "@types/fontkit@npm:2.0.8",
-        "version": "2.0.8",
-        "dependencies": {
-          "@types/node": "*"
-        }
-      }
-    },
     "@types/geojson@npm:*": {
       "checksum": "580a2e7c0df4de635967cd4a9408aa92efdca47d43356e4ab9bdd1c06764a9ad6e4758303d02d9a6e08eed296254d4bed9115ce22943ceea0a9cdc211534b024",
       "resolution": {
         "resolution": "@types/geojson@npm:7946.0.16",
         "version": "7946.0.16"
-      }
-    },
-    "@types/google.maps@npm:^3.55.12": {
-      "checksum": "d51098783498d0b38dca6759f564f89184a522faac346b44a70f6d27e2958577da8f02b5a3c5bf0fe5838fd0bfd2ac7d84fdf57f6e5338854d2fc4da5ed11953",
-      "resolution": {
-        "resolution": "@types/google.maps@npm:3.58.1",
-        "version": "3.58.1"
       }
     },
     "@types/graceful-fs@npm:^4.1.3": {
@@ -7369,13 +5972,6 @@
         "dependencies": {
           "@types/unist": "*"
         }
-      }
-    },
-    "@types/hogan.js@npm:^3.0.0": {
-      "checksum": "4af59e91e70e5006aefb69ee6e182ab6ded16880d78ecd54480b7857310b8af7193105eeea74773edfa7b664f07af7bcd250a2fa309890614c0cad1550fd09ba",
-      "resolution": {
-        "resolution": "@types/hogan.js@npm:3.0.5",
-        "version": "3.0.5"
       }
     },
     "@types/http-cache-semantics@npm:*": {
@@ -7430,13 +6026,6 @@
         }
       }
     },
-    "@types/js-yaml@npm:^4.0.9": {
-      "checksum": "eef01bb6b4262e3dadc2355cfbf5af4226fffcc987df12ca73861a7b8889f021c7d0a320dd163dc79119e5bf2a4ecd3039c788377feaba7b780b4523eb1d88af",
-      "resolution": {
-        "resolution": "@types/js-yaml@npm:4.0.9",
-        "version": "4.0.9"
-      }
-    },
     "@types/json-schema@npm:^7.0.15": {
       "checksum": "8d6197425f055ac8e2ecf45e33064c2184679faff4be6892cd3018f7ee35543154a761126d66d6ddc6abd4a358f69e8c456b81cc38461bb8ca728991eb19c407",
       "resolution": {
@@ -7468,7 +6057,7 @@
         "version": "4.17.20"
       }
     },
-    "@types/mdast@npm:^4.0.0, @types/mdast@npm:^4.0.4": {
+    "@types/mdast@npm:^4.0.0": {
       "checksum": "a8d83266f5f391e12ee17a378f1474aeaa7ef0cbcdea816d59bba8beea899c56aa0f49f8cad0f22e6e3acc55eb73389a566695c16c5090c0c3c086c393b5a6e4",
       "resolution": {
         "resolution": "@types/mdast@npm:4.0.4",
@@ -7476,13 +6065,6 @@
         "dependencies": {
           "@types/unist": "*"
         }
-      }
-    },
-    "@types/mdx@npm:^2.0.0": {
-      "checksum": "01fd457a0d1aa0dd161bf3d15e6118e63a50ff7e33bdfb57e63aa9d1528d8e00c1426d176d0d18fdc274786197cf8628ad3ee4b8cd86f57c4ce0bc278e711df5",
-      "resolution": {
-        "resolution": "@types/mdx@npm:2.0.13",
-        "version": "2.0.13"
       }
     },
     "@types/mime@npm:*": {
@@ -7532,16 +6114,6 @@
         }
       }
     },
-    "@types/parse-path@npm:^7.0.0": {
-      "checksum": "d8863f1daca7063839b240dffd40124ab8811aff0f7ab8bb76e43c8744d8825e34017743321c37e3eee18f45c3b44efb0044190f0698cd8217167f17e54c628b",
-      "resolution": {
-        "resolution": "@types/parse-path@npm:7.1.0",
-        "version": "7.1.0",
-        "dependencies": {
-          "parse-path": "*"
-        }
-      }
-    },
     "@types/pem@npm:^1": {
       "checksum": "62ffdd9ffb93b713afa1b0ab6d4229f2c7e6ad1673a4450f9d74c94ed36f6ba9286d363cc0129ef26774ae607cc9dcdd3eadfd406fff4557fd09bc40598adf45",
       "resolution": {
@@ -7552,7 +6124,7 @@
         }
       }
     },
-    "@types/qs@npm:*, @types/qs@npm:^6.5.3": {
+    "@types/qs@npm:*": {
       "checksum": "cb065152d3d8aa22d5582397c1846c6e8c246649006a92e2dfa422c72ffd09619ec53ad170f187dc2d28c0ac77bccd4d7e5e143a65dcbbf61585cc7d880e4db2",
       "resolution": {
         "resolution": "@types/qs@npm:6.14.0",
@@ -7564,16 +6136,6 @@
       "resolution": {
         "resolution": "@types/range-parser@npm:1.2.7",
         "version": "1.2.7"
-      }
-    },
-    "@types/react@npm:*": {
-      "checksum": "4d015998c6a1031db06e7f8e83d2478cc7741c5c0cb34edbbb9bb62ee78ed216fbd1cbfabd0df7795f9e3d27111c44487b436871a72516246184ee88c31f234f",
-      "resolution": {
-        "resolution": "@types/react@npm:19.2.2",
-        "version": "19.2.2",
-        "dependencies": {
-          "csstype": "^3.0.2"
-        }
       }
     },
     "@types/react@npm:^19.2.14, @types/react@npm:^19.2.2": {
@@ -7596,23 +6158,6 @@
         }
       }
     },
-    "@types/react-is@npm:^19": {
-      "checksum": "c50d11088348bfac17ecc0a562806595633b60ab83fb5d0d04ae7b71952fd0c05af25c06cec03365f5b3a45dc848ec94a002573efeac19b756019a4f325507b4",
-      "resolution": {
-        "resolution": "@types/react-is@npm:19.2.0",
-        "version": "19.2.0",
-        "dependencies": {
-          "@types/react": "*"
-        }
-      }
-    },
-    "@types/resolve@npm:^1": {
-      "checksum": "cd3c21a24f50955f5ea255e9e5fd0a73196d9b9c17b7225ac204e2b250298287d1db98b4df86dbdb4371a84ce706bc6dcabdac9441a52b0a067abf54d44e3ab5",
-      "resolution": {
-        "resolution": "@types/resolve@npm:1.20.6",
-        "version": "1.20.6"
-      }
-    },
     "@types/responselike@npm:^1.0.0": {
       "checksum": "2ba9fefbe58242bcb180419dd6332703e3831a34f4b8ac9d004b18a4a6061d14c59c7c7f945d013458ded509b13a7edb064d013f13f7bb850e6d0d94f41f2a65",
       "resolution": {
@@ -7633,7 +6178,7 @@
         }
       }
     },
-    "@types/semver@npm:^7, @types/semver@npm:^7.1.0": {
+    "@types/semver@npm:^7.1.0": {
       "checksum": "0668f9171e2d86a139abaebaa11f71b03f67b47f6708084af04afcf96382865baf63a34e17ed7897fd95434c057884deff8368327cdc408914914dcdae75d24d",
       "resolution": {
         "resolution": "@types/semver@npm:7.7.1",
@@ -7668,13 +6213,6 @@
         "version": "2.0.3"
       }
     },
-    "@types/stats.js@npm:*": {
-      "checksum": "b93d5bb2459d25ba7871af9bec82056460b9ee0244fa8d3da81aaf2c416945924553dfe5e1c54426452586451d60f7849d69fbde35a413b3c5eb38c2ae0c088d",
-      "resolution": {
-        "resolution": "@types/stats.js@npm:0.17.4",
-        "version": "0.17.4"
-      }
-    },
     "@types/tar@npm:^4.0.4": {
       "checksum": "d3262da8141e8fb833a97829f78e1d2c5b6fe5fb3a55f14309c7a4328ace7178b0f7c5092707dc1b567dd3ddbfba0ca15df67f16818d5289e158ccb98b225851",
       "resolution": {
@@ -7707,22 +6245,6 @@
         }
       }
     },
-    "@types/three@npm:^0.180.0": {
-      "checksum": "fd9707406ecff951db82b6f5098c6ec54b9ea2050894e4547a458a493609e1aeed81ff9ba5451f5d209fa1d543ad6aa4a5328ffade72a2232f95e93357452be4",
-      "resolution": {
-        "resolution": "@types/three@npm:0.180.0",
-        "version": "0.180.0",
-        "dependencies": {
-          "@dimforge/rapier3d-compat": "~0.12.0",
-          "@tweenjs/tween.js": "~23.1.3",
-          "@types/stats.js": "*",
-          "@types/webxr": "*",
-          "@webgpu/types": "*",
-          "fflate": "~0.8.2",
-          "meshoptimizer": "~0.22.0"
-        }
-      }
-    },
     "@types/treeify@npm:^1.0.0": {
       "checksum": "94c133d81b258b3a2e07054ddeaf6946220bc1f93fba984df78103847949f61590e1b4ec6535fa3ac57af258142f27c4ca9494caf10c1db3f49976284ecffbf8",
       "resolution": {
@@ -7737,7 +6259,7 @@
         "version": "2.0.7"
       }
     },
-    "@types/unist@npm:*, @types/unist@npm:^3.0.0, @types/unist@npm:^3.0.3": {
+    "@types/unist@npm:*, @types/unist@npm:^3.0.0": {
       "checksum": "13ec1f028f8b95de75d46e02d84700249cd4463fbccd7dd6f7b1f05da2863c012b0a0d9e910c12269b50139a95add75b7cfceb7333a76d044bc78a9af77f7182",
       "resolution": {
         "resolution": "@types/unist@npm:3.0.3",
@@ -7763,13 +6285,6 @@
       "resolution": {
         "resolution": "@types/uuid@npm:8.3.4",
         "version": "8.3.4"
-      }
-    },
-    "@types/webxr@npm:*": {
-      "checksum": "604382b57d74898d513a79673bea560733c80e5645c7cc1ccc15f9925919cc0e4b13ba621815ae2ddb48a9075684d3482b8df7a045628ba5aac797c83cf07e28",
-      "resolution": {
-        "resolution": "@types/webxr@npm:0.5.24",
-        "version": "0.5.24"
       }
     },
     "@types/yargs@npm:^17.0.8": {
@@ -7980,13 +6495,6 @@
         ]
       }
     },
-    "@vercel/oidc@npm:^3.0.1": {
-      "checksum": "d14e0a004be95e2e8755d49ff56e34093734fef3641e580b5cf74acaff1ac3a09ca76a126fae508f8dccc8e599c411fa2edfd44b802d5a00c7a16b3b8ddcf35e",
-      "resolution": {
-        "resolution": "@vercel/oidc@npm:3.0.1",
-        "version": "3.0.1"
-      }
-    },
     "@vitejs/plugin-react@npm:^5.1.0, @vitejs/plugin-react@npm:^5.2.0": {
       "checksum": "9bc95a013cf42fa61b5d69fd8c70afa35715bbdb62b4a04ebf87b20c00c41867e088c257f73bbfbc2593d3b9d5e798684740f054d44051189e14459b9613fbaf",
       "resolution": {
@@ -8003,13 +6511,6 @@
         "peerDependencies": {
           "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
         }
-      }
-    },
-    "@webgpu/types@npm:*": {
-      "checksum": "cb1bb228540b7711e6db60538081fa0aaf3b068f3b4417c0a1d064da226a550f4872a189b927b7e82e544b496698daf4d98f8762dcfd3c82420d7c18f15a7260",
-      "resolution": {
-        "resolution": "@webgpu/types@npm:0.1.65",
-        "version": "0.1.65"
       }
     },
     "@xterm/addon-fit@npm:^0.11.0": {
@@ -8031,70 +6532,6 @@
       "resolution": {
         "resolution": "@xterm/xterm@npm:6.0.0",
         "version": "6.0.0"
-      }
-    },
-    "@yarnpkg/builder@npm:^4.2.2": {
-      "checksum": "3dca4ad2b32252b35ddf066ac0d4ec12a55e0dd30930f453f0585a3b937f7916eefb1deca2731da9f3b26c092244bed74867e6ce8806889f931fe2670a1b0cb9",
-      "resolution": {
-        "resolution": "@yarnpkg/builder@npm:4.2.3",
-        "version": "4.2.3",
-        "dependencies": {
-          "@yarnpkg/cli": "^4.10.0",
-          "@yarnpkg/core": "^4.4.4",
-          "@yarnpkg/fslib": "^3.1.3",
-          "chalk": "^4.1.2",
-          "clipanion": "^4.0.0-rc.2",
-          "esbuild": "npm:esbuild-wasm@^0.23.0",
-          "semver": "^7.1.2",
-          "tslib": "^2.4.0"
-        }
-      }
-    },
-    "@yarnpkg/cli@npm:^4.10.0, @yarnpkg/cli@npm:^4.9.2": {
-      "checksum": "485d3f8b60b95393c74351c0e5bf6a92db141b75ba4ad02f7f4fb8915ccca5b86bd238bd53214a1f101bb0a985691ba9d68a43f14264a6d889e3ae9e8f3bd95e",
-      "resolution": {
-        "resolution": "@yarnpkg/cli@npm:4.10.3",
-        "version": "4.10.3",
-        "dependencies": {
-          "@yarnpkg/core": "^4.4.4",
-          "@yarnpkg/fslib": "^3.1.3",
-          "@yarnpkg/libzip": "^3.2.2",
-          "@yarnpkg/parsers": "^3.0.3",
-          "@yarnpkg/plugin-catalog": "^1.0.1",
-          "@yarnpkg/plugin-compat": "^4.0.12",
-          "@yarnpkg/plugin-constraints": "^4.0.5",
-          "@yarnpkg/plugin-dlx": "^4.0.2",
-          "@yarnpkg/plugin-essentials": "^4.4.4",
-          "@yarnpkg/plugin-exec": "^3.0.2",
-          "@yarnpkg/plugin-file": "^3.0.2",
-          "@yarnpkg/plugin-git": "^3.1.3",
-          "@yarnpkg/plugin-github": "^3.0.2",
-          "@yarnpkg/plugin-http": "^3.0.3",
-          "@yarnpkg/plugin-init": "^4.1.2",
-          "@yarnpkg/plugin-interactive-tools": "^4.0.3",
-          "@yarnpkg/plugin-jsr": "^1.1.1",
-          "@yarnpkg/plugin-link": "^3.0.2",
-          "@yarnpkg/plugin-nm": "^4.0.8",
-          "@yarnpkg/plugin-npm": "^3.3.2",
-          "@yarnpkg/plugin-npm-cli": "^4.3.1",
-          "@yarnpkg/plugin-pack": "^4.0.4",
-          "@yarnpkg/plugin-patch": "^4.0.3",
-          "@yarnpkg/plugin-pnp": "^4.1.2",
-          "@yarnpkg/plugin-pnpm": "^2.1.2",
-          "@yarnpkg/plugin-stage": "^4.0.2",
-          "@yarnpkg/plugin-typescript": "^4.1.3",
-          "@yarnpkg/plugin-version": "^4.2.0",
-          "@yarnpkg/plugin-workspace-tools": "^4.1.6",
-          "@yarnpkg/shell": "^4.1.3",
-          "ci-info": "^4.0.0",
-          "clipanion": "^4.0.0-rc.2",
-          "semver": "^7.1.2",
-          "tslib": "^2.4.0",
-          "typanion": "^3.14.0"
-        },
-        "peerDependencies": {
-          "@yarnpkg/core": "^4.4.4"
-        }
       }
     },
     "@yarnpkg/cli@npm:^4.12.0": {
@@ -8144,7 +6581,7 @@
         }
       }
     },
-    "@yarnpkg/core@npm:^4.4.2, @yarnpkg/core@npm:^4.4.3, @yarnpkg/core@npm:^4.4.4": {
+    "@yarnpkg/core@npm:^4.4.2": {
       "checksum": "0dadb333f855ca9f6351b9479e40392135f506d17827e75fe88f647ce69918b3942086282638824898b11e8810124a206ecdd509b65206a96951516fdf6d5278",
       "resolution": {
         "resolution": "@yarnpkg/core@npm:4.4.4",
@@ -8393,21 +6830,6 @@
         }
       }
     },
-    "@yarnpkg/plugin-catalog@npm:^1.0.1": {
-      "checksum": "4dca03c6a2a1e1781f487109787e4cc7e9869cdd968f6494182a0f737590bdb747e5db27aa17a3328737324c41baf6868da9ad2bc5ce3686d59fd9ec66a0fe6e",
-      "resolution": {
-        "resolution": "@yarnpkg/plugin-catalog@npm:1.0.1",
-        "version": "1.0.1",
-        "dependencies": {
-          "@yarnpkg/fslib": "^3.1.3",
-          "tslib": "^2.4.0"
-        },
-        "peerDependencies": {
-          "@yarnpkg/core": "^4.4.4",
-          "@yarnpkg/plugin-pack": "^4.0.4"
-        }
-      }
-    },
     "@yarnpkg/plugin-catalog@npm:^1.0.2": {
       "checksum": "cc06eb35564dac327c6eb68a400c47f5eeccae49296e16bf16669ad5a78e179884b7a1185d5bbc4fb9b4243139106c7d30c7a6270bb9a45018646aa6004aa304",
       "resolution": {
@@ -8521,25 +6943,6 @@
         },
         "peerDependencies": {
           "@yarnpkg/core": "^4.4.2"
-        }
-      }
-    },
-    "@yarnpkg/plugin-git@npm:^3.1.3": {
-      "checksum": "9db56a43ccf9dc59d8ac4c7f9c0973ec17a04cc59607aa88fa12f9cc1c7a29ae723b47e9092abfdf33924d3a68aad5aeee9e698711ee9856df4d75690377a628",
-      "resolution": {
-        "resolution": "@yarnpkg/plugin-git@npm:3.1.3",
-        "version": "3.1.3",
-        "dependencies": {
-          "@types/semver": "^7.1.0",
-          "@yarnpkg/fslib": "^3.1.2",
-          "clipanion": "^4.0.0-rc.2",
-          "es-toolkit": "^1.39.7",
-          "git-url-parse": "^13.1.0",
-          "semver": "^7.1.2",
-          "tslib": "^2.4.0"
-        },
-        "peerDependencies": {
-          "@yarnpkg/core": "^4.4.3"
         }
       }
     },
@@ -8679,27 +7082,6 @@
         }
       }
     },
-    "@yarnpkg/plugin-npm@npm:^3.3.2": {
-      "checksum": "d4411edb4a629bca0ad589271c7d46f6fd8ede68f7ba8ff3526cbc9948d247eb588ac542d6dab74dc98bdf7908d2ba6311c0b7d4f0784131ee0ce414e5f95b69",
-      "resolution": {
-        "resolution": "@yarnpkg/plugin-npm@npm:3.3.2",
-        "version": "3.3.2",
-        "dependencies": {
-          "@yarnpkg/fslib": "^3.1.3",
-          "enquirer": "^2.3.6",
-          "es-toolkit": "^1.39.7",
-          "micromatch": "^4.0.2",
-          "semver": "^7.1.2",
-          "sigstore": "^3.1.0",
-          "ssri": "^12.0.0",
-          "tslib": "^2.4.0"
-        },
-        "peerDependencies": {
-          "@yarnpkg/core": "^4.4.4",
-          "@yarnpkg/plugin-pack": "^4.0.4"
-        }
-      }
-    },
     "@yarnpkg/plugin-npm@npm:^3.4.0": {
       "checksum": "d26991a219401e8ebd9bc52a3b62c2a219adfa86a5b4285b6fe461ee00804d02ed98c65f7457e19b527da15b43377fdd89f25fc2d952085d2421e40f13072bb0",
       "resolution": {
@@ -8717,28 +7099,6 @@
         },
         "peerDependencies": {
           "@yarnpkg/core": "^4.5.0",
-          "@yarnpkg/plugin-pack": "^4.0.4"
-        }
-      }
-    },
-    "@yarnpkg/plugin-npm-cli@npm:^4.3.1": {
-      "checksum": "cd9f87213e192df372d23b5050c153f7cbd582022d4d49c7f049cac0fb102020bdccee2801dfa35a8e5727147fae8f0367f7f7d82d62c0bc1643efa2fc4dd28d",
-      "resolution": {
-        "resolution": "@yarnpkg/plugin-npm-cli@npm:4.3.1",
-        "version": "4.3.1",
-        "dependencies": {
-          "@yarnpkg/fslib": "^3.1.3",
-          "clipanion": "^4.0.0-rc.2",
-          "enquirer": "^2.3.6",
-          "micromatch": "^4.0.2",
-          "semver": "^7.1.2",
-          "tslib": "^2.4.0",
-          "typanion": "^3.14.0"
-        },
-        "peerDependencies": {
-          "@yarnpkg/cli": "^4.10.3",
-          "@yarnpkg/core": "^4.4.4",
-          "@yarnpkg/plugin-npm": "^3.3.2",
           "@yarnpkg/plugin-pack": "^4.0.4"
         }
       }
@@ -8958,37 +7318,6 @@
         }
       }
     },
-    "@yarnpkg/pnpify@npm:^4.1.5": {
-      "checksum": "6a60a2a80d7517c94756fd488643e8a8a4878656adfe28abec63f998b9219ed8e4c0105cfe376e091e83c9b1c210c1d0225b14efcfd3c978c99f553783fbde11",
-      "resolution": {
-        "resolution": "@yarnpkg/pnpify@npm:4.1.6",
-        "version": "4.1.6",
-        "dependencies": {
-          "@yarnpkg/core": "^4.4.4",
-          "@yarnpkg/fslib": "^3.1.3",
-          "@yarnpkg/nm": "^4.0.7",
-          "clipanion": "^4.0.0-rc.2",
-          "tslib": "^2.4.0"
-        }
-      }
-    },
-    "@yarnpkg/sdks@npm:^3.2.2": {
-      "checksum": "5c2c390c919c3135a3e8194ecc67e4452aed6d6256e813818578b3e9624b97cbf173fbeba39176e11d7f3c4bbe829246814edf88a0db2226c3bc32fbfb961df5",
-      "resolution": {
-        "resolution": "@yarnpkg/sdks@npm:3.2.3",
-        "version": "3.2.3",
-        "dependencies": {
-          "@yarnpkg/core": "^4.4.3",
-          "@yarnpkg/fslib": "^3.1.2",
-          "@yarnpkg/parsers": "^3.0.3",
-          "chalk": "^4.1.2",
-          "clipanion": "^4.0.0-rc.2",
-          "comment-json": "^2.2.0",
-          "es-toolkit": "^1.39.7",
-          "tslib": "^2.4.0"
-        }
-      }
-    },
     "@yarnpkg/shell@npm:^4.1.3": {
       "checksum": "623cbae0157a8d6ecab50316d7eefb828f2688b9ffbb4118874f635ad24ef933513340094bcad7fb41109adaf88cd79e05934d58aede4107823583385a2c69c1",
       "resolution": {
@@ -9028,28 +7357,14 @@
         }
       }
     },
-    "abbrev@npm:1": {
-      "checksum": "2f95c192a368ece8395b09fb30f4ceab24b09eed0510646b971b5d9bf60ae08920150da0a86436f88f9bde12c600e703568576b955cfc11e6ad93a53edcf4ee6",
-      "resolution": {
-        "resolution": "abbrev@npm:1.1.1",
-        "version": "1.1.1"
-      }
-    },
-    "abbrev@npm:^3.0.0": {
-      "checksum": "b3b569df011935e9c2a1ffc49656313de46fdb61ddf35d59acb0ccf5a5fdb026f5a750d4fc4e952ccd2ef758ca8ef5598b0f14aa885f9d78c9fdd62b97d17567",
-      "resolution": {
-        "resolution": "abbrev@npm:3.0.1",
-        "version": "3.0.1"
-      }
-    },
-    "acorn@npm:^8.0.0, acorn@npm:^8.15.0": {
+    "acorn@npm:^8.15.0": {
       "checksum": "ed7053eb83a8c131ffce1abb573ca45431ceb5ec684cedc7ef44523475157b8d96edd0a69d198ff8dbbbb9cbbd38c0d0584c77f553f6ad7b1cc62a825cd7f937",
       "resolution": {
         "resolution": "acorn@npm:8.15.0",
         "version": "8.15.0"
       }
     },
-    "acorn-jsx@npm:^5.0.0, acorn-jsx@npm:^5.3.2": {
+    "acorn-jsx@npm:^5.3.2": {
       "checksum": "ebba6a41453b945da2e281b54f2a3deaf91298c4443b6f30f125f845eba7c8dd1e4a34738313c909708a67580b1aa140143db1ed3bb88f8fc8fdc18f134b3cf3",
       "resolution": {
         "resolution": "acorn-jsx@npm:5.3.2",
@@ -9064,22 +7379,6 @@
       "resolution": {
         "resolution": "agent-base@npm:7.1.4",
         "version": "7.1.4"
-      }
-    },
-    "ai@npm:5.0.60, ai@npm:^5.0.30": {
-      "checksum": "bef7f847aa374bfc8735d2b428537638c2f592280fc8e19c5b430b9e0b42888258a0787c6e27b4d1e18ee016f1cab9a31b5c4f3560a991bf98be1db7a7422c0f",
-      "resolution": {
-        "resolution": "ai@npm:5.0.60",
-        "version": "5.0.60",
-        "dependencies": {
-          "@ai-sdk/gateway": "1.0.33",
-          "@ai-sdk/provider": "2.0.0",
-          "@ai-sdk/provider-utils": "3.0.10",
-          "@opentelemetry/api": "1.9.0"
-        },
-        "peerDependencies": {
-          "zod": "^3.25.76 || ^4.1.8"
-        }
       }
     },
     "ajv@npm:^6.12.4": {
@@ -9119,29 +7418,6 @@
         }
       }
     },
-    "algoliasearch@npm:^5.14.2, algoliasearch@npm:^5.28.0, algoliasearch@npm:^5.37.0": {
-      "checksum": "cc8d273b23495e08c1061a256c5389caae145232a7c4c8f24a4b7854ea847a7efac7d53a30fa98567bfd2d3dd2b9956b349889f4fadba03772e8a803159e9d3e",
-      "resolution": {
-        "resolution": "algoliasearch@npm:5.39.0",
-        "version": "5.39.0",
-        "dependencies": {
-          "@algolia/abtesting": "1.5.0",
-          "@algolia/client-abtesting": "5.39.0",
-          "@algolia/client-analytics": "5.39.0",
-          "@algolia/client-common": "5.39.0",
-          "@algolia/client-insights": "5.39.0",
-          "@algolia/client-personalization": "5.39.0",
-          "@algolia/client-query-suggestions": "5.39.0",
-          "@algolia/client-search": "5.39.0",
-          "@algolia/ingestion": "1.39.0",
-          "@algolia/monitoring": "1.39.0",
-          "@algolia/recommend": "5.39.0",
-          "@algolia/requester-browser-xhr": "5.39.0",
-          "@algolia/requester-fetch": "5.39.0",
-          "@algolia/requester-node-http": "5.39.0"
-        }
-      }
-    },
     "algoliasearch@npm:^5.52.0": {
       "checksum": "7dc8da04c2cfa73717bff1c4fa2f1172faf98dee6f2f23070c301d304921c21401232e40a82444c7693b2f37a7a794ee1d94001410e5f8e619ab43430b0e9ca5",
       "resolution": {
@@ -9162,19 +7438,6 @@
           "@algolia/requester-browser-xhr": "5.52.1",
           "@algolia/requester-fetch": "5.52.1",
           "@algolia/requester-node-http": "5.52.1"
-        }
-      }
-    },
-    "algoliasearch-helper@npm:3.26.0": {
-      "checksum": "09d2fe196dbd394b55ab71bf91bf8a0e98672f292eb90de54c43c66134ecf54c858104557acb6f5d3080c7a30790a84f3c1f326dfe1a78744d7a0c4075d30d35",
-      "resolution": {
-        "resolution": "algoliasearch-helper@npm:3.26.0",
-        "version": "3.26.0",
-        "dependencies": {
-          "@algolia/events": "^4.0.1"
-        },
-        "peerDependencies": {
-          "algoliasearch": ">= 3.1 < 6"
         }
       }
     },
@@ -9422,88 +7685,6 @@
         "version": "2.0.0"
       }
     },
-    "astring@npm:^1.8.0": {
-      "checksum": "fa144178849d933dac115d44a5aaead947b31b503b66a32af785a2823bd5a98ea96a4b13db7c1949840ff948602d0eb8b156498c6421a9dd39e44dd6d042a01e",
-      "resolution": {
-        "resolution": "astring@npm:1.9.0",
-        "version": "1.9.0"
-      }
-    },
-    "astro@npm:^5.6.1": {
-      "checksum": "d00de70e81c93dec9bdc800fb69ad6e6aeadee121ce711d35d24542066047a4a4ca5c8b4d8e5558bd756259cae9984741f9cc3270b7800ec3314c3854e99fca6",
-      "resolution": {
-        "resolution": "astro@npm:5.14.1",
-        "version": "5.14.1",
-        "dependencies": {
-          "@astrojs/compiler": "^2.12.2",
-          "@astrojs/internal-helpers": "0.7.3",
-          "@astrojs/markdown-remark": "6.3.7",
-          "@astrojs/telemetry": "3.3.0",
-          "@capsizecss/unpack": "^2.4.0",
-          "@oslojs/encoding": "^1.1.0",
-          "@rollup/pluginutils": "^5.2.0",
-          "acorn": "^8.15.0",
-          "aria-query": "^5.3.2",
-          "axobject-query": "^4.1.0",
-          "boxen": "8.0.1",
-          "ci-info": "^4.3.0",
-          "clsx": "^2.1.1",
-          "common-ancestor-path": "^1.0.1",
-          "cookie": "^1.0.2",
-          "cssesc": "^3.0.0",
-          "debug": "^4.4.1",
-          "deterministic-object-hash": "^2.0.2",
-          "devalue": "^5.3.2",
-          "diff": "^5.2.0",
-          "dlv": "^1.1.3",
-          "dset": "^3.1.4",
-          "es-module-lexer": "^1.7.0",
-          "esbuild": "^0.25.0",
-          "estree-walker": "^3.0.3",
-          "flattie": "^1.1.1",
-          "fontace": "~0.3.0",
-          "github-slugger": "^2.0.0",
-          "html-escaper": "3.0.3",
-          "http-cache-semantics": "^4.2.0",
-          "import-meta-resolve": "^4.2.0",
-          "js-yaml": "^4.1.0",
-          "kleur": "^4.1.5",
-          "magic-string": "^0.30.18",
-          "magicast": "^0.3.5",
-          "mrmime": "^2.0.1",
-          "neotraverse": "^0.6.18",
-          "p-limit": "^6.2.0",
-          "p-queue": "^8.1.0",
-          "package-manager-detector": "^1.3.0",
-          "picomatch": "^4.0.3",
-          "prompts": "^2.4.2",
-          "rehype": "^13.0.2",
-          "semver": "^7.7.2",
-          "sharp": "^0.34.0",
-          "shiki": "^3.12.0",
-          "smol-toml": "^1.4.2",
-          "tinyexec": "^0.3.2",
-          "tinyglobby": "^0.2.14",
-          "tsconfck": "^3.1.6",
-          "ultrahtml": "^1.6.0",
-          "unifont": "~0.5.2",
-          "unist-util-visit": "^5.0.0",
-          "unstorage": "^1.17.0",
-          "vfile": "^6.0.3",
-          "vite": "^6.3.6",
-          "vitefu": "^1.1.1",
-          "xxhash-wasm": "^1.1.0",
-          "yargs-parser": "^21.1.1",
-          "yocto-spinner": "^0.2.3",
-          "zod": "^3.25.76",
-          "zod-to-json-schema": "^3.24.6",
-          "zod-to-ts": "^1.2.0"
-        },
-        "optionalDependencies": [
-          "sharp"
-        ]
-      }
-    },
     "astro@npm:^5.9.3": {
       "checksum": "8336c33a2103f600fe3ae28db5124b9904476357ff90889e34bde6a23835d73668524c394ab093390e9df34d3692727f6d3885b3ad3d4a8060e483436801659c",
       "resolution": {
@@ -9578,19 +7759,6 @@
         "optionalDependencies": [
           "sharp"
         ]
-      }
-    },
-    "astro-expressive-code@npm:^0.41.1": {
-      "checksum": "59c065f58d9acd43ffc1e266a66ac10b0c2c4fd535f16be7ff46328b74c52943afc868021ad99dc0b26536f1e8cf0bf853ddacb5d1efeeb3014ba584081d40ee",
-      "resolution": {
-        "resolution": "astro-expressive-code@npm:0.41.3",
-        "version": "0.41.3",
-        "dependencies": {
-          "rehype-expressive-code": "^0.41.3"
-        },
-        "peerDependencies": {
-          "astro": "^4.0.0-beta || ^5.0.0-beta || ^3.3.0"
-        }
       }
     },
     "async-function@npm:^1.0.0": {
@@ -9680,16 +7848,6 @@
           "@babel/types": "^7.3.3",
           "@types/babel__core": "^7.1.14",
           "@types/babel__traverse": "^7.0.6"
-        }
-      }
-    },
-    "babel-plugin-transform-hook-names@npm:^1.0.2": {
-      "checksum": "9c58d1bf57a891df9f2e4b02e929e84d303809ca58b4a4061e11d08f9b80dffb6ee4cadd19ec07c4e87be939a268e8330c9e89625dfabc23148292d909623556",
-      "resolution": {
-        "resolution": "babel-plugin-transform-hook-names@npm:1.0.2",
-        "version": "1.0.2",
-        "peerDependencies": {
-          "@babel/core": "^7.12.10"
         }
       }
     },
@@ -9827,7 +7985,7 @@
         "version": "1.0.0"
       }
     },
-    "base64-js@npm:^1.1.2, base64-js@npm:^1.3.0, base64-js@npm:^1.3.1": {
+    "base64-js@npm:^1.3.1": {
       "checksum": "cff56707633ee705eb85a56ca2e1b60a16e974b446dd54c002f0ad2b4ca1533c85501c1b25f676723c0a0114db74f7d6d9db25c9a294e31020e1ca614975776f",
       "resolution": {
         "resolution": "base64-js@npm:1.5.1",
@@ -9846,25 +8004,6 @@
       "resolution": {
         "resolution": "basic-ftp@npm:5.3.1",
         "version": "5.3.1"
-      }
-    },
-    "bcp-47@npm:^2.1.0": {
-      "checksum": "de01f014e73e68b967569450f6c3dfd58ed3a6ef513a7ab0cdc20abd684ec5a8897600ffaecee755711200ccab31a0a8062919b0b521d095fa3447f8026378c1",
-      "resolution": {
-        "resolution": "bcp-47@npm:2.1.0",
-        "version": "2.1.0",
-        "dependencies": {
-          "is-alphabetical": "^2.0.0",
-          "is-alphanumerical": "^2.0.0",
-          "is-decimal": "^2.0.0"
-        }
-      }
-    },
-    "bcp-47-match@npm:^2.0.0": {
-      "checksum": "2d4e8f52940819b5c2fe86d9cc985e295e89c71867b6451ed4b60761fe01df3bcce859337f41c63c2e9cd74f51b48a9462f70c978bdf5713806bcfa12db1b03a",
-      "resolution": {
-        "resolution": "bcp-47-match@npm:2.0.3",
-        "version": "2.0.3"
       }
     },
     "before-after-hook@npm:^4.0.0": {
@@ -9895,13 +8034,6 @@
           "inherits": "^2.0.4",
           "readable-stream": "^3.4.0"
         }
-      }
-    },
-    "blob-to-buffer@npm:^1.2.8": {
-      "checksum": "f5080dbfd8d6ffe2508fbc51473ddc340f3908ecc419b7a4febfe0ccd07dde3b07dc287d9943732602e7aea0fd016c1ffeeec7b3704e8c1d5142cce86d96e99a",
-      "resolution": {
-        "resolution": "blob-to-buffer@npm:1.2.9",
-        "version": "1.2.9"
       }
     },
     "boolbase@npm:^1.0.0": {
@@ -9963,16 +8095,6 @@
         "version": "3.0.3",
         "dependencies": {
           "fill-range": "^7.1.1"
-        }
-      }
-    },
-    "brotli@npm:^1.3.2": {
-      "checksum": "3d71ee0e808d7ace6b2200339274cad948fa211ee1894db0c0e1194c68b7a120bbd9e262f346f741799f4b2631b438f685e17ddc2ee69ed1c0d9bef7c0b98e94",
-      "resolution": {
-        "resolution": "brotli@npm:1.3.3",
-        "version": "1.3.3",
-        "dependencies": {
-          "base64-js": "^1.1.2"
         }
       }
     },
@@ -10251,16 +8373,6 @@
         "version": "0.0.2"
       }
     },
-    "chokidar@npm:^4.0.3": {
-      "checksum": "c81fe4bdbc640d679f6d75a13af28368a995ca29cdddc9bb4a26ce8092603a6e1780f16ec477b0814c1d44da8e6600d0d96a1f73dc47fd62ba3ba195b891c560",
-      "resolution": {
-        "resolution": "chokidar@npm:4.0.3",
-        "version": "4.0.3",
-        "dependencies": {
-          "readdirp": "^4.0.1"
-        }
-      }
-    },
     "chokidar@npm:^5.0.0": {
       "checksum": "e87bb328aa9247216a0477d37fa57eed6063df62ef8250940ad85f0f893fdca29bbf03a71d0bcc355a01fc1e3c202c99bce5b15a58e111af1bd2ff59bd3f3fab",
       "resolution": {
@@ -10271,7 +8383,7 @@
         }
       }
     },
-    "chownr@npm:^1.0.1, chownr@npm:^1.1.1": {
+    "chownr@npm:^1.0.1": {
       "checksum": "b36f18706e8079af4abde5028dde3c499a6f5d5053e310e5e908df965f07f51c24e9289f5300902e3cd3323963a2ee257cc863363eabf923b67182bfd3d956c5",
       "resolution": {
         "resolution": "chownr@npm:1.1.4",
@@ -10320,7 +8432,7 @@
         "version": "3.9.0"
       }
     },
-    "ci-info@npm:^4.0.0, ci-info@npm:^4.2.0, ci-info@npm:^4.3.0": {
+    "ci-info@npm:^4.0.0, ci-info@npm:^4.2.0": {
       "checksum": "015531e1df759a132bc15431d46d67764a29ea5ea47cb7ef173e462096f476cbfe7e9ef1af91e8c346ba3ab96b8c389dd146373ab241f62f5d50d07e03a8b1ac",
       "resolution": {
         "resolution": "ci-info@npm:4.3.1",
@@ -10401,13 +8513,6 @@
         }
       }
     },
-    "clone@npm:^2.1.2": {
-      "checksum": "451bd0decfe2d9e2ed3031c1041362f7398a89c7ea4980328aa48bec035aa188fd8120711b0dd13b87da6f193ca6d9ddac19d2a5aae4927bcf6dfe04c6443ddc",
-      "resolution": {
-        "resolution": "clone@npm:2.1.2",
-        "version": "2.1.2"
-      }
-    },
     "clone-response@npm:^1.0.2": {
       "checksum": "02d02b2283a6fc56534bf457c36a9dac20c8d7fdeae931782ee82d3ae3e7c673d1015f57f4b5beb716b55df358cd720382683ddd1e5d2dd520c3121a956ffe35",
       "resolution": {
@@ -10449,29 +8554,11 @@
         }
       }
     },
-    "collapse-white-space@npm:^2.0.0": {
-      "checksum": "08546f14df3d09a0def43552d3d42a77c47d86dbdd43a34adfd58d5d244884e91a5d241bb7b5762f3909b38729fbefb194503651dcc6d1a727526f09c6282f65",
-      "resolution": {
-        "resolution": "collapse-white-space@npm:2.1.0",
-        "version": "2.1.0"
-      }
-    },
     "collect-v8-coverage@npm:^1.0.0": {
       "checksum": "7a284d295e43e6f20d58dac31f6c103b1d226e25a91857551efc1693119f86f767760c4246db688c7e23a9293746fb50283b7befccf6c3da864437efda1380ba",
       "resolution": {
         "resolution": "collect-v8-coverage@npm:1.0.3",
         "version": "1.0.3"
-      }
-    },
-    "color@npm:^4.2.3": {
-      "checksum": "881fa0c39c9a0fc2f5a5eec54a5d96a6f277cb18805fdaf82421f605b29805a84853e2879593354a92a5008a4f9a1ddd21e0d8ac1f3a32dc415eb60d158ff3bc",
-      "resolution": {
-        "resolution": "color@npm:4.2.3",
-        "version": "4.2.3",
-        "dependencies": {
-          "color-convert": "^2.0.1",
-          "color-string": "^1.9.0"
-        }
       }
     },
     "color-convert@npm:^2.0.1": {
@@ -10484,22 +8571,11 @@
         }
       }
     },
-    "color-name@npm:^1.0.0, color-name@npm:~1.1.4": {
+    "color-name@npm:~1.1.4": {
       "checksum": "7f35baf37f5327ef54032a5b4b25644e3ee747203ae77de7d0e48a73104a1c7e576f04dd5a669f4b1f4ad587e6525f9822a3f21ae78de0049e002e1c9cce2b00",
       "resolution": {
         "resolution": "color-name@npm:1.1.4",
         "version": "1.1.4"
-      }
-    },
-    "color-string@npm:^1.9.0": {
-      "checksum": "5fbed560ca5fdca4985d6ce69bbac85115b26cc0e75d35e85e57cc2eb886696a067c6948386e902d97d76e1b0700d93a0aab6402f1b989d6d82c36018e2b2922",
-      "resolution": {
-        "resolution": "color-string@npm:1.9.1",
-        "version": "1.9.1",
-        "dependencies": {
-          "color-name": "^1.0.0",
-          "simple-swizzle": "^0.2.2"
-        }
       }
     },
     "comma-separated-tokens@npm:^2.0.0": {
@@ -10537,19 +8613,6 @@
         "version": "8.3.0"
       }
     },
-    "comment-json@npm:^2.2.0": {
-      "checksum": "830ad7b422982257af7ac4258b4ef471b1aa81f0d3d43e4c00f397594fe62cd045b80d0b8b128a7230ea31cf11165729bfaa0cedb4027f702dcbb250aecfa184",
-      "resolution": {
-        "resolution": "comment-json@npm:2.4.2",
-        "version": "2.4.2",
-        "dependencies": {
-          "core-util-is": "^1.0.2",
-          "esprima": "^4.0.1",
-          "has-own-prop": "^2.0.0",
-          "repeat-string": "^1.6.1"
-        }
-      }
-    },
     "common-ancestor-path@npm:^1.0.1": {
       "checksum": "db3bf77fbcd11f01896bc4aad870fc5a51ed95f4e896a10c7e5f160528d539300222212f006d299c0b34a5cead2a1cc646a299fe0bf4c1a08978bd9f332b0822",
       "resolution": {
@@ -10578,25 +8641,11 @@
         "version": "1.0.2"
       }
     },
-    "cookie@npm:^1.0.2": {
-      "checksum": "efbbbeb73e99ea3986cb000d85d4f6762c635a195e26b45fde97b01544d52aacd1a656375482c5f55b425720e7dcfc563e45d755e153368776d9ee53f7a408d0",
-      "resolution": {
-        "resolution": "cookie@npm:1.0.2",
-        "version": "1.0.2"
-      }
-    },
     "cookie@npm:^1.1.1": {
       "checksum": "529f4f30597138fbe882943e1d40a91d01202da52921359f3447e5040d2c6f1a2d2ecf64764a5ae1d03d8f4084b2299c8b3c346778d5f9651627a43cea0599e8",
       "resolution": {
         "resolution": "cookie@npm:1.1.1",
         "version": "1.1.1"
-      }
-    },
-    "cookie-es@npm:^1.2.2": {
-      "checksum": "6be66f1a51e99c36d5b9fb789b2307c64e9939302f22e35732acf9a3f43cc29ea48517a0eef7b3f112cf28d3dd347789e5bd66d57567f1ef7f6b2c686ae11e83",
-      "resolution": {
-        "resolution": "cookie-es@npm:1.2.2",
-        "version": "1.2.2"
       }
     },
     "cookie-es@npm:^1.2.3": {
@@ -10613,7 +8662,7 @@
         "version": "3.1.1"
       }
     },
-    "core-util-is@npm:^1.0.2, core-util-is@npm:~1.0.0": {
+    "core-util-is@npm:~1.0.0": {
       "checksum": "7e8480334bd3d9c42bb05f468f1013fd66231cfd2625f971b0c0e90d001d14c3a9308a8a7230c0971c9ce257c4afafe04f9ef7ac7a55e1517cc3d3928f508b91",
       "resolution": {
         "resolution": "core-util-is@npm:1.0.3",
@@ -10638,25 +8687,6 @@
         "dependencies": {
           "layout-base": "^2.0.0"
         }
-      }
-    },
-    "cosmiconfig@npm:^8.1.3": {
-      "checksum": "c4d1dc231731e803a6822a1f4651ddb34aec4d35e241b5c373349f2b3e617fd2b9b426e978edd47a88351fb147452d7fa356c542857ac683cc403b779eb2b483",
-      "resolution": {
-        "resolution": "cosmiconfig@npm:8.3.6",
-        "version": "8.3.6",
-        "dependencies": {
-          "import-fresh": "^3.3.0",
-          "js-yaml": "^4.1.0",
-          "parse-json": "^5.2.0",
-          "path-type": "^4.0.0"
-        },
-        "peerDependencies": {
-          "typescript": ">=4.9.5"
-        },
-        "optionalPeerDependencies": [
-          "typescript"
-        ]
       }
     },
     "cosmiconfig@npm:^9.0.0": {
@@ -10691,16 +8721,6 @@
           "jest-config": "^29.7.0",
           "jest-util": "^29.7.0",
           "prompts": "^2.0.1"
-        }
-      }
-    },
-    "cross-fetch@npm:^3.0.4": {
-      "checksum": "762e98abaca731ba61e16ed24c77348b6673213275f8aac0128c17486c1121c564e0933ffc6fe1cd52160c1e6e7018ee567323371af8b942ecf2af891b429ab7",
-      "resolution": {
-        "resolution": "cross-fetch@npm:3.2.0",
-        "version": "3.2.0",
-        "dependencies": {
-          "node-fetch": "^2.7.0"
         }
       }
     },
@@ -10744,24 +8764,6 @@
           "domhandler": "^5.0.2",
           "domutils": "^3.0.1",
           "nth-check": "^2.0.1"
-        }
-      }
-    },
-    "css-selector-parser@npm:^3.0.0": {
-      "checksum": "076dcac66a67c9ed22719c347c744b27ba959d4c8939e1af51d47b06dae354e5183275f09c767f89afbef143c56b819d119b461172f7a4c9e2e21b42b53ba17b",
-      "resolution": {
-        "resolution": "css-selector-parser@npm:3.1.3",
-        "version": "3.1.3"
-      }
-    },
-    "css-tree@npm:^3.0.0": {
-      "checksum": "6325d47eec5174b413ad1855cd110621361fe12487c82eb762f8f7e2a7981e3b9509925a0cbeee6fd6330ab03fcd70fc1e9e3f171c1a002bd0ff14e95108d0d5",
-      "resolution": {
-        "resolution": "css-tree@npm:3.1.0",
-        "version": "3.1.0",
-        "dependencies": {
-          "mdn-data": "2.12.2",
-          "source-map-js": "^1.0.1"
         }
       }
     },
@@ -10809,13 +8811,6 @@
         "dependencies": {
           "css-tree": "~2.2.0"
         }
-      }
-    },
-    "csstype@npm:^3.0.2": {
-      "checksum": "94e163c6127729a3a0c2be7881abe86b388c8e81cec405d128a0ac7c1fd02cb741c1554649ccd7f156bd1e1a3eab1d5a0bbcc2dfc59299787eadf9c8ff1e6d8e",
-      "resolution": {
-        "resolution": "csstype@npm:3.1.3",
-        "version": "3.1.3"
       }
     },
     "csstype@npm:^3.2.2": {
@@ -10914,7 +8909,7 @@
         }
       }
     },
-    "d3-array@npm:3, d3-array@npm:^3.1.6, d3-array@npm:^3.2.0": {
+    "d3-array@npm:3, d3-array@npm:^3.2.0": {
       "checksum": "f7e171ab4ece1c931e2b8e016a0cbc8c201bf2d17cdd79a9540154f4e72c380c576e4297f299a040b7005a48783520370eb7faf24c3c24653a4ee3058ab8fbb1",
       "resolution": {
         "resolution": "d3-array@npm:3.2.4",
@@ -11077,7 +9072,7 @@
         "version": "2.0.0"
       }
     },
-    "d3-ease@npm:3, d3-ease@npm:^3.0.1": {
+    "d3-ease@npm:3": {
       "checksum": "126757b36ab5fe84158045358f474aa1dde6ab5ab2f696e0fa84ab517bdc42f7d9db5db05809184907ab01247b0bda14f4fa7ac00204ffda21b65f9fb6df9e87",
       "resolution": {
         "resolution": "d3-ease@npm:3.0.1",
@@ -11157,7 +9152,7 @@
         }
       }
     },
-    "d3-interpolate@npm:3, d3-interpolate@npm:^3.0.1": {
+    "d3-interpolate@npm:3": {
       "checksum": "858f202fe7212901d7c12d67d7b964af7d41e814718d36d31ba15ac7ddd9c7b42347852eef595ed52eaadf4318984b3bebb60b424f3fdf48912d412f2a1fcde1",
       "resolution": {
         "resolution": "d3-interpolate@npm:3.0.1",
@@ -11227,7 +9222,7 @@
         }
       }
     },
-    "d3-scale@npm:4, d3-scale@npm:^4.0.2": {
+    "d3-scale@npm:4": {
       "checksum": "fa8c3aeb9274d2afd3c6d439fbd0f2d12e401da75212ae19590a3786ae37cb229266d5ec358679468915014d84627ce5268ae5b658d1706e9a985c6f2b76a20c",
       "resolution": {
         "resolution": "d3-scale@npm:4.0.2",
@@ -11266,7 +9261,7 @@
         "version": "3.0.0"
       }
     },
-    "d3-shape@npm:3, d3-shape@npm:^3.1.0": {
+    "d3-shape@npm:3": {
       "checksum": "5f93ca4c092cb79e7d0b5babe04d3137a8046216772abbf43347620b88579a1dbb0734f6c531cf107bf91d39d9b9095d9e930bee3a5509aae9da3c0731f2e497",
       "resolution": {
         "resolution": "d3-shape@npm:3.2.0",
@@ -11303,7 +9298,7 @@
         }
       }
     },
-    "d3-time@npm:3, d3-time@npm:^3.0.0": {
+    "d3-time@npm:3": {
       "checksum": "4429aa55cf8e5b05c86b67b298701659abd597da558b26d53a92dbd8b35ff26e835870365c91619f597da1ac9a57a6471030e491f584fb14f3c7c05cc1c4626d",
       "resolution": {
         "resolution": "d3-time@npm:3.1.0",
@@ -11347,7 +9342,7 @@
         "version": "2.0.0"
       }
     },
-    "d3-timer@npm:3, d3-timer@npm:^3.0.1": {
+    "d3-timer@npm:3": {
       "checksum": "5ff804395daa9afb4dd4fafa5635c46da11cd22dabe882cf728b0668a43412837abce71add4c25c11b48e4a636bf4e8cfe4c957ae650477ec5a1e88cde73532a",
       "resolution": {
         "resolution": "d3-timer@npm:3.0.1",
@@ -11456,13 +9451,6 @@
         }
       }
     },
-    "dayjs@npm:^1.11.13": {
-      "checksum": "22d89bc9cc81afd31fb26365d08f9b0823750476ed728d73e4ea34ee48a34dd44c2e71a0943fc1290376373699ff1aff0ebd60661f5c55a8f1f9cd3ccc0dd480",
-      "resolution": {
-        "resolution": "dayjs@npm:1.11.18",
-        "version": "1.11.18"
-      }
-    },
     "dayjs@npm:^1.11.19": {
       "checksum": "f9e0e78fd745085625eb9540c96e47560e8493dd9e9425cb6c2d49fc4b9fbad6d0c0b6e8e3c04a384ddb36850d4deff96f24456575ed77661f41c3024d1e508b",
       "resolution": {
@@ -11496,13 +9484,6 @@
         ]
       }
     },
-    "decimal.js-light@npm:^2.5.1": {
-      "checksum": "c53b00ae206d1612268cf37f46665e5376308531021408d3cd546f9b6e6cf71e456d6df5cf1b0a56789b93e3f8f1d8283baeec3b91d775c635e36d91350e9315",
-      "resolution": {
-        "resolution": "decimal.js-light@npm:2.5.1",
-        "version": "2.5.1"
-      }
-    },
     "decode-named-character-reference@npm:^1.0.0": {
       "checksum": "b6b48119e43a7771937cbcf5bef332dca019793e453fdd32dd6759b0c689d2d099fc21fdca68f10f684a1c96dbde705cf30db1948b4ac9f1bb85e9b9fd7709ce",
       "resolution": {
@@ -11534,26 +9515,6 @@
         "optionalPeerDependencies": [
           "babel-plugin-macros"
         ]
-      }
-    },
-    "dedent@npm:^1.7.0": {
-      "checksum": "4e6c48ca4743bc09faf68b1682b25065cff33f72d764aa2b0d0dd4e5a5e0bd7ac20c8b97d279719e83dc564230f3eba530d6756952b7ecd87640bacdb537f7e0",
-      "resolution": {
-        "resolution": "dedent@npm:1.7.0",
-        "version": "1.7.0",
-        "peerDependencies": {
-          "babel-plugin-macros": "^3.1.0"
-        },
-        "optionalPeerDependencies": [
-          "babel-plugin-macros"
-        ]
-      }
-    },
-    "deep-extend@npm:^0.6.0": {
-      "checksum": "ff5939ada8f36d067ecd42fb7278f1a6c8c4964a27b9c2b8dab1a4a38fa2b3e3d932e0af3cb8899b0818e2180317220760e24e277cb50963eb3c02b17eebda76",
-      "resolution": {
-        "resolution": "deep-extend@npm:0.6.0",
-        "version": "0.6.0"
       }
     },
     "deep-is@npm:^0.1.3": {
@@ -11601,13 +9562,6 @@
         }
       }
     },
-    "defu@npm:^6.1.4": {
-      "checksum": "4fbe0b355ef06c1df1cdfd00c64989fafc8858b4924515c1998e842afaa6415add7c4deb40f5598164920b6b44170c2d2cb268567cc71191fed2055238bfc2ab",
-      "resolution": {
-        "resolution": "defu@npm:6.1.4",
-        "version": "6.1.4"
-      }
-    },
     "defu@npm:^6.1.6": {
       "checksum": "6a8cf1249c49efd67cc4518f5e7f258776bb2ef4647f2ad2db6c98e8ffb5381bb3026137b10afa2845f50ec8a91d4c7c4e53bdfa3e2278376fc0fc19d0fe6f65",
       "resolution": {
@@ -11644,14 +9598,14 @@
         "version": "2.0.0"
       }
     },
-    "dequal@npm:^2.0.0, dequal@npm:^2.0.3": {
+    "dequal@npm:^2.0.0": {
       "checksum": "9969ad557c9ea0a7ab41f00ddca16a507f4944d6b7e2ca0fa0e63f87e16dbffdea06225c9585d3f0724d36a7f6729c45026a6a4ef25e427ec760932d12530585",
       "resolution": {
         "resolution": "dequal@npm:2.0.3",
         "version": "2.0.3"
       }
     },
-    "destr@npm:^2.0.3, destr@npm:^2.0.5": {
+    "destr@npm:^2.0.5": {
       "checksum": "952413d89566ba65fba0aeaf55ef8624045afbb3a63ddfefa198272d80ebb0996d776cf4d4b2db2d6b63338012e84dd0747cc03d82ff5bd77fb723a79d4a58ec",
       "resolution": {
         "resolution": "destr@npm:2.0.5",
@@ -11665,7 +9619,7 @@
         "version": "1.2.0"
       }
     },
-    "detect-libc@npm:^2.0.0, detect-libc@npm:^2.0.2, detect-libc@npm:^2.0.3, detect-libc@npm:^2.0.4, detect-libc@npm:^2.1.0": {
+    "detect-libc@npm:^2.0.3, detect-libc@npm:^2.0.4, detect-libc@npm:^2.1.0": {
       "checksum": "7675eb16b694743f1da5046f41fedaa328e9a22118bc00d269ac1d1b6d390c73a54fd628b6f39d221ea56ebe06874811a508dbf71cf259c2284742c2592b45d0",
       "resolution": {
         "resolution": "detect-libc@npm:2.1.2",
@@ -11687,13 +9641,6 @@
         "dependencies": {
           "base-64": "^1.0.0"
         }
-      }
-    },
-    "devalue@npm:^5.3.2": {
-      "checksum": "1ea02e7ee932c183d3df9dc4c6cf9101bfe365065dde2527eb5158c67b8873f3c92c44d5f168255c07712f6d8c782765b8064973473a58081edbe16149ec97f7",
-      "resolution": {
-        "resolution": "devalue@npm:5.3.2",
-        "version": "5.3.2"
       }
     },
     "devalue@npm:^5.6.2, devalue@npm:^5.6.4": {
@@ -11720,14 +9667,7 @@
         "version": "0.0.1608973"
       }
     },
-    "dfa@npm:^1.2.0": {
-      "checksum": "83c6c577da521d48fd8c129e6223396b5388af86c5eb6307ae31743f2348063b6f9749c586cbc335f3be43856a1e2dfa370ae5f3ce935fc54d29b740c767576f",
-      "resolution": {
-        "resolution": "dfa@npm:1.2.0",
-        "version": "1.2.0"
-      }
-    },
-    "diff@npm:^5.1.0, diff@npm:^5.2.0": {
+    "diff@npm:^5.1.0": {
       "checksum": "e8068b637846911551e41de4effd37ddfeff4048b161d9d995598d57717309b7ef81bb39adfc5c10346c4a67ac3a52038e62c61630864338ae434a1851991fd4",
       "resolution": {
         "resolution": "diff@npm:5.2.0",
@@ -11746,13 +9686,6 @@
       "resolution": {
         "resolution": "diff-sequences@npm:29.6.3",
         "version": "29.6.3"
-      }
-    },
-    "direction@npm:^2.0.0": {
-      "checksum": "fe8f4b2d921c7ae60debe3a850a327b0391a9f6b73929960ce8e5220c2ac65f03f4e48c328ec75f2e3756e3fa0c0455ae93ebd1aec8d345d1880f1f7636e83db",
-      "resolution": {
-        "resolution": "direction@npm:2.0.1",
-        "version": "2.0.1"
       }
     },
     "dlv@npm:^1.1.3": {
@@ -11801,19 +9734,6 @@
         }
       }
     },
-    "dompurify@npm:^3.2.6": {
-      "checksum": "bc6a018fec72e2dd972410401e4eae5ae62ad6ff25ada52eb5002581f2135f354b2050b850aef1e8836c46a6434723ba832c957eb4ed258de93373432c1a4960",
-      "resolution": {
-        "resolution": "dompurify@npm:3.2.7",
-        "version": "3.2.7",
-        "dependencies": {
-          "@types/trusted-types": "^2.0.7"
-        },
-        "optionalDependencies": [
-          "@types/trusted-types"
-        ]
-      }
-    },
     "dompurify@npm:^3.3.1": {
       "checksum": "7ab09966612f5f941d866a8acb780505b0f5952d81229f69eee1aab35bfc521ff3f50173ecb959713a582d6d8c734a64d3eecdcbe5c3e8377fe88b0167f32b19",
       "resolution": {
@@ -11836,17 +9756,6 @@
           "dom-serializer": "^2.0.0",
           "domelementtype": "^2.3.0",
           "domhandler": "^5.0.3"
-        }
-      }
-    },
-    "dot-case@npm:^3.0.4": {
-      "checksum": "08672155b1a8931f7d1bcefc562515c15d4cc3d46eae2add110502c8ba2fef4ab1b5bcd4621d9317843e1a0dfb21b3376e06237e843b635be9ad76accfbb83a2",
-      "resolution": {
-        "resolution": "dot-case@npm:3.0.4",
-        "version": "3.0.4",
-        "dependencies": {
-          "no-case": "^3.0.4",
-          "tslib": "^2.0.3"
         }
       }
     },
@@ -11985,7 +9894,7 @@
         }
       }
     },
-    "entities@npm:^4.2.0, entities@npm:^4.4.0": {
+    "entities@npm:^4.2.0": {
       "checksum": "fd22553339ad642e39c52c3dfc324f9fd9a01626e169682a4f0898fc21e5506972943937fdccde6cf35b6a89c25ce672b39050e803dc706a29c8886df9b28d68",
       "resolution": {
         "resolution": "entities@npm:4.5.0",
@@ -11999,7 +9908,7 @@
         "version": "6.0.1"
       }
     },
-    "env-paths@npm:^2.2.0, env-paths@npm:^2.2.1": {
+    "env-paths@npm:^2.2.1": {
       "checksum": "f1740c5cfa1f277cb8f0c9751eec990828d430a524f70f770757cfdf569257a8ffbc43e1e6a724bda5fd96680f2a19ba02a647ea69364785804960e03ded0cdd",
       "resolution": {
         "resolution": "env-paths@npm:2.2.1",
@@ -12177,7 +10086,7 @@
         }
       }
     },
-    "es-toolkit@npm:^1.39.10, es-toolkit@npm:^1.39.3, es-toolkit@npm:^1.39.7": {
+    "es-toolkit@npm:^1.39.7": {
       "checksum": "812d7d4fd45203de906ec6bb2402f13bb49eeb3d55f5ec8556ce5a61445b70d641c9b60654a3d2a0be1ccd0eed960fd810c46d07ac634751ad831d4d85573369",
       "resolution": {
         "resolution": "es-toolkit@npm:1.39.10",
@@ -12196,32 +10105,6 @@
       "resolution": {
         "resolution": "es6-promisify@npm:7.0.0",
         "version": "7.0.0"
-      }
-    },
-    "esast-util-from-estree@npm:^2.0.0": {
-      "checksum": "e65038db9b2a6e1222312a7136e3acab6fac3be3356e56fd3587776ec7017c8f4259547e2f6d5952efceb29e6943335044dc40f06553dc13fc100a5114efa93e",
-      "resolution": {
-        "resolution": "esast-util-from-estree@npm:2.0.0",
-        "version": "2.0.0",
-        "dependencies": {
-          "@types/estree-jsx": "^1.0.0",
-          "devlop": "^1.0.0",
-          "estree-util-visit": "^2.0.0",
-          "unist-util-position-from-estree": "^2.0.0"
-        }
-      }
-    },
-    "esast-util-from-js@npm:^2.0.0": {
-      "checksum": "7859e523c883c29b7666588f231939fdda6614030edfdad59d8d93802ed102d7c25fe51278b1f438599a8ee6ed88aeff94f3cafa9147b364e0747ed9d1c1cb48",
-      "resolution": {
-        "resolution": "esast-util-from-js@npm:2.0.1",
-        "version": "2.0.1",
-        "dependencies": {
-          "@types/estree-jsx": "^1.0.0",
-          "acorn": "^8.0.0",
-          "esast-util-from-estree": "^2.0.0",
-          "vfile-message": "^4.0.0"
-        }
       }
     },
     "esbuild@npm:^0.25.0": {
@@ -12632,29 +10515,6 @@
         "version": "5.3.0"
       }
     },
-    "estree-util-attach-comments@npm:^3.0.0": {
-      "checksum": "8f37a6b9ad9e1d3f099dca91b6c341a2f5035736a196296c1ac353a5f83ce0dd92003d03b178043eaa9f2d3fcab38d6fee2acde7d709781ceb9609d7fb1a6b3d",
-      "resolution": {
-        "resolution": "estree-util-attach-comments@npm:3.0.0",
-        "version": "3.0.0",
-        "dependencies": {
-          "@types/estree": "^1.0.0"
-        }
-      }
-    },
-    "estree-util-build-jsx@npm:^3.0.0": {
-      "checksum": "a5fbf7effd53e6fae5c76af4a9b0a3c41add881ac9a6983aa214792942063efd89ccb78eb4ed96d4fffed871f72b5e0c00e75fc675729038a72cbc1f12754a30",
-      "resolution": {
-        "resolution": "estree-util-build-jsx@npm:3.0.1",
-        "version": "3.0.1",
-        "dependencies": {
-          "@types/estree-jsx": "^1.0.0",
-          "devlop": "^1.0.0",
-          "estree-util-is-identifier-name": "^3.0.0",
-          "estree-walker": "^3.0.0"
-        }
-      }
-    },
     "estree-util-is-identifier-name@npm:^3.0.0": {
       "checksum": "2d661527d3e449c1b69dc8166e527d683671a05ee86adf957a8ca11333ca31f176e6d004df6ded4a89fb6ed4a158d0155a9ed86ce46d95cb0e917df89b240138",
       "resolution": {
@@ -12662,48 +10522,14 @@
         "version": "3.0.0"
       }
     },
-    "estree-util-scope@npm:^1.0.0": {
-      "checksum": "c500484fbfa1156041c914565a90a3ecc4b689ceb22569df75fdb5f17c90329295b170069596d835f415de290e94f7aefbd9dcba783e6be98f87996df85e3767",
-      "resolution": {
-        "resolution": "estree-util-scope@npm:1.0.0",
-        "version": "1.0.0",
-        "dependencies": {
-          "@types/estree": "^1.0.0",
-          "devlop": "^1.0.0"
-        }
-      }
-    },
-    "estree-util-to-js@npm:^2.0.0": {
-      "checksum": "d6292963cfa0ae3152a80a20b03b6f497c59e228c0fecb5620c1e1b8c97ce9ee2deb6247d8e77edd880fc8b0e5482f28e8abb517a3406262255c17456eee01d4",
-      "resolution": {
-        "resolution": "estree-util-to-js@npm:2.0.0",
-        "version": "2.0.0",
-        "dependencies": {
-          "@types/estree-jsx": "^1.0.0",
-          "astring": "^1.8.0",
-          "source-map": "^0.7.0"
-        }
-      }
-    },
-    "estree-util-visit@npm:^2.0.0": {
-      "checksum": "37de8fa476de8cc9b013194314b5800df0a82513e281ea98e1fc331a213150e95936e0dc1c3f19fb68f08db025ff17a966423fb457d2f997801eb0022d02606e",
-      "resolution": {
-        "resolution": "estree-util-visit@npm:2.0.0",
-        "version": "2.0.0",
-        "dependencies": {
-          "@types/estree-jsx": "^1.0.0",
-          "@types/unist": "^3.0.0"
-        }
-      }
-    },
-    "estree-walker@npm:^2.0.1, estree-walker@npm:^2.0.2": {
+    "estree-walker@npm:^2.0.2": {
       "checksum": "d4087550073f7974f6ff84d755b43f64b27175e77297aee408f7b8b4a386210a8ef24006b2663285e53b1d02cdc65e7baaadd8bde7ba1420d120b0faf46f8353",
       "resolution": {
         "resolution": "estree-walker@npm:2.0.2",
         "version": "2.0.2"
       }
     },
-    "estree-walker@npm:^3.0.0, estree-walker@npm:^3.0.3": {
+    "estree-walker@npm:^3.0.3": {
       "checksum": "0ec3bb2ac641ce25ba5fcb28972982df4bfb0689be84082fffe3f9958d1874219c596673effb0b32e5243c099c25bf499b065cd09446bcfe3b86edcbb7d52c0c",
       "resolution": {
         "resolution": "estree-walker@npm:3.0.3",
@@ -12744,13 +10570,6 @@
         }
       }
     },
-    "eventsource-parser@npm:^3.0.5": {
-      "checksum": "79db2e2d817b3217ba311f66948851998e81889bf27e6ba0bd768f299ab3f2c840071ff348618ca13356274448773c8794d027dd0294d0b23adcffb03f7faf71",
-      "resolution": {
-        "resolution": "eventsource-parser@npm:3.0.6",
-        "version": "3.0.6"
-      }
-    },
     "execa@npm:^5.0.0": {
       "checksum": "827a69b9a5704b3acb264510013757078f24915da39a41e70e931f680609fac4f829a28ced8f2fa419c138d328d3ad3faed1e2e6319eeb15471d617b7a56479e",
       "resolution": {
@@ -12776,13 +10595,6 @@
         "version": "0.1.2"
       }
     },
-    "expand-template@npm:^2.0.3": {
-      "checksum": "cdca0002aebde5c807789275e8800cb2b1277e2f77b94a189f1cd6ba12dd9548e2b6fb697cf603bfea94d505dfd82e958ef4ac93e1ff91ba34510d62ae878140",
-      "resolution": {
-        "resolution": "expand-template@npm:2.0.3",
-        "version": "2.0.3"
-      }
-    },
     "expect@npm:^29.0.0, expect@npm:^29.7.0": {
       "checksum": "c95c10839240328622f29801b8cddcb11ba87324c2711e3b8abf813eb734b00643361c82bf2bb803444376a0d27e60635547a86db8fd88b1be4b7f7679f3831f",
       "resolution": {
@@ -12794,26 +10606,6 @@
           "jest-matcher-utils": "^29.7.0",
           "jest-message-util": "^29.7.0",
           "jest-util": "^29.7.0"
-        }
-      }
-    },
-    "exponential-backoff@npm:^3.1.1": {
-      "checksum": "425580bfa44e08b46e35aca22bfe2e87c5585f4e2791956dbfdee90d1b59c472d7a5155a7201219a2d5203c148a9ac03b9fcc892395ead760d69150643d43202",
-      "resolution": {
-        "resolution": "exponential-backoff@npm:3.1.2",
-        "version": "3.1.2"
-      }
-    },
-    "expressive-code@npm:^0.41.3": {
-      "checksum": "11173166e24032c531be12edf9e2961db6c8d2dc73a2450da9c786cbcd137e88cfea2db7e6e67618dec105accc8e1ed5ddbbf899bed28650575a156ac5818cc7",
-      "resolution": {
-        "resolution": "expressive-code@npm:0.41.3",
-        "version": "0.41.3",
-        "dependencies": {
-          "@expressive-code/core": "^0.41.3",
-          "@expressive-code/plugin-frames": "^0.41.3",
-          "@expressive-code/plugin-shiki": "^0.41.3",
-          "@expressive-code/plugin-text-markers": "^0.41.3"
         }
       }
     },
@@ -12932,13 +10724,6 @@
         ]
       }
     },
-    "fflate@npm:~0.8.2": {
-      "checksum": "2b60b27dd5d7025e80f347bf49919e0eec5488f703a083baf7195eae4fb53aa52d56962a9f77db5b07b0e02b126814064fd8eb78c8847b1b37e3efe34249cd8e",
-      "resolution": {
-        "resolution": "fflate@npm:0.8.2",
-        "version": "0.8.2"
-      }
-    },
     "file-entry-cache@npm:^8.0.0": {
       "checksum": "fb095f56fa64fe42decde43ce90460c5f5a9334df66ce124341046cd0ddb57d18708a9c96742bd8999bd48b876f21e363c0b653ba9c39a194fba17b48fa63d7f",
       "resolution": {
@@ -13022,17 +10807,6 @@
         "version": "1.1.1"
       }
     },
-    "fontace@npm:~0.3.0": {
-      "checksum": "94892852b1a3da1dbc5c11bb1cc42e70d4a6b8a1aff659e2778f80064e0b12854499eed81fcd4db0bfb2c29191b092cff9daf79c5f713362ed8039cdcffb2ee9",
-      "resolution": {
-        "resolution": "fontace@npm:0.3.1",
-        "version": "0.3.1",
-        "dependencies": {
-          "@types/fontkit": "^2.0.8",
-          "fontkit": "^2.0.4"
-        }
-      }
-    },
     "fontace@npm:~0.4.0": {
       "checksum": "e5647d92e1043f56a5f767fde7b2b3d5337b158065442282bb257bb0fe8b56c860767a31b649886432a64e41c1e422c29955f52bfbcf9741eb1e1f2a619925fb",
       "resolution": {
@@ -13040,24 +10814,6 @@
         "version": "0.4.1",
         "dependencies": {
           "fontkitten": "^1.0.2"
-        }
-      }
-    },
-    "fontkit@npm:^2.0.2, fontkit@npm:^2.0.4": {
-      "checksum": "071b37c2262c2722fad4fd3412f5474be31f2d6f9e09223ae86a1abf197b7c0e5be65c70240a9176f5761b3cb0a03ea83f982019f3c9478237b74dfcee0a13e4",
-      "resolution": {
-        "resolution": "fontkit@npm:2.0.4",
-        "version": "2.0.4",
-        "dependencies": {
-          "@swc/helpers": "^0.5.12",
-          "brotli": "^1.3.2",
-          "clone": "^2.1.2",
-          "dfa": "^1.2.0",
-          "fast-deep-equal": "^3.1.3",
-          "restructure": "^3.0.0",
-          "tiny-inflate": "^1.0.3",
-          "unicode-properties": "^1.4.0",
-          "unicode-trie": "^2.0.0"
         }
       }
     },
@@ -13081,7 +10837,7 @@
         }
       }
     },
-    "foreground-child@npm:^3.1.0, foreground-child@npm:^3.3.1": {
+    "foreground-child@npm:^3.1.0": {
       "checksum": "17ee1aa2807eb9846a23866c2ba16f52d2e60eafee1b4b1274361f4881516f1c783d468d747bab1dc6e37a0deda69773c448ad769a6135742c257989dc3a47b5",
       "resolution": {
         "resolution": "foreground-child@npm:3.3.1",
@@ -13294,17 +11050,6 @@
         }
       }
     },
-    "git-up@npm:^8.1.0": {
-      "checksum": "607cae2116d5536d88355eb3e012a67950bc2d090a71d20807afb2b80d47758371bc4748b94468ed1a71a3bff9652fc09dcdc9e32d1dfc42b1be1b567e167fdb",
-      "resolution": {
-        "resolution": "git-up@npm:8.1.1",
-        "version": "8.1.1",
-        "dependencies": {
-          "is-ssh": "^1.4.0",
-          "parse-url": "^9.2.0"
-        }
-      }
-    },
     "git-url-parse@npm:^13.1.0": {
       "checksum": "658aaa92cb256524c4595c84f916db05ae1a4c6b1522a8f059c78957b7bca06232c7a9d153640da0b143e663b3e08690f362a44ef68b47108ae48b105b498654",
       "resolution": {
@@ -13313,23 +11058,6 @@
         "dependencies": {
           "git-up": "^7.0.0"
         }
-      }
-    },
-    "git-url-parse@npm:^16.1.0": {
-      "checksum": "8b7b814be81e910665cdc7e6fb1a1d04475d3f5c65d56cbdfbd82e005d67b50d1e6e894cc31d1741820a0b4d7eee7833e027cfcf1973013c9e2748064b2d01a5",
-      "resolution": {
-        "resolution": "git-url-parse@npm:16.1.0",
-        "version": "16.1.0",
-        "dependencies": {
-          "git-up": "^8.1.0"
-        }
-      }
-    },
-    "github-from-package@npm:0.0.0": {
-      "checksum": "866d603c85b80c148db55c97b3c03b4715842b8a976c8981e733bad45ea287acbfc8815f2462f90be305826cbc9b2e77a3ca53dcafbc586808cb2fa46cb3fbb9",
-      "resolution": {
-        "resolution": "github-from-package@npm:0.0.0",
-        "version": "0.0.0"
       }
     },
     "github-markdown-css@npm:^5.9.0": {
@@ -13358,21 +11086,6 @@
           "minipass": "^7.1.2",
           "package-json-from-dist": "^1.0.0",
           "path-scurry": "^1.11.1"
-        }
-      }
-    },
-    "glob@npm:^11.0.3": {
-      "checksum": "c89e969b887897bd225ae8be8b2a510a130e888499e4ece6e591206d414d56936a0a2ca9256d975fd91e698f0aa2a4df97d2cd70d0b82b9ee31319c0645e416e",
-      "resolution": {
-        "resolution": "glob@npm:11.0.3",
-        "version": "11.0.3",
-        "dependencies": {
-          "foreground-child": "^3.3.1",
-          "jackspeak": "^4.1.1",
-          "minimatch": "^10.0.3",
-          "minipass": "^7.1.2",
-          "package-json-from-dist": "^1.0.0",
-          "path-scurry": "^2.0.0"
         }
       }
     },
@@ -13489,7 +11202,7 @@
         }
       }
     },
-    "graceful-fs@npm:^4.2.10, graceful-fs@npm:^4.2.4, graceful-fs@npm:^4.2.6, graceful-fs@npm:^4.2.9": {
+    "graceful-fs@npm:^4.2.10, graceful-fs@npm:^4.2.4, graceful-fs@npm:^4.2.9": {
       "checksum": "dff3c6ff874d12e505e1fdaa5425c880e8d8e0d720cddda38a28f2bbf1c37da241603fb9d05fc6fec3ff1120f07dffbdf23127dfa654da7ef18021931b1bc12d",
       "resolution": {
         "resolution": "graceful-fs@npm:4.2.11",
@@ -13528,24 +11241,6 @@
         }
       }
     },
-    "h3@npm:^1.15.4": {
-      "checksum": "2c6741bdeaba3551c8992b65e93b32d1d12f376a28f553b2b198d4aeabe30435267ee739cdc509c642a2ae38caa6c587c466c139fb963547ecb62395183693de",
-      "resolution": {
-        "resolution": "h3@npm:1.15.4",
-        "version": "1.15.4",
-        "dependencies": {
-          "cookie-es": "^1.2.2",
-          "crossws": "^0.3.5",
-          "defu": "^6.1.4",
-          "destr": "^2.0.5",
-          "iron-webcrypto": "^1.2.1",
-          "node-mock-http": "^1.0.2",
-          "radix3": "^1.1.2",
-          "ufo": "^1.6.1",
-          "uncrypto": "^0.1.3"
-        }
-      }
-    },
     "hachure-fill@npm:^0.5.2": {
       "checksum": "8a42d3f39916d2bbf7ee1af331b174b59f1d6f0ec6c49d3368e1ffe6c5f44b00a0ffc0d998ff891ec3bfa3397dcd54b80cfc7afb60ae02a088920c7e18908d26",
       "resolution": {
@@ -13565,13 +11260,6 @@
       "resolution": {
         "resolution": "has-flag@npm:4.0.0",
         "version": "4.0.0"
-      }
-    },
-    "has-own-prop@npm:^2.0.0": {
-      "checksum": "f2272dd9bfd991cddaf80e4bbbf74016f971b59fae9fbea1c5264f00b188430dab8f0eca608761ca083a3e6ccad09b75455cfee86a7a47be4e9b15157623dca7",
-      "resolution": {
-        "resolution": "has-own-prop@npm:2.0.0",
-        "version": "2.0.0"
       }
     },
     "has-property-descriptors@npm:^1.0.0, has-property-descriptors@npm:^1.0.2": {
@@ -13621,17 +11309,6 @@
         }
       }
     },
-    "hast-util-embedded@npm:^3.0.0": {
-      "checksum": "f704dbbf869394ef96c5cc71dd9b6e5890a91756e7a6a3c540e5cf529825bd11532485ea1b4de4f84efadae11aed128e5d4e7577b952a691abb5ba2dc97c3973",
-      "resolution": {
-        "resolution": "hast-util-embedded@npm:3.0.0",
-        "version": "3.0.0",
-        "dependencies": {
-          "@types/hast": "^3.0.0",
-          "hast-util-is-element": "^3.0.0"
-        }
-      }
-    },
     "hast-util-find-and-replace@npm:^5.0.0": {
       "checksum": "37ed323e8a557c43c3307b0f8147a4b93daf1632835d0055bfb26b347446ccdc737cbaef159f5ba74c71a2236227a76f38ab2260255d3a3a2b098ff48809e919",
       "resolution": {
@@ -13645,23 +11322,7 @@
         }
       }
     },
-    "hast-util-format@npm:^1.0.0": {
-      "checksum": "cbc04d0e41b5905978e129c13acb4b8d94cf4e5f59f4f6c8704e4f92195090048851b298a3a7b5b47e4f25a9c45c8b0139fada358cd941db409bc4452b19bd38",
-      "resolution": {
-        "resolution": "hast-util-format@npm:1.1.0",
-        "version": "1.1.0",
-        "dependencies": {
-          "@types/hast": "^3.0.0",
-          "hast-util-embedded": "^3.0.0",
-          "hast-util-minify-whitespace": "^1.0.0",
-          "hast-util-phrasing": "^3.0.0",
-          "hast-util-whitespace": "^3.0.0",
-          "html-whitespace-sensitive-tag-names": "^3.0.0",
-          "unist-util-visit-parents": "^6.0.0"
-        }
-      }
-    },
-    "hast-util-from-html@npm:^2.0.0, hast-util-from-html@npm:^2.0.1, hast-util-from-html@npm:^2.0.3": {
+    "hast-util-from-html@npm:^2.0.0, hast-util-from-html@npm:^2.0.3": {
       "checksum": "ef5576f283896b05df8b03dd6c0d0634a0cb59b138b41a18766807e1f3f17ad1a701310e83826f0bd2e07d895ede643f5c8513e364649ef60ea52d741542ad39",
       "resolution": {
         "resolution": "hast-util-from-html@npm:2.0.3",
@@ -13693,26 +11354,6 @@
         }
       }
     },
-    "hast-util-has-property@npm:^3.0.0": {
-      "checksum": "8319c6ef03dd52c875be56a24c9ec82c6fbee78aa0e376c32f6665ea8c229ac17a51a158e08097943653764657ae813c756f4e8fb3a4b12ceac0259e7d6938f9",
-      "resolution": {
-        "resolution": "hast-util-has-property@npm:3.0.0",
-        "version": "3.0.0",
-        "dependencies": {
-          "@types/hast": "^3.0.0"
-        }
-      }
-    },
-    "hast-util-is-body-ok-link@npm:^3.0.0": {
-      "checksum": "b67d5fdf9725d8d09c4cab0c1e16051cd18cbfa0d8b3f629cc2517b9353011968c8058956b33fc969121eb4c17d29c7a1ada7822e18ec2bae1f5e1a078d995b1",
-      "resolution": {
-        "resolution": "hast-util-is-body-ok-link@npm:3.0.1",
-        "version": "3.0.1",
-        "dependencies": {
-          "@types/hast": "^3.0.0"
-        }
-      }
-    },
     "hast-util-is-element@npm:^3.0.0": {
       "checksum": "58e9342d89e61215cc06f936804fb9859e627285b11883a654339eb004e4d7ddc8c569922b78e7674dff10004455e67932ecb255c22bd975b85a34cdb6a50280",
       "resolution": {
@@ -13723,20 +11364,6 @@
         }
       }
     },
-    "hast-util-minify-whitespace@npm:^1.0.0": {
-      "checksum": "c3b2a2a5ce47d2b153250e409b2c191cbd1a9a9c89ba42ed73f5678fb50f5c6852e2cdae5209f97ad4cb3c86ae925dd7fe81775580618a4b211fca67ceb73e39",
-      "resolution": {
-        "resolution": "hast-util-minify-whitespace@npm:1.0.1",
-        "version": "1.0.1",
-        "dependencies": {
-          "@types/hast": "^3.0.0",
-          "hast-util-embedded": "^3.0.0",
-          "hast-util-is-element": "^3.0.0",
-          "hast-util-whitespace": "^3.0.0",
-          "unist-util-is": "^6.0.0"
-        }
-      }
-    },
     "hast-util-parse-selector@npm:^4.0.0": {
       "checksum": "8ad7fbba2f75aa60b3e75776968d62313c6e0cd8fac76ad40367a4e29bd7ca7a20e9cc568c21cd565d2ced474dbdec47d19e327337cb61fc052163187c4e2335",
       "resolution": {
@@ -13744,20 +11371,6 @@
         "version": "4.0.0",
         "dependencies": {
           "@types/hast": "^3.0.0"
-        }
-      }
-    },
-    "hast-util-phrasing@npm:^3.0.0": {
-      "checksum": "ac2d4e0d0ec89b7f1c3ef806c0d7b07dabfb754c9283781f9a63adcb94ab5979072135df4229747633b4c93423266ba69b3efb6322a008b8aa82b169dbaa64ab",
-      "resolution": {
-        "resolution": "hast-util-phrasing@npm:3.0.1",
-        "version": "3.0.1",
-        "dependencies": {
-          "@types/hast": "^3.0.0",
-          "hast-util-embedded": "^3.0.0",
-          "hast-util-has-property": "^3.0.0",
-          "hast-util-is-body-ok-link": "^3.0.0",
-          "hast-util-is-element": "^3.0.0"
         }
       }
     },
@@ -13783,56 +11396,7 @@
         }
       }
     },
-    "hast-util-select@npm:^6.0.2": {
-      "checksum": "4e9665a6d301383900ade0fcd71084c7e21eed432d35f4d0598ceb9214099d386b1a9eb77a7fcd7a677dfb09ff58aecdb6060c7324593a07bebf06e8af1cb488",
-      "resolution": {
-        "resolution": "hast-util-select@npm:6.0.4",
-        "version": "6.0.4",
-        "dependencies": {
-          "@types/hast": "^3.0.0",
-          "@types/unist": "^3.0.0",
-          "bcp-47-match": "^2.0.0",
-          "comma-separated-tokens": "^2.0.0",
-          "css-selector-parser": "^3.0.0",
-          "devlop": "^1.0.0",
-          "direction": "^2.0.0",
-          "hast-util-has-property": "^3.0.0",
-          "hast-util-to-string": "^3.0.0",
-          "hast-util-whitespace": "^3.0.0",
-          "nth-check": "^2.0.0",
-          "property-information": "^7.0.0",
-          "space-separated-tokens": "^2.0.0",
-          "unist-util-visit": "^5.0.0",
-          "zwitch": "^2.0.0"
-        }
-      }
-    },
-    "hast-util-to-estree@npm:^3.0.0": {
-      "checksum": "e804bc9b5201defec1b0d46941d9a268866ef1c55e61da07087da58f266a361cf2c72290a6943cf376ca89c40e93fd2d95d3fefda20fe933432fc554a88de3dd",
-      "resolution": {
-        "resolution": "hast-util-to-estree@npm:3.1.3",
-        "version": "3.1.3",
-        "dependencies": {
-          "@types/estree": "^1.0.0",
-          "@types/estree-jsx": "^1.0.0",
-          "@types/hast": "^3.0.0",
-          "comma-separated-tokens": "^2.0.0",
-          "devlop": "^1.0.0",
-          "estree-util-attach-comments": "^3.0.0",
-          "estree-util-is-identifier-name": "^3.0.0",
-          "hast-util-whitespace": "^3.0.0",
-          "mdast-util-mdx-expression": "^2.0.0",
-          "mdast-util-mdx-jsx": "^3.0.0",
-          "mdast-util-mdxjs-esm": "^2.0.0",
-          "property-information": "^7.0.0",
-          "space-separated-tokens": "^2.0.0",
-          "style-to-js": "^1.0.0",
-          "unist-util-position": "^5.0.0",
-          "zwitch": "^2.0.0"
-        }
-      }
-    },
-    "hast-util-to-html@npm:^9.0.0, hast-util-to-html@npm:^9.0.1, hast-util-to-html@npm:^9.0.5": {
+    "hast-util-to-html@npm:^9.0.0, hast-util-to-html@npm:^9.0.5": {
       "checksum": "94878cecff85279031776a451489e599dd548072ca3241fbe3b9e372e2673c135a3d9a5baff5401660b41cce50f8e5a64833ca4a1e7b074c12d89bb32c6a70db",
       "resolution": {
         "resolution": "hast-util-to-html@npm:9.0.5",
@@ -13902,7 +11466,7 @@
         }
       }
     },
-    "hast-util-to-text@npm:^4.0.1, hast-util-to-text@npm:^4.0.2": {
+    "hast-util-to-text@npm:^4.0.2": {
       "checksum": "391b394b69d15b9467dfcd4d119d52b0c676f6129444dc6431abe95977e349f6f967e26e28faf3985a2856b795ced6a91a1052f677d4c754756d602805230b51",
       "resolution": {
         "resolution": "hast-util-to-text@npm:4.0.2",
@@ -13939,36 +11503,11 @@
         }
       }
     },
-    "he@npm:1.2.0": {
-      "checksum": "a620f9091644604c8ed6fe8c047b001ddfc82fb5ba19161a9839bbbfbb6e37dc7eba095f5bdc4dc66ba23a9dc5682e703aae5589d03ce665509fc64545dc8af5",
-      "resolution": {
-        "resolution": "he@npm:1.2.0",
-        "version": "1.2.0"
-      }
-    },
-    "hogan.js@npm:^3.0.2": {
-      "checksum": "131173bc88a175f4d8dba0dc724e8bd768b94267fd965a18d0abe4f168e966517bb85216a1946d73aaf8d88ec4f2f12e8297bdd30c20e365e9fe34242ce1ca29",
-      "resolution": {
-        "resolution": "hogan.js@npm:3.0.2",
-        "version": "3.0.2",
-        "dependencies": {
-          "mkdirp": "0.3.0",
-          "nopt": "1.0.10"
-        }
-      }
-    },
     "hpagent@npm:^1.2.0": {
       "checksum": "dfeca505d0700867a6bd7964b7c7d459d75186b3eabc014f9d7192f36039b92bf6d92c15a43eba4b3844245a70a77797a295f05c84bc965cd4372d34faaaa7fb",
       "resolution": {
         "resolution": "hpagent@npm:1.2.0",
         "version": "1.2.0"
-      }
-    },
-    "htm@npm:^3.0.0": {
-      "checksum": "68066da64a4eb67c7cb0efa7e6106fae0f355e6f58eaea3d66ca1da7bf52a5a1c6b00325b3ccbd5f655251afa50b92a83f11e1491c455edc68b67e17d32915d5",
-      "resolution": {
-        "resolution": "htm@npm:3.1.1",
-        "version": "3.1.1"
       }
     },
     "html-escaper@npm:3.0.3": {
@@ -13997,13 +11536,6 @@
       "resolution": {
         "resolution": "html-void-elements@npm:3.0.0",
         "version": "3.0.0"
-      }
-    },
-    "html-whitespace-sensitive-tag-names@npm:^3.0.0": {
-      "checksum": "5d8e3aeb6b28c84d63dc823eb3986503a2362632b76db9bc3c28baddcc2e04aa00877fb5513c1455fc5d1dee0fd94f6d00b625856eebc322567af1e303da7aa4",
-      "resolution": {
-        "resolution": "html-whitespace-sensitive-tag-names@npm:3.0.1",
-        "version": "3.0.1"
       }
     },
     "http-cache-semantics@npm:^4.0.0, http-cache-semantics@npm:^4.1.1, http-cache-semantics@npm:^4.2.0": {
@@ -14067,16 +11599,6 @@
         "version": "2.1.0"
       }
     },
-    "i18next@npm:^23.11.5": {
-      "checksum": "d3e8b588cccdf958d5d28924b1597baab4684c361043f2bb4b1176ffed771e12738e36ef65f00d70ddd8b20952349557f3540b863657a82aee94a776c7201f23",
-      "resolution": {
-        "resolution": "i18next@npm:23.16.8",
-        "version": "23.16.8",
-        "dependencies": {
-          "@babel/runtime": "^7.23.2"
-        }
-      }
-    },
     "iconv-lite@npm:0.4": {
       "checksum": "05f1a0c1b7a95f11eaa14f2776906c1b98289e6bbb2fb293e479756b848521ad7cdcf89d99b59d5533561b4ef922aa73113afc9ce77a32d23229898419247b83",
       "resolution": {
@@ -14116,13 +11638,6 @@
       "resolution": {
         "resolution": "ignore@npm:7.0.5",
         "version": "7.0.5"
-      }
-    },
-    "immer@npm:^10.0.3, immer@npm:^10.1.1": {
-      "checksum": "f8bd7a0f5019773de5e8a06fa34965fca4e9e63e3770a3a829160279e12d75f022c1cc39b60913a961230b62a8eedd10f28d3a17f4ad45c0dc841e2126d548c5",
-      "resolution": {
-        "resolution": "immer@npm:10.1.3",
-        "version": "10.1.3"
       }
     },
     "immer@npm:^11.0.0": {
@@ -14193,20 +11708,6 @@
         "version": "2.0.4"
       }
     },
-    "inherits@npm:2.0.3": {
-      "checksum": "bfd934adf15de831203ecefcc0ec670956fb3bd2c41834d841be963f38f8029cbaf090b45e9e42c5366cc1431c3cddc6b16816a6d218968cf92e191e5742fe10",
-      "resolution": {
-        "resolution": "inherits@npm:2.0.3",
-        "version": "2.0.3"
-      }
-    },
-    "ini@npm:~1.3.0": {
-      "checksum": "d9e8d7a5a472a4bb609b3611f91cd7cfc82e1dcbed222e39785878b8683efb90d186211d6a1150244e39b54cda44446b330556de007b37d9d23f641dd90e5b8d",
-      "resolution": {
-        "resolution": "ini@npm:1.3.8",
-        "version": "1.3.8"
-      }
-    },
     "ink@npm:^3.2.0": {
       "checksum": "2d8751a60b32daa8721083eacd582aaa1f173ed0fb79307a42efa23a3382e2c8596c38c834a55c7cfd1c545ab736e609fc73a9fe1fe839e97db390e9d99bf944",
       "resolution": {
@@ -14266,47 +11767,6 @@
       "resolution": {
         "resolution": "inline-style-parser@npm:0.2.4",
         "version": "0.2.4"
-      }
-    },
-    "inline-style-parser@npm:0.2.6": {
-      "checksum": "56d065c6048078d9080bcc092ddbc6e76b3e85c85bac26d592052ccb3df7b5ec347c2a6f06b515f499779b425d93b77805caffd0754215870409c57f27e8b4d5",
-      "resolution": {
-        "resolution": "inline-style-parser@npm:0.2.6",
-        "version": "0.2.6"
-      }
-    },
-    "instantsearch-ui-components@npm:0.11.2": {
-      "checksum": "7166c8aac161c114e101e3919d9bc0c565152d99ef31835100f29a8f00f5b7fc15cbcbff3e2871fba5ac985e8424f4827c9a1be061352a499a86f5caf9944c8b",
-      "resolution": {
-        "resolution": "instantsearch-ui-components@npm:0.11.2",
-        "version": "0.11.2",
-        "dependencies": {
-          "@babel/runtime": "^7.27.6"
-        }
-      }
-    },
-    "instantsearch.js@npm:4.80.0, instantsearch.js@npm:^4.80.0": {
-      "checksum": "a55c9c389e0de5cdce3a733ca6c2f483e40ec3c596cb295ba8139e3a928aefe34f0045ac7b11abac2747d1c8d697776cb47f592abb9b8da65535ab49c3de51d3",
-      "resolution": {
-        "resolution": "instantsearch.js@npm:4.80.0",
-        "version": "4.80.0",
-        "dependencies": {
-          "@algolia/events": "^4.0.1",
-          "@types/dom-speech-recognition": "^0.0.1",
-          "@types/google.maps": "^3.55.12",
-          "@types/hogan.js": "^3.0.0",
-          "@types/qs": "^6.5.3",
-          "algoliasearch-helper": "3.26.0",
-          "hogan.js": "^3.0.2",
-          "htm": "^3.0.0",
-          "instantsearch-ui-components": "0.11.2",
-          "preact": "^10.10.0",
-          "qs": "^6.5.1 < 6.10",
-          "search-insights": "^2.17.2"
-        },
-        "peerDependencies": {
-          "algoliasearch": ">= 3.1 < 6"
-        }
       }
     },
     "internal-slot@npm:^1.1.0": {
@@ -14396,13 +11856,6 @@
         "version": "0.2.1"
       }
     },
-    "is-arrayish@npm:^0.3.1": {
-      "checksum": "1743cf4c9188716fd4724c38fae3e05f908cb3d171e680a67c778ab0c1778b4a55f854557ca57234dcc113ea8c318e46a0ed79be4036d33304c3d0a6c7278118",
-      "resolution": {
-        "resolution": "is-arrayish@npm:0.3.4",
-        "version": "0.3.4"
-      }
-    },
     "is-async-function@npm:^2.0.0": {
       "checksum": "ff8ae6622df12fbb1b8134a4c999a134f58e6c246a2fafeb4d4ab1ac78b9ef356627c54255029f027270823b004bb794ed45d85d70c45b32c9007203ae1b94f0",
       "resolution": {
@@ -14462,7 +11915,7 @@
         }
       }
     },
-    "is-core-module@npm:^2.13.0, is-core-module@npm:^2.16.0, is-core-module@npm:^2.16.1": {
+    "is-core-module@npm:^2.13.0, is-core-module@npm:^2.16.1": {
       "checksum": "c6b46f45c03487b3df0da1b7d061be97539f88687a40eef145fc036e763ff305fde0edaa779448d685d9c8c4f1ea76712f49fd4efa82f3d0ec84421222f20ec7",
       "resolution": {
         "resolution": "is-core-module@npm:2.16.1",
@@ -14772,13 +12225,6 @@
         "version": "2.0.0"
       }
     },
-    "isexe@npm:^3.1.1": {
-      "checksum": "355e1c6bacf0f58b3af8a8c24aa59e5664fb7932e84ddde4e7fcc3e81c45af5b66427630e2b676b4d77ca1f33b3ecafe9b1c03ee5f3e0a955c51af369a8a9ac0",
-      "resolution": {
-        "resolution": "isexe@npm:3.1.1",
-        "version": "3.1.1"
-      }
-    },
     "istanbul-lib-coverage@npm:^3.0.0, istanbul-lib-coverage@npm:^3.2.0": {
       "checksum": "4c56545b6239f470bd1d542fae163ef8545e209537990b22271733a97e0d8e8ed875e225553f8611fc628ff816f57b58dae0d9e213fccc4f87b76bf6f41fa55c",
       "resolution": {
@@ -14876,16 +12322,6 @@
         "optionalDependencies": [
           "@pkgjs/parseargs"
         ]
-      }
-    },
-    "jackspeak@npm:^4.1.1": {
-      "checksum": "c6bfa49348f311871ccb062a5186d5159b2282d4e14290367766c7d7b45517d6c14a24325b8361d6c21f204a7ddb5605cd07bbf576e8bee2a37538bb4da1b801",
-      "resolution": {
-        "resolution": "jackspeak@npm:4.1.1",
-        "version": "4.1.1",
-        "dependencies": {
-          "@isaacs/cliui": "^8.0.2"
-        }
       }
     },
     "jest@npm:^29.2.1": {
@@ -15443,13 +12879,6 @@
         "version": "2.3.1"
       }
     },
-    "json-schema@npm:^0.4.0": {
-      "checksum": "45c85400fd8012e36ce320440cd5c2230dca61ae2d2f5abc078d83ea1dce9eb07c22a70d3d05126e5da554b57121bcc86c99e206230dc9a1c648d726a807d5b4",
-      "resolution": {
-        "resolution": "json-schema@npm:0.4.0",
-        "version": "0.4.0"
-      }
-    },
     "json-schema-traverse@npm:^0.4.1": {
       "checksum": "715a3f901df58055cd461c01640b83a0febd568acbf63fb4b36b365b952eacec2d0af05d78f069327ce1bd5b42d29eba73b79580122b1f6082f5116953673ad7",
       "resolution": {
@@ -15523,27 +12952,6 @@
       "resolution": {
         "resolution": "kleur@npm:3.0.3",
         "version": "3.0.3"
-      }
-    },
-    "kleur@npm:^4.1.5": {
-      "checksum": "49c639f4d49d59045fa15e30d1a2bc1b4d0fd9241d7d47efeed3265515aac932fe0f3355abfa78dc25a23b3362285daae8fa6519029d070f0d1cc6354464d148",
-      "resolution": {
-        "resolution": "kleur@npm:4.1.5",
-        "version": "4.1.5"
-      }
-    },
-    "klona@npm:^2.0.6": {
-      "checksum": "30fb1e5ef02882779e3a4ba48df17835f9e13ef33750eb6df9310263f7797f28b65311859b9b22f055add3c29f04f807bf382d48172b58b9b9b119bcb7c7c353",
-      "resolution": {
-        "resolution": "klona@npm:2.0.6",
-        "version": "2.0.6"
-      }
-    },
-    "kolorist@npm:^1.6.0, kolorist@npm:^1.8.0": {
-      "checksum": "230d577233036a8774c0c5a7b744067f9280d7325672fd17024cfc158dcbc5d732d7f30d15aacf661bd4bf4fbda7bb8b66b24288004b7ad48dfef98971e1bbc0",
-      "resolution": {
-        "resolution": "kolorist@npm:1.8.0",
-        "version": "1.8.0"
       }
     },
     "layout-base@npm:^1.0.0": {
@@ -16024,13 +13432,6 @@
         "version": "4.18.1"
       }
     },
-    "lodash.debounce@npm:^4.0.8": {
-      "checksum": "0ad221b78f3964b7eda3d03333f00e2cd2240efb1445ecea593b678591753745727c1a363171c13e0bd33ba3fa8a7e09e8d8607b630a08333c0dfacc912316a0",
-      "resolution": {
-        "resolution": "lodash.debounce@npm:4.0.8",
-        "version": "4.0.8"
-      }
-    },
     "lodash.merge@npm:^4.6.2": {
       "checksum": "1c33ff8dcdfb17b2f57a9ae183ce0787a5c5aa201eca2db4547eb602c99a5a14010d133beafa09afb64bd9e4058a8af177a8c9c8e8919abf3d2c9dbe92bb08ce",
       "resolution": {
@@ -16055,16 +13456,6 @@
         }
       }
     },
-    "lower-case@npm:^2.0.2": {
-      "checksum": "5a208dd110be344ce318f4445644fdfaad2cee6929b963bbc92af50f730c3adc0201314982c052365ff9b424d13abab248bdabaf1127584b11d3196ea45ea60d",
-      "resolution": {
-        "resolution": "lower-case@npm:2.0.2",
-        "version": "2.0.2",
-        "dependencies": {
-          "tslib": "^2.0.3"
-        }
-      }
-    },
     "lowercase-keys@npm:^2.0.0": {
       "checksum": "e767627771dc55fbb314a78de7b39e4cc5e0269012622af8fed71524eef368f8e4d89d15937b82531aa48acd8b9f30af3ff156170181e18397511d5f93266da8",
       "resolution": {
@@ -16072,7 +13463,7 @@
         "version": "2.0.0"
       }
     },
-    "lru-cache@npm:^10.0.1, lru-cache@npm:^10.2.0, lru-cache@npm:^10.4.3": {
+    "lru-cache@npm:^10.0.1, lru-cache@npm:^10.2.0": {
       "checksum": "a2aa0c59406f2836af37c2b6700ef4b6851d34f4631aa77ccd227d4256a996a6d24571e74bd8c31f77b5d22d814c39068aaa227ce8c92c91dad886ee37adfa8c",
       "resolution": {
         "resolution": "lru-cache@npm:10.4.3",
@@ -16117,7 +13508,7 @@
         "version": "7.18.3"
       }
     },
-    "magic-string@npm:0.x >= 0.26.0, magic-string@npm:^0.30.18, magic-string@npm:^0.30.19": {
+    "magic-string@npm:^0.30.19": {
       "checksum": "a295c76d597e345cfac9526519b33c8917772fb76f610c6cc278e9e9d54486c10246c156e52772dd6d043d9d6be0ebe68a52e9004c106f26267cecec4c065f4b",
       "resolution": {
         "resolution": "magic-string@npm:0.30.19",
@@ -16134,18 +13525,6 @@
         "version": "0.30.21",
         "dependencies": {
           "@jridgewell/sourcemap-codec": "^1.5.5"
-        }
-      }
-    },
-    "magicast@npm:^0.3.5": {
-      "checksum": "ae6d025047005a3f965211e51daa267198e85b3130177eae4499837c6bebf1200fd056cf89dc00988173365a58c1c851aed1b8c5ba9d5a4916433f04cb18b7cb",
-      "resolution": {
-        "resolution": "magicast@npm:0.3.5",
-        "version": "0.3.5",
-        "dependencies": {
-          "@babel/parser": "^7.25.4",
-          "@babel/types": "^7.25.4",
-          "source-map-js": "^1.2.0"
         }
       }
     },
@@ -16221,13 +13600,6 @@
         }
       }
     },
-    "markdown-extensions@npm:^2.0.0": {
-      "checksum": "69c1d6aa903aec8f8ca65ee31387edc5d55ab51b035cbc38f28c267f9ab286c347372a95afaa0a39abbdba60de2b6c680e2f52d83c7f610a216e5b34fb7feb85",
-      "resolution": {
-        "resolution": "markdown-extensions@npm:2.0.0",
-        "version": "2.0.0"
-      }
-    },
     "markdown-table@npm:^3.0.0": {
       "checksum": "8152e22ef44757998d38718cd4f81518ede33965fc5dc0d33eb92d9c9a455e7a3140e83af012c349a52bad7bce6814e9b1d8ac601392053ffc6677179d178bed",
       "resolution": {
@@ -16235,7 +13607,7 @@
         "version": "3.0.4"
       }
     },
-    "marked@npm:^16.0.0, marked@npm:^16.3.0": {
+    "marked@npm:^16.3.0": {
       "checksum": "5fcfdb487e43fc1cf6dc6fe5c5c1ee9260ab573d407f7e9b3135d843b1435acb4d74df4c32fb0bafce464b67d5de8b9deaf9a4b92ed21fa723df35da3d5cd6b4",
       "resolution": {
         "resolution": "marked@npm:16.4.0",
@@ -16408,20 +13780,6 @@
         }
       }
     },
-    "mdast-util-mdx@npm:^3.0.0": {
-      "checksum": "07b1d6344a9f5e96b2eb03982b4e9bb4ba9eceb12eac583c2fd0db9b474ca0f465b7e8bead7f373e6fd0982adead8ad1b8337d611e14503fd1281ba6007c317e",
-      "resolution": {
-        "resolution": "mdast-util-mdx@npm:3.0.0",
-        "version": "3.0.0",
-        "dependencies": {
-          "mdast-util-from-markdown": "^2.0.0",
-          "mdast-util-mdx-expression": "^2.0.0",
-          "mdast-util-mdx-jsx": "^3.0.0",
-          "mdast-util-mdxjs-esm": "^2.0.0",
-          "mdast-util-to-markdown": "^2.0.0"
-        }
-      }
-    },
     "mdast-util-mdx-expression@npm:^2.0.0": {
       "checksum": "3e24af4811cf710e45646dd67d78fc94c6d89bf31657eed18ae49d006f2bd144b3149a06a53a300ef5d5403761dec81de8fd7ab550c1891882299af338864892",
       "resolution": {
@@ -16502,7 +13860,7 @@
         }
       }
     },
-    "mdast-util-to-markdown@npm:^2.0.0, mdast-util-to-markdown@npm:^2.1.0": {
+    "mdast-util-to-markdown@npm:^2.0.0": {
       "checksum": "007803a2c7b2a0108675d8b77775d8bcd2f372ef8c4baca01c30b1e30b3b002010c941f8c62ec0609ec73709a0e9cdb126131d85aba14f12f83ad524cc150ad5",
       "resolution": {
         "resolution": "mdast-util-to-markdown@npm:2.1.2",
@@ -16535,13 +13893,6 @@
       "resolution": {
         "resolution": "mdn-data@npm:2.0.28",
         "version": "2.0.28"
-      }
-    },
-    "mdn-data@npm:2.12.2": {
-      "checksum": "be1cf3df764d2a266d68787cb52426836bfac21d6a5e812ae2332841ed9333fe2e216cf5e0414d7ef3d31e88143500fab5e2e153b787e484aa89e30fc1e14a70",
-      "resolution": {
-        "resolution": "mdn-data@npm:2.12.2",
-        "version": "2.12.2"
       }
     },
     "mdn-data@npm:2.27.1": {
@@ -16595,13 +13946,6 @@
         }
       }
     },
-    "meshoptimizer@npm:~0.22.0": {
-      "checksum": "e3195b774c5abe43b301688a168a911dcc12514dfd6a5808eb2240e003a2d6dde74d836c059aed78bca3d1b0abdb1bc3f423b5089cdb31f8e09e73fa02eedbd4",
-      "resolution": {
-        "resolution": "meshoptimizer@npm:0.22.0",
-        "version": "0.22.0"
-      }
-    },
     "micromark@npm:^4.0.0": {
       "checksum": "5a459586815d8063fd1ef6401960ee8931c30b410f8514dfeb5b5f19c35a48935b3fa6950dfa01335fd77dfa6fccba368a476bdeeca8720f32d72fef4ed3ebc1",
       "resolution": {
@@ -16650,22 +13994,6 @@
           "micromark-util-subtokenize": "^2.0.0",
           "micromark-util-symbol": "^2.0.0",
           "micromark-util-types": "^2.0.0"
-        }
-      }
-    },
-    "micromark-extension-directive@npm:^3.0.0": {
-      "checksum": "e8748bfc18c85cdb00ac6594cad9e7a03fe473bef9fded56798fbeba7868a1ceb0d8f59aa553731397ba72ad8c83b606707e6d983c71cd70db4018911a7b2c51",
-      "resolution": {
-        "resolution": "micromark-extension-directive@npm:3.0.2",
-        "version": "3.0.2",
-        "dependencies": {
-          "devlop": "^1.0.0",
-          "micromark-factory-space": "^2.0.0",
-          "micromark-factory-whitespace": "^2.0.0",
-          "micromark-util-character": "^2.0.0",
-          "micromark-util-symbol": "^2.0.0",
-          "micromark-util-types": "^2.0.0",
-          "parse-entities": "^4.0.0"
         }
       }
     },
@@ -16785,87 +14113,6 @@
         }
       }
     },
-    "micromark-extension-mdx-expression@npm:^3.0.0": {
-      "checksum": "8a5f57ffaf6f3f7d2f57237051e47712ea673dc0fbf7fdd55c72d9d8e3a31919369dc7c04cbc5de4e2c2b77ca5653a700ffb0be702f6e1a1bd8d831107be4ced",
-      "resolution": {
-        "resolution": "micromark-extension-mdx-expression@npm:3.0.1",
-        "version": "3.0.1",
-        "dependencies": {
-          "@types/estree": "^1.0.0",
-          "devlop": "^1.0.0",
-          "micromark-factory-mdx-expression": "^2.0.0",
-          "micromark-factory-space": "^2.0.0",
-          "micromark-util-character": "^2.0.0",
-          "micromark-util-events-to-acorn": "^2.0.0",
-          "micromark-util-symbol": "^2.0.0",
-          "micromark-util-types": "^2.0.0"
-        }
-      }
-    },
-    "micromark-extension-mdx-jsx@npm:^3.0.0": {
-      "checksum": "cb597813c1b6822d787595ca565889984fa516e990c82edfc7a09fd3ca39bdaa5f69aabf742e6a4ddf17acc63e6e3c4b611de1d57cb20ec286879aedea5d1202",
-      "resolution": {
-        "resolution": "micromark-extension-mdx-jsx@npm:3.0.2",
-        "version": "3.0.2",
-        "dependencies": {
-          "@types/estree": "^1.0.0",
-          "devlop": "^1.0.0",
-          "estree-util-is-identifier-name": "^3.0.0",
-          "micromark-factory-mdx-expression": "^2.0.0",
-          "micromark-factory-space": "^2.0.0",
-          "micromark-util-character": "^2.0.0",
-          "micromark-util-events-to-acorn": "^2.0.0",
-          "micromark-util-symbol": "^2.0.0",
-          "micromark-util-types": "^2.0.0",
-          "vfile-message": "^4.0.0"
-        }
-      }
-    },
-    "micromark-extension-mdx-md@npm:^2.0.0": {
-      "checksum": "c7748fc046a78346a3afa8f6dafe4406d579937119dc36efa47b84afab2165484159f17f4d61222d22366c6199237ccc8a79a65488aed54aba929f3ff95b266f",
-      "resolution": {
-        "resolution": "micromark-extension-mdx-md@npm:2.0.0",
-        "version": "2.0.0",
-        "dependencies": {
-          "micromark-util-types": "^2.0.0"
-        }
-      }
-    },
-    "micromark-extension-mdxjs@npm:^3.0.0": {
-      "checksum": "70da2da5ec7dac13de0d6cc483512a85559f1f95f93c736453248059d0fc3590808ef689865c914586c7127ce2c913ae28eb57b269e7c87bf9eb2ff79402ada9",
-      "resolution": {
-        "resolution": "micromark-extension-mdxjs@npm:3.0.0",
-        "version": "3.0.0",
-        "dependencies": {
-          "acorn": "^8.0.0",
-          "acorn-jsx": "^5.0.0",
-          "micromark-extension-mdx-expression": "^3.0.0",
-          "micromark-extension-mdx-jsx": "^3.0.0",
-          "micromark-extension-mdx-md": "^2.0.0",
-          "micromark-extension-mdxjs-esm": "^3.0.0",
-          "micromark-util-combine-extensions": "^2.0.0",
-          "micromark-util-types": "^2.0.0"
-        }
-      }
-    },
-    "micromark-extension-mdxjs-esm@npm:^3.0.0": {
-      "checksum": "1c6d2aa4bb1ba699a3c1515f11c70f90010da7bf72e30a4648afd993a770061c9154c7babde9dd9e4ac3831563858499d63e999eefa3fbaa58946ba44d92cd45",
-      "resolution": {
-        "resolution": "micromark-extension-mdxjs-esm@npm:3.0.0",
-        "version": "3.0.0",
-        "dependencies": {
-          "@types/estree": "^1.0.0",
-          "devlop": "^1.0.0",
-          "micromark-core-commonmark": "^2.0.0",
-          "micromark-util-character": "^2.0.0",
-          "micromark-util-events-to-acorn": "^2.0.0",
-          "micromark-util-symbol": "^2.0.0",
-          "micromark-util-types": "^2.0.0",
-          "unist-util-position-from-estree": "^2.0.0",
-          "vfile-message": "^4.0.0"
-        }
-      }
-    },
     "micromark-factory-destination@npm:^2.0.0": {
       "checksum": "c0edf95eecb4d7a78931914801318a182a6f6efebb288b08aebc66997a0ecb833fafcd7923ca9768328b1942cdf137b76d2fccdd8193c8b15f95b61405d1a0d1",
       "resolution": {
@@ -16888,24 +14135,6 @@
           "micromark-util-character": "^2.0.0",
           "micromark-util-symbol": "^2.0.0",
           "micromark-util-types": "^2.0.0"
-        }
-      }
-    },
-    "micromark-factory-mdx-expression@npm:^2.0.0": {
-      "checksum": "88d8d70fd86996cfba94e97b507ff1ecb25a11fe42d1673c8db2c086f097c88184391bd7ebfd3cf56424fcbdd2c054a86ebfa1efa7cbca70892102265aec5e97",
-      "resolution": {
-        "resolution": "micromark-factory-mdx-expression@npm:2.0.3",
-        "version": "2.0.3",
-        "dependencies": {
-          "@types/estree": "^1.0.0",
-          "devlop": "^1.0.0",
-          "micromark-factory-space": "^2.0.0",
-          "micromark-util-character": "^2.0.0",
-          "micromark-util-events-to-acorn": "^2.0.0",
-          "micromark-util-symbol": "^2.0.0",
-          "micromark-util-types": "^2.0.0",
-          "unist-util-position-from-estree": "^2.0.0",
-          "vfile-message": "^4.0.0"
         }
       }
     },
@@ -17020,22 +14249,6 @@
         "version": "2.0.1"
       }
     },
-    "micromark-util-events-to-acorn@npm:^2.0.0": {
-      "checksum": "22f53d6e88067716c22817272aceb499b04699cd5f3d39f87b90b83e9593181fc398c68faa039a2b69c83b40db986f30ec5b1d2ee39e16bfcb3771c426c3073c",
-      "resolution": {
-        "resolution": "micromark-util-events-to-acorn@npm:2.0.3",
-        "version": "2.0.3",
-        "dependencies": {
-          "@types/estree": "^1.0.0",
-          "@types/unist": "^3.0.0",
-          "devlop": "^1.0.0",
-          "estree-util-visit": "^2.0.0",
-          "micromark-util-symbol": "^2.0.0",
-          "micromark-util-types": "^2.0.0",
-          "vfile-message": "^4.0.0"
-        }
-      }
-    },
     "micromark-util-html-tag-name@npm:^2.0.0": {
       "checksum": "72ac1818c73ae0fb3ce275751e183374c98daae95a10841b0076b904a91d629f4d521735a34c8837d16ea19708567215c987654be9c84d8a5fc596246e1460fe",
       "resolution": {
@@ -17148,16 +14361,6 @@
         "version": "3.1.0"
       }
     },
-    "minimatch@npm:^10.0.3": {
-      "checksum": "981fd8517cb13de1e8ea2538d915aadbc5745afa84e5a262d15116a4ca4165504557c991b4180c58641b039b3f3ec053511c0f522b5814597ede162a3aa31d87",
-      "resolution": {
-        "resolution": "minimatch@npm:10.0.3",
-        "version": "10.0.3",
-        "dependencies": {
-          "@isaacs/brace-expansion": "^5.0.0"
-        }
-      }
-    },
     "minimatch@npm:^10.1.1": {
       "checksum": "6906bca8e19adfefe7bfd34f1ca537a7331f2a0e976dd39000bb2b1ac7e51f27f74b124519f1c5ea7550f74eb00f296afdbf2701bce45f7adf22366be76198b1",
       "resolution": {
@@ -17188,7 +14391,7 @@
         }
       }
     },
-    "minimist@npm:^1.2.0, minimist@npm:^1.2.3, minimist@npm:^1.2.6": {
+    "minimist@npm:^1.2.6": {
       "checksum": "d194bdc11ee8a5418d66d596c2871c3d1418c120c1c2de0b92e400cdc376ca1bfddac771c61195e737939a37be99a5088119540cf3e53d200ca5df81c593df53",
       "resolution": {
         "resolution": "minimist@npm:1.2.8",
@@ -17319,13 +14522,6 @@
         "version": "3.0.1"
       }
     },
-    "mkdirp@npm:0.3.0": {
-      "checksum": "d6c431ab547fc5be4da9d1d1842db4b4be817cefbfbd1274150678b782cb52ed7870d60b34cf50f8518c6e580c9f6382753867f319f1f430c58a101ff76e336d",
-      "resolution": {
-        "resolution": "mkdirp@npm:0.3.0",
-        "version": "0.3.0"
-      }
-    },
     "mkdirp@npm:^0.5.1": {
       "checksum": "abc3731ef776baf0687e74be29f061748349422a40a272da220484d554087553d027bbf03f6f2f32ae65e89f75efc676f6aa73391456773ab8c8e48fbed077cd",
       "resolution": {
@@ -17341,13 +14537,6 @@
       "resolution": {
         "resolution": "mkdirp@npm:1.0.4",
         "version": "1.0.4"
-      }
-    },
-    "mkdirp-classic@npm:^0.5.2, mkdirp-classic@npm:^0.5.3": {
-      "checksum": "9f56cbf8e70de21d03ace1a3021fb5ceb7df87737c8c8c533ad7d10bf8d14f4878fa0519b3391841893cca02b6574e21ac98e08dea0ea37fae7d3a65a3062ec4",
-      "resolution": {
-        "resolution": "mkdirp-classic@npm:0.5.3",
-        "version": "0.5.3"
       }
     },
     "mrmime@npm:^2.0.1": {
@@ -17376,13 +14565,6 @@
       "resolution": {
         "resolution": "nanoid@npm:3.3.11",
         "version": "3.3.11"
-      }
-    },
-    "napi-build-utils@npm:^2.0.0": {
-      "checksum": "e3e78ac8b0c2bc2bbd595167eb1e6f122dbbdd4f4b8a7a109c4549f8c3128ef06c1ec537e815f6eac091d36e27192048ca3297cc192d48515d38e77cf5c91fd1",
-      "resolution": {
-        "resolution": "napi-build-utils@npm:2.0.0",
-        "version": "2.0.0"
       }
     },
     "natural-compare@npm:^1.4.0": {
@@ -17423,88 +14605,11 @@
         }
       }
     },
-    "no-case@npm:^3.0.4": {
-      "checksum": "729199291b8c500ab21dfc0a1a3544806984d28ba5062183ca517774cfd944b25c54c8af492791aec9a615c3c911869c944ad796ae0ad48f88518df7940afc00",
-      "resolution": {
-        "resolution": "no-case@npm:3.0.4",
-        "version": "3.0.4",
-        "dependencies": {
-          "lower-case": "^2.0.2",
-          "tslib": "^2.0.3"
-        }
-      }
-    },
-    "node-abi@npm:^3.3.0": {
-      "checksum": "83bb6fcf2b25eb56da8ffc1e958377fa020a7ecf54a14f91b84702ad8ebe35c727416856b6588e413f5fddf958b0ae69d2cc869faed2777f28c9e1cbbdc149e5",
-      "resolution": {
-        "resolution": "node-abi@npm:3.78.0",
-        "version": "3.78.0",
-        "dependencies": {
-          "semver": "^7.3.5"
-        }
-      }
-    },
-    "node-addon-api@npm:^6.1.0": {
-      "checksum": "fe458b34f55dcad176172e423814eaefc95498089688b0a40a139d079f45062719a7c85dd545690452c7abc3222a6410ff1726967e8cf25e7169c430c212eb5a",
-      "resolution": {
-        "resolution": "node-addon-api@npm:6.1.0",
-        "version": "6.1.0",
-        "dependencies": {
-          "node-gyp": "*"
-        }
-      }
-    },
-    "node-fetch@npm:^2.7.0": {
-      "checksum": "de79ea6dd41714df75dac947f2b2804b049a6b30196794194e4d18520d23bea2e60a7cd7edaf8aa221a90a3eaaedf60458464441f9c4c0a58d8a1728f68a034a",
-      "resolution": {
-        "resolution": "node-fetch@npm:2.7.0",
-        "version": "2.7.0",
-        "dependencies": {
-          "whatwg-url": "^5.0.0"
-        },
-        "peerDependencies": {
-          "encoding": "^0.1.0"
-        },
-        "optionalPeerDependencies": [
-          "encoding"
-        ]
-      }
-    },
-    "node-fetch-native@npm:^1.6.4, node-fetch-native@npm:^1.6.7": {
+    "node-fetch-native@npm:^1.6.7": {
       "checksum": "9406fb6cf6a2c1f13cc7cfae22850b9ad9abfd21e8231be06a64603d92de5b36bfc1f2b22901f584ffb5bba5ec7315e50c797dfb8d07fa9c3c4b45a524d60dd0",
       "resolution": {
         "resolution": "node-fetch-native@npm:1.6.7",
         "version": "1.6.7"
-      }
-    },
-    "node-gyp@npm:*": {
-      "checksum": "caafc1bfaeb09a9d450f0ef7081f91a436a5686f9a347f4ea6aecdf34fa68e32d529924205fb5e6333fa3307a8d54758670123d47101b3aa1a56d866676b0b48",
-      "resolution": {
-        "resolution": "node-gyp@npm:11.4.2",
-        "version": "11.4.2",
-        "dependencies": {
-          "env-paths": "^2.2.0",
-          "exponential-backoff": "^3.1.1",
-          "graceful-fs": "^4.2.6",
-          "make-fetch-happen": "^14.0.3",
-          "nopt": "^8.0.0",
-          "proc-log": "^5.0.0",
-          "semver": "^7.3.5",
-          "tar": "^7.4.3",
-          "tinyglobby": "^0.2.12",
-          "which": "^5.0.0"
-        }
-      }
-    },
-    "node-html-parser@npm:^6.1.12": {
-      "checksum": "74440a01e61399293658de6d4debf6076eef35fcf9e10a9021e787da6908a021bd76a0d8efc530790287b38f38a8b1e86a3048f6fdfa16983eb5a730a1a5da92",
-      "resolution": {
-        "resolution": "node-html-parser@npm:6.1.13",
-        "version": "6.1.13",
-        "dependencies": {
-          "css-select": "^5.1.0",
-          "he": "1.2.0"
-        }
       }
     },
     "node-int64@npm:^0.4.0": {
@@ -17512,13 +14617,6 @@
       "resolution": {
         "resolution": "node-int64@npm:0.4.0",
         "version": "0.4.0"
-      }
-    },
-    "node-mock-http@npm:^1.0.2": {
-      "checksum": "66850510fd761486cd15c8f3cb20ec77e8c0305a094295eeefd17335ebf934baa73beca3f6dccb1370687337bbc6b69ff80878c7d12282a92025d1a8eb98d341",
-      "resolution": {
-        "resolution": "node-mock-http@npm:1.0.3",
-        "version": "1.0.3"
       }
     },
     "node-mock-http@npm:^1.0.4": {
@@ -17540,26 +14638,6 @@
       "resolution": {
         "resolution": "node-watch@npm:0.7.3",
         "version": "0.7.3"
-      }
-    },
-    "nopt@npm:1.0.10": {
-      "checksum": "a04b4cdc7f0a6747789a0108e6422763904fc812990bb1f4f40a1e2bcbf9043b5d72b2573c4f0f244f8b95d651e5c3c06d6ec55c5a0fa035537061dabdf007c2",
-      "resolution": {
-        "resolution": "nopt@npm:1.0.10",
-        "version": "1.0.10",
-        "dependencies": {
-          "abbrev": "1"
-        }
-      }
-    },
-    "nopt@npm:^8.0.0": {
-      "checksum": "fcff06dd3763041ba548a600d917d3e08ecd6284f22b93205d8dde6d6c75a14a1ff93710a47156590e312beffad5d50c94e82d9ce69a2ca2a22ee00540c937ce",
-      "resolution": {
-        "resolution": "nopt@npm:8.1.0",
-        "version": "8.1.0",
-        "dependencies": {
-          "abbrev": "^3.0.0"
-        }
       }
     },
     "normalize-path@npm:^3.0.0": {
@@ -17586,7 +14664,7 @@
         }
       }
     },
-    "nth-check@npm:^2.0.0, nth-check@npm:^2.0.1": {
+    "nth-check@npm:^2.0.1": {
       "checksum": "aed2cec6469015a6305bd7931ce0946554d9551cc041e7416a3f82544dbf3e28bca4acc94d0250947e2cfb5c53b03fbb9e217808b68a3bf44d7bfa53f4734a56",
       "resolution": {
         "resolution": "nth-check@npm:2.1.1",
@@ -17691,18 +14769,6 @@
         }
       }
     },
-    "ofetch@npm:^1.4.1": {
-      "checksum": "1d8f078ddd8cde5737071e9511409e6c15acb6e8411d467ffcce87e5e7dc46ef167923e1cac6579a1f68e86b49128e4818511aff3c8463d17bc3d0ca5d8b7530",
-      "resolution": {
-        "resolution": "ofetch@npm:1.4.1",
-        "version": "1.4.1",
-        "dependencies": {
-          "destr": "^2.0.3",
-          "node-fetch-native": "^1.6.4",
-          "ufo": "^1.5.4"
-        }
-      }
-    },
     "ofetch@npm:^1.5.1": {
       "checksum": "cf7d3e08ef7e13056559fa139d0c236e69357c410af9831d12b6835ecf3bb5f65170fa396c04a72dae7b3ed8349c62fbd136b2793203713945173bfc6848ba51",
       "resolution": {
@@ -17715,7 +14781,7 @@
         }
       }
     },
-    "ohash@npm:^2.0.0, ohash@npm:^2.0.11": {
+    "ohash@npm:^2.0.11": {
       "checksum": "07bec79855fa0a0e136034d016c32fda25ac76551326494044df5bf007711bcf8c8ea4a01aaf4f492fa5d63efc729c05014ef2ba3a70f642c465ea5905031135",
       "resolution": {
         "resolution": "ohash@npm:2.0.11",
@@ -17752,30 +14818,11 @@
         }
       }
     },
-    "oniguruma-parser@npm:^0.12.1": {
-      "checksum": "6e8b827852196b9ad6c93f2e791b0477d5bbf59c13366f83c5dfa30b478ccad29f03c084f741cc67e6628b169e040e412146ae09b44a2fe3cca455bb2a402518",
-      "resolution": {
-        "resolution": "oniguruma-parser@npm:0.12.1",
-        "version": "0.12.1"
-      }
-    },
     "oniguruma-parser@npm:^0.12.2": {
       "checksum": "271ca3eaf5d8c3b6aa9c9d2976b21820a8058fab016b6fcb73078e4655e928da8262cf40574ad5fa5073b3892d3c24140942e99726545c73273303dfcffe8385",
       "resolution": {
         "resolution": "oniguruma-parser@npm:0.12.2",
         "version": "0.12.2"
-      }
-    },
-    "oniguruma-to-es@npm:^4.3.3": {
-      "checksum": "df0d78f564bad964053717ef952fc61a5b1243e0b783885164ae8fcb3f7407377f2f47f392a29fcd8d26280981ad4274c0c0187f1b454918658c3b793306b8e1",
-      "resolution": {
-        "resolution": "oniguruma-to-es@npm:4.3.3",
-        "version": "4.3.3",
-        "dependencies": {
-          "oniguruma-parser": "^0.12.1",
-          "regex": "^6.0.1",
-          "regex-recursion": "^6.0.2"
-        }
       }
     },
     "oniguruma-to-es@npm:^4.3.4": {
@@ -17888,7 +14935,7 @@
         "version": "7.0.3"
       }
     },
-    "p-queue@npm:^8.1.0, p-queue@npm:^8.1.1": {
+    "p-queue@npm:^8.1.1": {
       "checksum": "80ec8e1d3e8b8c17834dda1ce3ea3c5bc7d53636c93b40c715cc2189129cc68c7898f922cfd4846eb40d7705cb6ea036f26bc7f50985ba37c7ded5360c7ffef5",
       "resolution": {
         "resolution": "p-queue@npm:8.1.1",
@@ -17962,36 +15009,6 @@
         "version": "1.6.0"
       }
     },
-    "pagefind@npm:^1.3.0": {
-      "checksum": "cdf015a8934ac5bc168564d0c6d14b5fea069656bbf2eb55ab01c28380a2d01eca806b77962ccb41f7c627c3c40fea8cd30d2993da4b306b5a75619d63081fec",
-      "resolution": {
-        "resolution": "pagefind@npm:1.4.0",
-        "version": "1.4.0",
-        "dependencies": {
-          "@pagefind/darwin-arm64": "1.4.0",
-          "@pagefind/darwin-x64": "1.4.0",
-          "@pagefind/freebsd-x64": "1.4.0",
-          "@pagefind/linux-arm64": "1.4.0",
-          "@pagefind/linux-x64": "1.4.0",
-          "@pagefind/windows-x64": "1.4.0"
-        },
-        "optionalDependencies": [
-          "@pagefind/darwin-arm64",
-          "@pagefind/darwin-x64",
-          "@pagefind/freebsd-x64",
-          "@pagefind/linux-arm64",
-          "@pagefind/linux-x64",
-          "@pagefind/windows-x64"
-        ]
-      }
-    },
-    "pako@npm:^0.2.5": {
-      "checksum": "2ebf95799cdbee909cd8f4dc612a2b0a1fbd2a5e7bc45b2181b22211a038580dd74e15ec40428d9abf226232f0c40f640aef024e7783a6267917f280492f7c52",
-      "resolution": {
-        "resolution": "pako@npm:0.2.9",
-        "version": "0.2.9"
-      }
-    },
     "parent-module@npm:^1.0.0": {
       "checksum": "ff42d946d5b60f129e727695d5f0011adf5082f1e51a88e72ad09a8d39470ba21a5aa8d7e67e92a2b0db744129a7edcc4882bf45230983d4e8301409ba0a6e5e",
       "resolution": {
@@ -18046,7 +15063,7 @@
         }
       }
     },
-    "parse-path@npm:*, parse-path@npm:^7.0.0": {
+    "parse-path@npm:^7.0.0": {
       "checksum": "6410a92924b4a97376d980b00fd892bdc102f8affefdd68221d3bf5fad0f291f412aaecfb65e253bbc487223a4e1907d322a82ab491cb8aa41d7f68128cc6cb1",
       "resolution": {
         "resolution": "parse-path@npm:7.1.0",
@@ -18062,17 +15079,6 @@
         "resolution": "parse-url@npm:8.1.0",
         "version": "8.1.0",
         "dependencies": {
-          "parse-path": "^7.0.0"
-        }
-      }
-    },
-    "parse-url@npm:^9.2.0": {
-      "checksum": "0b81698cd024d065e271f38412038491bb309233b1bbf683c7771de2ef83d9ae346ef34cd491149578d1741aaab379754663cbb570c6863770858bad9733370b",
-      "resolution": {
-        "resolution": "parse-url@npm:9.2.0",
-        "version": "9.2.0",
-        "dependencies": {
-          "@types/parse-path": "^7.0.0",
           "parse-path": "^7.0.0"
         }
       }
@@ -18099,17 +15105,6 @@
       "resolution": {
         "resolution": "patch-console@npm:1.0.0",
         "version": "1.0.0"
-      }
-    },
-    "path@npm:^0.12.7": {
-      "checksum": "e26a81380641590b51ae004bda32f6ce3ec01fe152227ab0e525ec8a4539091170c67d69adaab84ea4695b26806227fd64e4e142a57a250e555d0e4f9f16e4e3",
-      "resolution": {
-        "resolution": "path@npm:0.12.7",
-        "version": "0.12.7",
-        "dependencies": {
-          "process": "^0.11.1",
-          "util": "^0.10.3"
-        }
       }
     },
     "path-data-parser@npm:0.1.0, path-data-parser@npm:^0.1.0": {
@@ -18169,13 +15164,6 @@
         }
       }
     },
-    "path-type@npm:^4.0.0": {
-      "checksum": "5f23f39076958fd3a49cecc1ce6075a612b321b34135d00e7f5e8d0ce83cf927e83f377a4bdfc232d9af3aa6e5b528315a6f9b4c648ec64b144191c926c4ebe6",
-      "resolution": {
-        "resolution": "path-type@npm:4.0.0",
-        "version": "4.0.0"
-      }
-    },
     "pem@npm:^1.14.8": {
       "checksum": "7d2caea55450c1a4fce552a10baf247e123370a969ffd7336bc8702158e29d36ec6757b5a7c8f44feea4c6171738d2e442e2d3144c3cea9b6fef0a6deb7085af",
       "resolution": {
@@ -18210,7 +15198,7 @@
         "version": "1.1.1"
       }
     },
-    "picomatch@npm:^2.0.4, picomatch@npm:^2.2.2, picomatch@npm:^2.2.3, picomatch@npm:^2.3.1": {
+    "picomatch@npm:^2.0.4, picomatch@npm:^2.2.3, picomatch@npm:^2.3.1": {
       "checksum": "67871cb08eb3de5e9fa806f35956fb4c9cf9d4570746d3236d97548316eca69deafad7cf4f2386bd35dea2a01f92d5ea7a6188cd4e7ab22fe15913f103f9f0ef",
       "resolution": {
         "resolution": "picomatch@npm:2.3.1",
@@ -18273,18 +15261,6 @@
         "version": "1.1.0"
       }
     },
-    "postcss@npm:^8.4.38, postcss@npm:^8.5.3, postcss@npm:^8.5.6": {
-      "checksum": "fdb1f8c3dc77416c7d647da9b247a0619ac3ead631734e57425f935bb5309a4b2310e286ac8504b6f2f3d5fb8ff963687d5253ee97a388e37fc53f50f06f1b6c",
-      "resolution": {
-        "resolution": "postcss@npm:8.5.6",
-        "version": "8.5.6",
-        "dependencies": {
-          "nanoid": "^3.3.11",
-          "picocolors": "^1.1.1",
-          "source-map-js": "^1.2.1"
-        }
-      }
-    },
     "postcss@npm:^8.5.14": {
       "checksum": "55961f20c35d0d2a648a7db7d9156384d2c5bfe252aac8556559e33926b5ccc097882b98bc03e9edeaf3ea6b88f896f1099ec34a1a8c3980d5b3b7dc112f133f",
       "resolution": {
@@ -18297,76 +15273,15 @@
         }
       }
     },
-    "postcss-nested@npm:^6.0.1": {
-      "checksum": "e69bbc196079ed36d5b4e7b2d6c1ad8811df71489e02710803d0ac6fed0d588f4e185a35440c04aa9305775187db8bb4eba9e9b85ee8a83647e3f153f5ee6078",
+    "postcss@npm:^8.5.3, postcss@npm:^8.5.6": {
+      "checksum": "fdb1f8c3dc77416c7d647da9b247a0619ac3ead631734e57425f935bb5309a4b2310e286ac8504b6f2f3d5fb8ff963687d5253ee97a388e37fc53f50f06f1b6c",
       "resolution": {
-        "resolution": "postcss-nested@npm:6.2.0",
-        "version": "6.2.0",
+        "resolution": "postcss@npm:8.5.6",
+        "version": "8.5.6",
         "dependencies": {
-          "postcss-selector-parser": "^6.1.1"
-        },
-        "peerDependencies": {
-          "postcss": "^8.2.14"
-        }
-      }
-    },
-    "postcss-selector-parser@npm:^6.1.1": {
-      "checksum": "c9e27ee723ad3856f80d2fa7a95da089d35e4010d1111865c45dc6203b59c309858d15b9af52225f4059eb3dbb661127cd5d2a53bf061bc96dfc4227fcb5f95d",
-      "resolution": {
-        "resolution": "postcss-selector-parser@npm:6.1.2",
-        "version": "6.1.2",
-        "dependencies": {
-          "cssesc": "^3.0.0",
-          "util-deprecate": "^1.0.2"
-        }
-      }
-    },
-    "preact@npm:^10.0.0, preact@npm:^10.10.0, preact@npm:^10.26.9": {
-      "checksum": "dcc663f6b87693eb5176298d550c4fb3de76d940ebc4a247854803bebffa3f18a8e4f68db69c7173a0b8ab38afa456010ebd3328ffb756678492a116a1c2fe83",
-      "resolution": {
-        "resolution": "preact@npm:10.27.2",
-        "version": "10.27.2"
-      }
-    },
-    "preact-iso@npm:^2.9.2": {
-      "checksum": "c2a14e011b4b4b2cf2568d5263afd2003b6a20d14550558facca287f7adc69083c90969e714b61b6de1f180974b98ba61b7316318ea7a2a99905a60928cc77ca",
-      "resolution": {
-        "resolution": "preact-iso@npm:2.11.0",
-        "version": "2.11.0",
-        "peerDependencies": {
-          "preact": ">=10 || >= 11.0.0-0",
-          "preact-render-to-string": ">=6.4.0"
-        }
-      }
-    },
-    "preact-render-to-string@npm:^6.6.1": {
-      "checksum": "9514072e729946c9ef8b93b50ce688d91a6d4e31373331133ef474885ad2bffa65453791b3b966ae2ebcb3b1bde4af5acc736b8c084ef88dba348a79cae70d38",
-      "resolution": {
-        "resolution": "preact-render-to-string@npm:6.6.2",
-        "version": "6.6.2",
-        "peerDependencies": {
-          "preact": ">=10 || >= 11.0.0-0"
-        }
-      }
-    },
-    "prebuild-install@npm:^7.1.1": {
-      "checksum": "e739aa77b63030be9dda257ea86eeca9c4a84b109ddf99a1be8a5ed0ef63c44e45d448e20b125af3fa0016c3379a6cb2e469c4335a8e69994a9ab9cc14ea5c37",
-      "resolution": {
-        "resolution": "prebuild-install@npm:7.1.3",
-        "version": "7.1.3",
-        "dependencies": {
-          "detect-libc": "^2.0.0",
-          "expand-template": "^2.0.3",
-          "github-from-package": "0.0.0",
-          "minimist": "^1.2.3",
-          "mkdirp-classic": "^0.5.3",
-          "napi-build-utils": "^2.0.0",
-          "node-abi": "^3.3.0",
-          "pump": "^3.0.0",
-          "rc": "^1.2.7",
-          "simple-get": "^4.0.0",
-          "tar-fs": "^2.0.0",
-          "tunnel-agent": "^0.6.0"
+          "nanoid": "^3.3.11",
+          "picocolors": "^1.1.1",
+          "source-map-js": "^1.2.1"
         }
       }
     },
@@ -18415,13 +15330,6 @@
       "resolution": {
         "resolution": "proc-log@npm:6.1.0",
         "version": "6.1.0"
-      }
-    },
-    "process@npm:^0.11.1": {
-      "checksum": "a8d0d0ce60e1fffd1c3378cec967a378c339d42580d10f6d462e95024e4e38385fee3010afe23372d4c8bfcc4df3869732c98611d68ad874166e70d03815c151",
-      "resolution": {
-        "resolution": "process@npm:0.11.10",
-        "version": "0.11.10"
       }
     },
     "process-nextick-args@npm:~2.0.0": {
@@ -18584,13 +15492,6 @@
         "version": "6.1.0"
       }
     },
-    "qs@npm:^6.5.1 < 6.10": {
-      "checksum": "2512dff706b16cdd6ced5f5ebbae78898d89baa991336ca882b2771deec8cf2a47688509fbe4227c2a1c0186608bb750e972bdb9bd48d7672dc4eac42fdd0245",
-      "resolution": {
-        "resolution": "qs@npm:6.9.7",
-        "version": "6.9.7"
-      }
-    },
     "queue-microtask@npm:^1.2.2": {
       "checksum": "93500e04cf48432067c863e79d9c2cbbea5398f080d92cc2984a2afcdecd0cadfd818c1d3bcbac11dff1b73ec1f61ebbb74f60be2967435a22a50c881dc10358",
       "resolution": {
@@ -18629,19 +15530,6 @@
       "resolution": {
         "resolution": "range-parser@npm:1.2.1",
         "version": "1.2.1"
-      }
-    },
-    "rc@npm:^1.2.7": {
-      "checksum": "f608b8d1e74e5896c20f5eaa62c20ae86183e37b5bfa71c52baf28a41a7d6cd117ee880d481dbab99dae042dc66cd27d9aa539e77490736f14f6a9845d2b2e94",
-      "resolution": {
-        "resolution": "rc@npm:1.2.8",
-        "version": "1.2.8",
-        "dependencies": {
-          "deep-extend": "^0.6.0",
-          "ini": "~1.3.0",
-          "minimist": "^1.2.0",
-          "strip-json-comments": "~2.0.1"
-        }
       }
     },
     "react@npm:^17.0.2": {
@@ -18710,41 +15598,6 @@
         }
       }
     },
-    "react-instantsearch@npm:^7.16.0": {
-      "checksum": "3be2970ec6f647847f80a50c243b84a58ac79a290f5211746c9946c77cff0d853d248d6ce21351cbbdd8e8ebfdd9e05a21d11e98d09c7f0a90b8e0b56f58c1cd",
-      "resolution": {
-        "resolution": "react-instantsearch@npm:7.16.3",
-        "version": "7.16.3",
-        "dependencies": {
-          "@babel/runtime": "^7.27.6",
-          "instantsearch-ui-components": "0.11.2",
-          "instantsearch.js": "4.80.0",
-          "react-instantsearch-core": "7.16.3"
-        },
-        "peerDependencies": {
-          "algoliasearch": ">= 3.1 < 6",
-          "react": ">= 16.8.0 < 20",
-          "react-dom": ">= 16.8.0 < 20"
-        }
-      }
-    },
-    "react-instantsearch-core@npm:7.16.3": {
-      "checksum": "46d48d4fc51034e979e7cdfb510c8fb5bb385b798f63a8ed3b76d8fbec26ae06a6fb9331242053971ec95b92266fa5388550c4fe8573dbd232a7c0fa5ccb76e8",
-      "resolution": {
-        "resolution": "react-instantsearch-core@npm:7.16.3",
-        "version": "7.16.3",
-        "dependencies": {
-          "@babel/runtime": "^7.27.6",
-          "algoliasearch-helper": "3.26.0",
-          "instantsearch.js": "4.80.0",
-          "use-sync-external-store": "^1.0.0"
-        },
-        "peerDependencies": {
-          "algoliasearch": ">= 3.1 < 6",
-          "react": ">= 16.8.0 < 20"
-        }
-      }
-    },
     "react-is@npm:^16.13.1": {
       "checksum": "6c97c7175e98c76ecc2f907ed905ae1339869ce145504b8a79b60d7b31822e674ba6ab209be17c1d45712444b70b871f309759b8bbe5b8d8cb0acbb25e2b133f",
       "resolution": {
@@ -18757,23 +15610,6 @@
       "resolution": {
         "resolution": "react-is@npm:18.3.1",
         "version": "18.3.1"
-      }
-    },
-    "react-is@npm:^19.1.1": {
-      "checksum": "2063b12300b720df639f8115cc7be64a9ed7a59c9a35f2a4ae954c7a113a6c5c4e47fd5b0d49e2335362c00f77947e6fa73dd1dc3488c149e870cc3fa86d1947",
-      "resolution": {
-        "resolution": "react-is@npm:19.2.0",
-        "version": "19.2.0"
-      }
-    },
-    "react-json-doc@npm:^2.3.5": {
-      "checksum": "2297b01bd2438edfe398750eaf4a51c9348b0f47736f9a124a8cd5620147bdb56baf4896276f24a089cee35575cef013cf21698f052a59a8fdbecf1f9d8cfabb",
-      "resolution": {
-        "resolution": "react-json-doc@npm:2.3.5",
-        "version": "2.3.5",
-        "peerDependencies": {
-          "react": "*"
-        }
       }
     },
     "react-markdown@npm:^10.1.0": {
@@ -18815,7 +15651,7 @@
         }
       }
     },
-    "react-redux@npm:8.x.x || 9.x.x, react-redux@npm:^9.2.0": {
+    "react-redux@npm:^9.2.0": {
       "checksum": "e241aa4fffcba5d68f5c3046318a7a29f39786f84e0533444436ee0ccccbe8c5f35e891efb28bf8fc999ec74057d1eea9ad56278320fca4eb3b76afc05a7237e",
       "resolution": {
         "resolution": "react-redux@npm:9.2.0",
@@ -18870,13 +15706,6 @@
         }
       }
     },
-    "readdirp@npm:^4.0.1": {
-      "checksum": "f64e443832c6291ee16adc0d2eeb158037116a71d6ffacabf77e9ffc61366e6fbaad53fc254d4ce8252172888b05ebed561d21c561c70a47cc177a612867a5b0",
-      "resolution": {
-        "resolution": "readdirp@npm:4.1.2",
-        "version": "4.1.2"
-      }
-    },
     "readdirp@npm:^5.0.0": {
       "checksum": "0eb4c371831fc3dbf8ab33cd2bdda9b120f0e047ae1e733a02f70d0351fb3f7b50658e18c90839b450313fa7463ae65e7bf531022fd116f6818eb19378a13f31",
       "resolution": {
@@ -18884,98 +15713,11 @@
         "version": "5.0.0"
       }
     },
-    "reading-time@npm:^1.5.0": {
-      "checksum": "6dfba46e8073c19d2e6d474c24c1cc2814f8ef43350b7ce1d7dc687b3d9bb179947ca6f121f74d7e7384a5bdfa71dd3a7f61b323b02f73ea11511c06e9384000",
-      "resolution": {
-        "resolution": "reading-time@npm:1.5.0",
-        "version": "1.5.0"
-      }
-    },
     "readline-sync@npm:1.4.9": {
       "checksum": "62370d1b21bf83c189428b9bf879190f0fc052ef96ae6f53788cc2e8c507e3c831be00f9d93225da262f8d3f9cfe257f9e8b0092d0b0edc2e0d9908d66e6be4c",
       "resolution": {
         "resolution": "readline-sync@npm:1.4.9",
         "version": "1.4.9"
-      }
-    },
-    "recharts@npm:^3.1.0": {
-      "checksum": "f584b5e7b873744906a7458816d039fe04b509fb94547954d6f99f4e33681dfe3d78144c367d5738d6e4b15b5aabdcb07fcba8ef0fdc1eb1fd679036f276f54c",
-      "resolution": {
-        "resolution": "recharts@npm:3.2.1",
-        "version": "3.2.1",
-        "dependencies": {
-          "@reduxjs/toolkit": "1.x.x || 2.x.x",
-          "clsx": "^2.1.1",
-          "decimal.js-light": "^2.5.1",
-          "es-toolkit": "^1.39.3",
-          "eventemitter3": "^5.0.1",
-          "immer": "^10.1.1",
-          "react-redux": "8.x.x || 9.x.x",
-          "reselect": "5.1.1",
-          "tiny-invariant": "^1.3.3",
-          "use-sync-external-store": "^1.2.2",
-          "victory-vendor": "^37.0.2"
-        },
-        "peerDependencies": {
-          "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-          "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-          "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-        }
-      }
-    },
-    "recma-build-jsx@npm:^1.0.0": {
-      "checksum": "256ec4d36669afb8212df5ce7842309684cfc5f90862fcf6f976c427d71533acffedbc2fcad3c576b0e8e1156cd49d66962ea59c0abeacc25c917bab8577fb06",
-      "resolution": {
-        "resolution": "recma-build-jsx@npm:1.0.0",
-        "version": "1.0.0",
-        "dependencies": {
-          "@types/estree": "^1.0.0",
-          "estree-util-build-jsx": "^3.0.0",
-          "vfile": "^6.0.0"
-        }
-      }
-    },
-    "recma-jsx@npm:^1.0.0": {
-      "checksum": "afece3743953b17f9c22face4ec6818c857559aa257f3d923ef2c89210246c860c2b88c9132ac745537a6170beb3352fe9aadb2bf936cccefc59d5d2efc8984d",
-      "resolution": {
-        "resolution": "recma-jsx@npm:1.0.1",
-        "version": "1.0.1",
-        "dependencies": {
-          "acorn-jsx": "^5.0.0",
-          "estree-util-to-js": "^2.0.0",
-          "recma-parse": "^1.0.0",
-          "recma-stringify": "^1.0.0",
-          "unified": "^11.0.0"
-        },
-        "peerDependencies": {
-          "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
-        }
-      }
-    },
-    "recma-parse@npm:^1.0.0": {
-      "checksum": "b752b736770f8a4ee35daf1f33bb02927a96098ed0e45dcfcca7c40ac92ae983ee54e00576837cd9051189fcd4a8279550f4c70b6d8b5c721244a75633c1b896",
-      "resolution": {
-        "resolution": "recma-parse@npm:1.0.0",
-        "version": "1.0.0",
-        "dependencies": {
-          "@types/estree": "^1.0.0",
-          "esast-util-from-js": "^2.0.0",
-          "unified": "^11.0.0",
-          "vfile": "^6.0.0"
-        }
-      }
-    },
-    "recma-stringify@npm:^1.0.0": {
-      "checksum": "4db64f71ad78bd88e998e83288e99e2846a62d03ba82db07f447065096a19380f61f0df8149c068315373f1a2272b89a66b752bab010997bf7f0506033fbaff7",
-      "resolution": {
-        "resolution": "recma-stringify@npm:1.0.0",
-        "version": "1.0.0",
-        "dependencies": {
-          "@types/estree": "^1.0.0",
-          "estree-util-to-js": "^2.0.0",
-          "unified": "^11.0.0",
-          "vfile": "^6.0.0"
-        }
       }
     },
     "redux@npm:^5.0.1": {
@@ -19009,16 +15751,6 @@
           "get-intrinsic": "^1.2.7",
           "get-proto": "^1.0.1",
           "which-builtin-type": "^1.2.1"
-        }
-      }
-    },
-    "regex@npm:^6.0.1": {
-      "checksum": "0dd76a1cb7976109a9837804a0b9133297fc455ee511d6917be03aab9ca977c850a46221db88e2b432252ecd74ff14c7e80face9fd1fb2b4dbac59195d250380",
-      "resolution": {
-        "resolution": "regex@npm:6.0.1",
-        "version": "6.0.1",
-        "dependencies": {
-          "regex-utilities": "^2.3.0"
         }
       }
     },
@@ -19064,7 +15796,7 @@
         }
       }
     },
-    "rehype@npm:^13.0.1, rehype@npm:^13.0.2": {
+    "rehype@npm:^13.0.2": {
       "checksum": "3cf316443b79ded681d007909358db82c7d5c30e6c688539607e02a9534219563d13f8e38b0995d0ba585b2355a406dabb6c0765496c72b16b3878597e2f1116",
       "resolution": {
         "resolution": "rehype@npm:13.0.2",
@@ -19074,27 +15806,6 @@
           "rehype-parse": "^9.0.0",
           "rehype-stringify": "^10.0.0",
           "unified": "^11.0.0"
-        }
-      }
-    },
-    "rehype-expressive-code@npm:^0.41.3": {
-      "checksum": "e557a8c22cabc639d60c7265d24ca50074670e1eff2e33b7395d027033213ae21f737d6c2461e075b46e7737c22f3ed318c992b2a4d0ac4e58ee6cfe4082dc8d",
-      "resolution": {
-        "resolution": "rehype-expressive-code@npm:0.41.3",
-        "version": "0.41.3",
-        "dependencies": {
-          "expressive-code": "^0.41.3"
-        }
-      }
-    },
-    "rehype-format@npm:^5.0.0": {
-      "checksum": "86b5d1d3c957d608460a8f17784efc3ab45612e22f588490cce574ce077b6e25868436dbd305a9eae55ed4fa8cbbcc80814eeeaf4913b2a8f91f18bc6539b47a",
-      "resolution": {
-        "resolution": "rehype-format@npm:5.0.1",
-        "version": "5.0.1",
-        "dependencies": {
-          "@types/hast": "^3.0.0",
-          "hast-util-format": "^1.0.0"
         }
       }
     },
@@ -19196,18 +15907,6 @@
         }
       }
     },
-    "rehype-recma@npm:^1.0.0": {
-      "checksum": "6f4def2694f43eb5e34161418defd9c94f4435c825a785636a400611b4d9a14eba585f2f7f78e6b6beb140e10bd322aa444a0659abfb315471b7b44bd56a6ec9",
-      "resolution": {
-        "resolution": "rehype-recma@npm:1.0.0",
-        "version": "1.0.0",
-        "dependencies": {
-          "@types/estree": "^1.0.0",
-          "@types/hast": "^3.0.0",
-          "hast-util-to-estree": "^3.0.0"
-        }
-      }
-    },
     "rehype-stringify@npm:^10.0.0, rehype-stringify@npm:^10.0.1": {
       "checksum": "ebbd140f5707e155609ed9b1520e8075995d85c028f4f8bde3f2c8f33febc6b38cc114ae38ee3e2e3503af135f519ab8f2d0a185b7b9ba0c361ac557f7d5d72d",
       "resolution": {
@@ -19216,19 +15915,6 @@
         "dependencies": {
           "@types/hast": "^3.0.0",
           "hast-util-to-html": "^9.0.0",
-          "unified": "^11.0.0"
-        }
-      }
-    },
-    "remark-directive@npm:^3.0.0": {
-      "checksum": "2120ba838808d3b6184b6824f707bfc915261c28324317a540ddc1fee84cf9030fa27fa7f3df2fc3a133ea2aa90e455f6ccc3f218fca7cd36d3e70ffdfce58c2",
-      "resolution": {
-        "resolution": "remark-directive@npm:3.0.1",
-        "version": "3.0.1",
-        "dependencies": {
-          "@types/mdast": "^4.0.0",
-          "mdast-util-directive": "^3.0.0",
-          "micromark-extension-directive": "^3.0.0",
           "unified": "^11.0.0"
         }
       }
@@ -19258,17 +15944,6 @@
           "remark-parse": "^11.0.0",
           "remark-stringify": "^11.0.0",
           "unified": "^11.0.0"
-        }
-      }
-    },
-    "remark-mdx@npm:^3.0.0": {
-      "checksum": "50aaaae80a43dcec97060a3df0ad797a0d4a37722b5e65f908960853bb12ed1a99468c615985cd8e562c44671e307d3cf2763d4409d15fa71bcd6281684dcad5",
-      "resolution": {
-        "resolution": "remark-mdx@npm:3.1.1",
-        "version": "3.1.1",
-        "dependencies": {
-          "mdast-util-mdx": "^3.0.0",
-          "micromark-extension-mdxjs": "^3.0.0"
         }
       }
     },
@@ -19324,13 +15999,6 @@
         }
       }
     },
-    "repeat-string@npm:^1.6.1": {
-      "checksum": "4ee83903cfd901b7a508acc26c4a36f952d323163b1e73c3856e5082cb92b53f94f1c2f506a8cb38a0b50a6152c2df794d105ea5337250a0ebe960756e4dd7be",
-      "resolution": {
-        "resolution": "repeat-string@npm:1.6.1",
-        "version": "1.6.1"
-      }
-    },
     "require-directory@npm:^2.1.1": {
       "checksum": "c4eca91efb53bc18450818b405e799408fe94c59134cf97be798204bf933e6c5d7020e1f7dc4daa1cb12249c43903f34899a8225900817e439992111fd624589",
       "resolution": {
@@ -19338,7 +16006,7 @@
         "version": "2.1.1"
       }
     },
-    "reselect@npm:5.1.1, reselect@npm:^5.1.0, reselect@npm:^5.1.1": {
+    "reselect@npm:^5.1.0": {
       "checksum": "de13a399262e6a063554906ca0d8582dcc66b972ec787339d8677bad33476e831f3cf1ed27ed2009f06c68a0d1f6f14474d687dedf53bc8a48d1cd795964c4cf",
       "resolution": {
         "resolution": "reselect@npm:5.1.1",
@@ -19352,18 +16020,6 @@
         "version": "1.22.11",
         "dependencies": {
           "is-core-module": "^2.16.1",
-          "path-parse": "^1.0.7",
-          "supports-preserve-symlinks-flag": "^1.0.0"
-        }
-      }
-    },
-    "resolve@npm:^1.22.10": {
-      "checksum": "a8fa3a9cf2c12322ee0093be9cdc4d5c51deac2f0e8a86962b95d4425f9f5aaaa105453addc7bde21a9719f099553ac8a8ede444742cdd21e898d88f3baae5f9",
-      "resolution": {
-        "resolution": "resolve@npm:1.22.10",
-        "version": "1.22.10",
-        "dependencies": {
-          "is-core-module": "^2.16.0",
           "path-parse": "^1.0.7",
           "supports-preserve-symlinks-flag": "^1.0.0"
         }
@@ -19412,7 +16068,7 @@
         "version": "5.0.0"
       }
     },
-    "resolve.exports@npm:^2.0.0, resolve.exports@npm:^2.0.3": {
+    "resolve.exports@npm:^2.0.0": {
       "checksum": "7db5c0f704791531d9d5923a5d6ef73cea8e447c08bd9e889f7f037a96e1dd81f49e5a7d2ece5a02515a502ddd8ae2b193bd904813ac0ae5a817ebb8cfff2586",
       "resolution": {
         "resolution": "resolve.exports@npm:2.0.3",
@@ -19438,13 +16094,6 @@
           "onetime": "^5.1.0",
           "signal-exit": "^3.0.2"
         }
-      }
-    },
-    "restructure@npm:^3.0.0": {
-      "checksum": "1e89162bc3e9565c68d74227f6b97a6a518675c2bf9c9899b417484e1d44a8f8efe80f7eb894a4b0c06b6a1b6143307daa780e8747a180f79b3945c5b72bdd24",
-      "resolution": {
-        "resolution": "restructure@npm:3.0.2",
-        "version": "3.0.2"
       }
     },
     "retext@npm:^9.0.0": {
@@ -19662,7 +16311,7 @@
         }
       }
     },
-    "safe-buffer@npm:^5.0.1, safe-buffer@npm:^5.1.1, safe-buffer@npm:^5.2.1, safe-buffer@npm:~5.2.0": {
+    "safe-buffer@npm:^5.1.1, safe-buffer@npm:^5.2.1, safe-buffer@npm:~5.2.0": {
       "checksum": "306778e510c392b6f54df72b8b4ca2d4c074e0009c9237f1afe3dda7d92e21a69fffcc7e23e6f5e18a46f47edaad8737424f7d32639f1a2025761a87080363d9",
       "resolution": {
         "resolution": "safe-buffer@npm:5.2.1",
@@ -19706,13 +16355,6 @@
         "version": "2.1.2"
       }
     },
-    "sax@npm:^1.2.4": {
-      "checksum": "1ce8f8404c0e506cb3479385fe11ce6c8786c99190eeca8d4e6843d11b5558e15a83d795466de36b1767af763fd90a61cb9962c915fbe24618e470fc82678d5d",
-      "resolution": {
-        "resolution": "sax@npm:1.4.1",
-        "version": "1.4.1"
-      }
-    },
     "sax@npm:^1.4.1, sax@npm:^1.5.0": {
       "checksum": "c025ef102458472436150bb1457157ea5d67df11d24afaabad8baa779ebc27067aad052e945e26d683bf259cb76c522b78a5e48d9a9cd3a33dda8fc2212d9f74",
       "resolution": {
@@ -19746,13 +16388,6 @@
       "resolution": {
         "resolution": "scheduler@npm:0.27.0",
         "version": "0.27.0"
-      }
-    },
-    "search-insights@npm:^2.17.2": {
-      "checksum": "26996ffb1b511cc0c774bcd39cf0cfdde4ede721bf450cb6a32acb53f422450bb1149ba75a397161592d3e4fb0bc9ee4c4f2d73389dd549e5f6121a21872246f",
-      "resolution": {
-        "resolution": "search-insights@npm:2.17.3",
-        "version": "2.17.3"
       }
     },
     "semver@npm:^6.3.0, semver@npm:^6.3.1": {
@@ -19899,24 +16534,6 @@
         "version": "1.2.0"
       }
     },
-    "sharp@npm:^0.32.5": {
-      "checksum": "be9b564eeeb0e8bc4dfe2594955e2d4256ab5653a5be4ec1c78f58089c3138e942562e5b2b8f61ef084af284b0b788112efcbd14e036608b7f56631dc9886240",
-      "resolution": {
-        "resolution": "sharp@npm:0.32.6",
-        "version": "0.32.6",
-        "dependencies": {
-          "color": "^4.2.3",
-          "detect-libc": "^2.0.2",
-          "node-addon-api": "^6.1.0",
-          "node-gyp": "*",
-          "prebuild-install": "^7.1.1",
-          "semver": "^7.5.4",
-          "simple-get": "^4.0.1",
-          "tar-fs": "^3.0.4",
-          "tunnel-agent": "^0.6.0"
-        }
-      }
-    },
     "sharp@npm:^0.34.0": {
       "checksum": "6f7223ba01cc53b27254116cb6022f55ff50b2f5d43b224ce276df30fa39e77449b58706a8e7ff7b81f7793843d43e4a1ab5658e1c1094a4f922bc133125f0fe",
       "resolution": {
@@ -19997,23 +16614,6 @@
       "resolution": {
         "resolution": "shell-quote@npm:1.8.3",
         "version": "1.8.3"
-      }
-    },
-    "shiki@npm:^3.12.0, shiki@npm:^3.12.2, shiki@npm:^3.2.2": {
-      "checksum": "e492e4cc7fa5139edf282282341e48082699cd902ec4052e27d6527d4fcb55760ed93682eab4c1a1f2959bbf883e6243742decd00f4e8ea440ea75e272916396",
-      "resolution": {
-        "resolution": "shiki@npm:3.13.0",
-        "version": "3.13.0",
-        "dependencies": {
-          "@shikijs/core": "3.13.0",
-          "@shikijs/engine-javascript": "3.13.0",
-          "@shikijs/engine-oniguruma": "3.13.0",
-          "@shikijs/langs": "3.13.0",
-          "@shikijs/themes": "3.13.0",
-          "@shikijs/types": "3.13.0",
-          "@shikijs/vscode-textmate": "^10.0.2",
-          "@types/hast": "^3.0.4"
-        }
       }
     },
     "shiki@npm:^3.21.0": {
@@ -20146,63 +16746,11 @@
         }
       }
     },
-    "simple-code-frame@npm:^1.3.0": {
-      "checksum": "1ccc587869104908f9cd27c085f69d87199489e1bcb0b0f46d761968150d37c30cea19bd410c4d4aaba9bf32bdefc9e02bcf76f2b0be9ecebbf6932354f4dfe7",
-      "resolution": {
-        "resolution": "simple-code-frame@npm:1.3.0",
-        "version": "1.3.0",
-        "dependencies": {
-          "kolorist": "^1.6.0"
-        }
-      }
-    },
-    "simple-concat@npm:^1.0.0": {
-      "checksum": "2b19e13fdca3749771e6b4b3d7a72fc576cea5d8d08da4de7fd94e6ed9a952a4b03d53faf1ca6712eca732064461321662bfe408419312e1ac391c8b71a98dac",
-      "resolution": {
-        "resolution": "simple-concat@npm:1.0.1",
-        "version": "1.0.1"
-      }
-    },
-    "simple-get@npm:^4.0.0, simple-get@npm:^4.0.1": {
-      "checksum": "e68577e72de0e0cfb2f3f329d1cd09536e7eb4df7da93fe7df54e862e18f0ab3b257e9280aca4b7703b20beb36d6cdb1e35485972d008c0fce10729227c43e88",
-      "resolution": {
-        "resolution": "simple-get@npm:4.0.1",
-        "version": "4.0.1",
-        "dependencies": {
-          "decompress-response": "^6.0.0",
-          "once": "^1.3.1",
-          "simple-concat": "^1.0.0"
-        }
-      }
-    },
-    "simple-swizzle@npm:^0.2.2": {
-      "checksum": "a4559da550651d854b66e51c8cb7c95779d7b4c9e15a2887d558ac1ddab27bd10fd5763e109e47e4d2c234e52ed9bc46455a96ea9eb9ff20c0d7687d043bf1fe",
-      "resolution": {
-        "resolution": "simple-swizzle@npm:0.2.4",
-        "version": "0.2.4",
-        "dependencies": {
-          "is-arrayish": "^0.3.1"
-        }
-      }
-    },
     "sisteransi@npm:^1.0.5": {
       "checksum": "03a3ceb09d17be9876f04a3569b84cf987fe44fd7f0642a731ba179e09b65c1760943440a38d1eaaad1f73f396e02de95e70802d59aa06397277c070bd376500",
       "resolution": {
         "resolution": "sisteransi@npm:1.0.5",
         "version": "1.0.5"
-      }
-    },
-    "sitemap@npm:^8.0.0": {
-      "checksum": "f9fb0ff1889ebb76330cc0cd477fe9294df54dfd9ac8247f8a020ba41d4621cc2ce17d7bfb410fdfcfa8fc5db131bace382c5f7a4937977eec332fba30911920",
-      "resolution": {
-        "resolution": "sitemap@npm:8.0.0",
-        "version": "8.0.0",
-        "dependencies": {
-          "@types/node": "^17.0.5",
-          "@types/sax": "^1.2.1",
-          "arg": "^5.0.0",
-          "sax": "^1.2.4"
-        }
       }
     },
     "sitemap@npm:^9.0.0": {
@@ -20244,29 +16792,11 @@
         "version": "4.2.0"
       }
     },
-    "smol-toml@npm:^1.4.2": {
-      "checksum": "e779b61606ae677eb5e5ad2569f4996e2163cbaa51a69c45344544af251d49932c3bac9060cb049b80147620ed1f245c11193819a3789c8a4eb078ceb40f5127",
-      "resolution": {
-        "resolution": "smol-toml@npm:1.4.2",
-        "version": "1.4.2"
-      }
-    },
     "smol-toml@npm:^1.6.0": {
       "checksum": "c71d5b5c1f1c7b24fdbec247b2030bd38b8f2a1318be0fcf18ee9e124cad42a95a4914fb72d1a4fb01d9244f0caacb3c711672e31e2b09d435afb3509a2abfe9",
       "resolution": {
         "resolution": "smol-toml@npm:1.6.1",
         "version": "1.6.1"
-      }
-    },
-    "snake-case@npm:^3.0.4": {
-      "checksum": "14df35a73844726b5093ad55f716c9ec18f9269e675239ea681c683cc9219555df7673e98e4ba435ff1f5304813b5775a50ba6b64a31608fbd783047f76b6c9c",
-      "resolution": {
-        "resolution": "snake-case@npm:3.0.4",
-        "version": "3.0.4",
-        "dependencies": {
-          "dot-case": "^3.0.4",
-          "tslib": "^2.0.3"
-        }
       }
     },
     "socks@npm:^2.8.3": {
@@ -20299,14 +16829,7 @@
         "version": "0.6.1"
       }
     },
-    "source-map@npm:^0.7.0, source-map@npm:^0.7.4, source-map@npm:^0.7.6": {
-      "checksum": "5d23ed7ef0ebf8340cfc505d4bf408f383370fbefeac65d82d0429ca664b078197a44488574f548c4a597dd302552e256343d44c1d491cad11c40ff96d96bf36",
-      "resolution": {
-        "resolution": "source-map@npm:0.7.6",
-        "version": "0.7.6"
-      }
-    },
-    "source-map-js@npm:^1.0.1, source-map-js@npm:^1.2.0, source-map-js@npm:^1.2.1": {
+    "source-map-js@npm:^1.0.1, source-map-js@npm:^1.2.1": {
       "checksum": "eee9990b542b063c21cc0785697b7576a44877f3b6e1632b015691240642b8e423a03a26e73124a3480b7247685f3b2fc67c528ff04b4f10205b693730cfc105",
       "resolution": {
         "resolution": "source-map-js@npm:1.2.1",
@@ -20358,13 +16881,6 @@
         }
       }
     },
-    "stack-trace@npm:^1.0.0-pre2": {
-      "checksum": "f218ad3e514f2ff4979126c0fac13d3fdf77f277200d3c972c557b985aaa71bd06fd2ae71b6c552472c388569968de8b1f27aea43dd2269f993a1a2c3ebcc5d4",
-      "resolution": {
-        "resolution": "stack-trace@npm:1.0.0-pre2",
-        "version": "1.0.0-pre2"
-      }
-    },
     "stack-utils@npm:^2.0.2, stack-utils@npm:^2.0.3": {
       "checksum": "cbb4bb44a71b6ab957134c96ca9a1ca9c8775f26e62f6145abb3e1ae388f603fadc8f9c7b2b0f49d9d4472e22b286614f0b486740838d5db691b136289057c2a",
       "resolution": {
@@ -20372,19 +16888,6 @@
         "version": "2.0.6",
         "dependencies": {
           "escape-string-regexp": "^2.0.0"
-        }
-      }
-    },
-    "starlight-auto-sidebar@npm:^0.1.4": {
-      "checksum": "81a4748cab254a33969f3159b9696f537c4522b5b6d1e80c4a3f352e993811f05580f59d5864b1eecd8b9a6e3089d2efdfb525f551f97161f48c5ad449bf0639",
-      "resolution": {
-        "resolution": "starlight-auto-sidebar@npm:0.1.4",
-        "version": "0.1.4",
-        "dependencies": {
-          "github-slugger": "^2.0.0"
-        },
-        "peerDependencies": {
-          "@astrojs/starlight": ">=0.32.0"
         }
       }
     },
@@ -20625,13 +17128,6 @@
         "version": "3.1.1"
       }
     },
-    "strip-json-comments@npm:~2.0.1": {
-      "checksum": "4c755591c03f52c7cfd08a1883bfa1eefcbd8c2e69ce769fd4b51decc5cb3899e85c4f4fd44539ce8bab8b6308d59f2c5b257293fa6efd67df13b2543be12e56",
-      "resolution": {
-        "resolution": "strip-json-comments@npm:2.0.1",
-        "version": "2.0.1"
-      }
-    },
     "style-to-js@npm:^1.0.0": {
       "checksum": "3f04b7a3434db11e5fb55497f30c28df39611adab914b79cd826a0139922d01a7a1009cd0e7ed63c6599d2c6b40432e971512bdf4804d9f55967c870e19ea585",
       "resolution": {
@@ -20649,16 +17145,6 @@
         "version": "1.0.9",
         "dependencies": {
           "inline-style-parser": "0.2.4"
-        }
-      }
-    },
-    "style-to-object@npm:^1.0.11": {
-      "checksum": "7633794d6fa2b5e91df520ee6c4a37abd3cbfb790beb4925d2f21db9bf038a5f4608fe57e471126a6d42f9aab269c03f377531034e19ae1ec71e4ef14cbe21e9",
-      "resolution": {
-        "resolution": "style-to-object@npm:1.0.12",
-        "version": "1.0.12",
-        "dependencies": {
-          "inline-style-parser": "0.2.6"
         }
       }
     },
@@ -20709,13 +17195,6 @@
         "version": "1.0.0"
       }
     },
-    "svg-parser@npm:^2.0.4": {
-      "checksum": "76e7cc9d0b4beddcebda96e3c41f0f54d2f759bc0b8212b31df0041529067530f219317f4a384ae9ab8e50584492be49fc7cc221693272b0569223981ea37945",
-      "resolution": {
-        "resolution": "svg-parser@npm:2.0.4",
-        "version": "2.0.4"
-      }
-    },
     "svgo@npm:^4.0.0": {
       "checksum": "dedd289c78b4e50f8d1ce7d1ffcac0ab67525096be65bb7872130a47e2190fc0c665fe73a2042ce5fbac7d57089a1fff4d92570b11349bb7ded3c20b725e6a93",
       "resolution": {
@@ -20730,34 +17209,6 @@
           "picocolors": "^1.1.1",
           "sax": "^1.5.0"
         }
-      }
-    },
-    "swr@npm:^2.2.5": {
-      "checksum": "a3b3763dc93e0743101bfe9a973cb7a8750396330e3347ffb33fbf5b0e0e59c7866bf2ba4511a52f5821c77570d05547418f66a9620d428c7d9a6854f9240f35",
-      "resolution": {
-        "resolution": "swr@npm:2.3.6",
-        "version": "2.3.6",
-        "dependencies": {
-          "dequal": "^2.0.3",
-          "use-sync-external-store": "^1.4.0"
-        },
-        "peerDependencies": {
-          "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-        }
-      }
-    },
-    "tabbable@npm:^6.2.0": {
-      "checksum": "faceef93063f262f7a5acdcb3832b6b76c338b50aae016352192b49acf3e0c66066140d67ea90177df37d871a361f9f66e6d8a93c95f64592e9f5a1f22cf3048",
-      "resolution": {
-        "resolution": "tabbable@npm:6.2.0",
-        "version": "6.2.0"
-      }
-    },
-    "tailwind-merge@npm:^3.3.1": {
-      "checksum": "4bc174edab95d696feaa8874cf8f7cb50fae3476a694ce42a9d73341a964abcff3f10ff443cb339ae1b507593d492fb1a97773ea2d6091569c5fbc886c175710",
-      "resolution": {
-        "resolution": "tailwind-merge@npm:3.3.1",
-        "version": "3.3.1"
       }
     },
     "tailwindcss@npm:4.1.14, tailwindcss@npm:^4.1.11": {
@@ -20841,36 +17292,6 @@
         }
       }
     },
-    "tar-fs@npm:^2.0.0": {
-      "checksum": "671215cf7e12150dd4681f4b13ef9176da1047853f77936024b4f0279a349562a6cb196b511459ecaa4e561477c1c5a042f89befe62869b890eaa2e9ebbc2701",
-      "resolution": {
-        "resolution": "tar-fs@npm:2.1.4",
-        "version": "2.1.4",
-        "dependencies": {
-          "chownr": "^1.1.1",
-          "mkdirp-classic": "^0.5.2",
-          "pump": "^3.0.0",
-          "tar-stream": "^2.1.4"
-        }
-      }
-    },
-    "tar-fs@npm:^3.0.4": {
-      "checksum": "abbd6ff86b2b6c278f98ecfbaa1a52764fe4dd1461b17cd7aead056ffc9b1e41cad5505d994caefb2fd4ce3c4610c8c33ed2626101103b1eab95386530f3cd9c",
-      "resolution": {
-        "resolution": "tar-fs@npm:3.1.1",
-        "version": "3.1.1",
-        "dependencies": {
-          "bare-fs": "^4.0.1",
-          "bare-path": "^3.0.0",
-          "pump": "^3.0.0",
-          "tar-stream": "^3.1.5"
-        },
-        "optionalDependencies": [
-          "bare-fs",
-          "bare-path"
-        ]
-      }
-    },
     "tar-fs@npm:^3.1.1": {
       "checksum": "f6433fa122af0a66dd48fa0211a794986fb57f801595bc6b5270543683e4fc34b42cdce4629f4b2eea6ec21d32843e7156e3b3b7c47b436024cd6238138e3d89",
       "resolution": {
@@ -20904,7 +17325,7 @@
         }
       }
     },
-    "tar-stream@npm:^2.0.1, tar-stream@npm:^2.1.4": {
+    "tar-stream@npm:^2.0.1": {
       "checksum": "f55a6c02d1aab7180a24f7288fd153f0af28103e93ac462014c734726828661a0c5900f38ce21055042cc084a94bbc76af776375d74012cb839d24b92d129914",
       "resolution": {
         "resolution": "tar-stream@npm:2.2.0",
@@ -20963,20 +17384,6 @@
         }
       }
     },
-    "three@npm:^0.180.0": {
-      "checksum": "9b49a11311ec01ac018578d090399988a61d4fbf0c6674ee2c0388a70762e14fff7259995c3ff56c6a5869a3da4fc366e23a6b7d8f38b9c79dd991a32e524e2f",
-      "resolution": {
-        "resolution": "three@npm:0.180.0",
-        "version": "0.180.0"
-      }
-    },
-    "throttleit@npm:2.1.0": {
-      "checksum": "442030796ace01bf2e8ae709e4b6cb71de6834e20c733a27574d4347d73bee1da6b21ec9483fa9d3bb5e7742289b666efe7df8f1b43d821b6db7290534195ea7",
-      "resolution": {
-        "resolution": "throttleit@npm:2.1.0",
-        "version": "2.1.0"
-      }
-    },
     "tiny-glob@npm:0.2.9": {
       "checksum": "5030793531491ef3919fef3a333ddc0d364bb070ab09fa2ba136d95c5ebacc5d6ea74c5cac98cbe127d1ca55a8d83661d45c1b5067b64c8574c148e9e3459590",
       "resolution": {
@@ -20988,25 +17395,11 @@
         }
       }
     },
-    "tiny-inflate@npm:^1.0.0, tiny-inflate@npm:^1.0.3": {
+    "tiny-inflate@npm:^1.0.3": {
       "checksum": "299d1ae2c9eb494ee9b5bac46a057b3071b56ff15b18f203dcc010bbfeba1043adf484127e7cb8779cb449a65a33548108162dae2e14e9e7605e65103a8995ec",
       "resolution": {
         "resolution": "tiny-inflate@npm:1.0.3",
         "version": "1.0.3"
-      }
-    },
-    "tiny-invariant@npm:^1.3.3": {
-      "checksum": "551e6873c9ce74ed259b9031756345e594dd3431d05a79d8e33a03b5609bd4fb8822f886ba30a43f7ef4370c52e6bd62edc4c710e0a10be03ce20b0d17578b8f",
-      "resolution": {
-        "resolution": "tiny-invariant@npm:1.3.3",
-        "version": "1.3.3"
-      }
-    },
-    "tinyexec@npm:^0.3.2": {
-      "checksum": "cf726d19ebd35b738c0e254fb82ebd060ca7a975e2e5e9b0c245e6ff087c243ce27ed70d72f9f31328c615e62299e0ac33c810ecb39fcd6da306134c0d7e4c04",
-      "resolution": {
-        "resolution": "tinyexec@npm:0.3.2",
-        "version": "0.3.2"
       }
     },
     "tinyexec@npm:^1.0.1, tinyexec@npm:^1.0.2": {
@@ -21016,7 +17409,7 @@
         "version": "1.1.2"
       }
     },
-    "tinyglobby@npm:^0.2.12, tinyglobby@npm:^0.2.13, tinyglobby@npm:^0.2.14, tinyglobby@npm:^0.2.15": {
+    "tinyglobby@npm:^0.2.13, tinyglobby@npm:^0.2.15": {
       "checksum": "57467da2137c5d1ae705ef8efee6edbe0558142d5d87bc35d09edde2325aa607e3a3f98c625bf7ab05de7e2f7f5bcd058178d5896232fa0525e47a3e499a8466",
       "resolution": {
         "resolution": "tinyglobby@npm:0.2.15",
@@ -21088,13 +17481,6 @@
         "version": "1.0.1"
       }
     },
-    "tr46@npm:~0.0.3": {
-      "checksum": "bbac0274ec26d2ac7eebc69f515024a2f4af07ade62ede39cddeb334f097febeef82d7d4a50e998269510dd835760748f720a0fa332dfb040042c800c5768bd6",
-      "resolution": {
-        "resolution": "tr46@npm:0.0.3",
-        "version": "0.0.3"
-      }
-    },
     "treeify@npm:^1.1.0": {
       "checksum": "3017cce4523997526124408d694c9c48323739b89917f163b70fd02cc4352872b2001a7b25aa7eb45eefa08af2cba6ce6288cbb5822ad1d5f04bffda95d54f5c",
       "resolution": {
@@ -21146,7 +17532,7 @@
         ]
       }
     },
-    "tslib@npm:^2.0.1, tslib@npm:^2.0.3, tslib@npm:^2.4.0, tslib@npm:^2.8.0, tslib@npm:^2.8.1": {
+    "tslib@npm:^2.0.1, tslib@npm:^2.4.0, tslib@npm:^2.8.1": {
       "checksum": "93bfec26e84243600f2fd0e9426bfca813cc6a22ecafecce1b938b4fd53f9fd0f1a569686908e7b79c6bd3bdb2ff87c7238994e5ffaf924ab3ffbfaca45c2e5d",
       "resolution": {
         "resolution": "tslib@npm:2.8.1",
@@ -21174,16 +17560,6 @@
           "@tufjs/models": "4.1.0",
           "debug": "^4.4.3",
           "make-fetch-happen": "^15.0.1"
-        }
-      }
-    },
-    "tunnel-agent@npm:^0.6.0": {
-      "checksum": "03e401b977c935621990eef07db0f9531615d7dbe58c9f5f8b23368f72f2ad8800ac146cae5ce73eaadea3e95a3db742ccc562d009b4213b842f8321b287f119",
-      "resolution": {
-        "resolution": "tunnel-agent@npm:0.6.0",
-        "version": "0.6.0",
-        "dependencies": {
-          "safe-buffer": "^5.0.1"
         }
       }
     },
@@ -21310,7 +17686,7 @@
         "version": "5.9.3"
       }
     },
-    "ufo@npm:^1.5.4, ufo@npm:^1.6.1": {
+    "ufo@npm:^1.6.1": {
       "checksum": "4f7318a30ff0ce7beef8be4fe615e8352f8f3404c0ba1585f4ab1cb0e21c4ae0732fccd62ae594239ace6360a49c170139d077fc303d2b2a372d35793551a0f0",
       "resolution": {
         "resolution": "ufo@npm:1.6.1",
@@ -21358,28 +17734,6 @@
         "version": "7.16.0"
       }
     },
-    "unicode-properties@npm:^1.4.0": {
-      "checksum": "76ffe428df47a4b6245a6585cf89301320e70f75bec9060cd12779e3fc416e1ca9726fa7b562dee5d32f3d5c9cbb3d1d96a73d1d4c7eec72d6301f59441f711c",
-      "resolution": {
-        "resolution": "unicode-properties@npm:1.4.1",
-        "version": "1.4.1",
-        "dependencies": {
-          "base64-js": "^1.3.0",
-          "unicode-trie": "^2.0.0"
-        }
-      }
-    },
-    "unicode-trie@npm:^2.0.0": {
-      "checksum": "5a2c50c5047749862adc80b62e132452ee11fd7618dea4c0303c684f70c28c1b3b713de072392e21acd3b7c39fdef29ef699288b37030b9709509923cd60e5d4",
-      "resolution": {
-        "resolution": "unicode-trie@npm:2.0.0",
-        "version": "2.0.0",
-        "dependencies": {
-          "pako": "^0.2.5",
-          "tiny-inflate": "^1.0.0"
-        }
-      }
-    },
     "unified@npm:^11.0.0, unified@npm:^11.0.4, unified@npm:^11.0.5": {
       "checksum": "d45451c1952950fe329d96d05bd1e2f47e53de14ef23675c8eed405b0e71abe3de530fa620e1aeb9b321f060076d51fc260bfc46239bcb928c9e9eda79401060",
       "resolution": {
@@ -21393,18 +17747,6 @@
           "is-plain-obj": "^4.0.0",
           "trough": "^2.0.0",
           "vfile": "^6.0.0"
-        }
-      }
-    },
-    "unifont@npm:~0.5.2": {
-      "checksum": "4456cd7b7eb67c2d9a706900083a6dc540917d6b03370b50f1438c98e8e2ac709fa60f591c02eb07a73df89d4a65b8df9599eaa8e4a9dca90ee1ab701c459f95",
-      "resolution": {
-        "resolution": "unifont@npm:0.5.2",
-        "version": "0.5.2",
-        "dependencies": {
-          "css-tree": "^3.0.0",
-          "ofetch": "^1.4.1",
-          "ohash": "^2.0.0"
         }
       }
     },
@@ -21460,13 +17802,6 @@
         }
       }
     },
-    "unist@npm:^0.0.1": {
-      "checksum": "242c95f369a857dfa34eaf14e80043900c2049f6e923cad732a9ce22b455b4bf298ef2d24cb6d91c2da4d29f68d1d64799f1209ce2af23fc75a59925a75cc31f",
-      "resolution": {
-        "resolution": "unist@npm:0.0.1",
-        "version": "0.0.1"
-      }
-    },
     "unist-util-find-after@npm:^5.0.0": {
       "checksum": "a12db5cc6aca8ab838326bfc04b9e5729bb75d36f2e8a0baf3669b65ec13c6961c97a99681a97d027a6fbabd85270dd0f5e41ecbce4b466bc234bb55b6ae5013",
       "resolution": {
@@ -21504,16 +17839,6 @@
       "resolution": {
         "resolution": "unist-util-position@npm:5.0.0",
         "version": "5.0.0",
-        "dependencies": {
-          "@types/unist": "^3.0.0"
-        }
-      }
-    },
-    "unist-util-position-from-estree@npm:^2.0.0": {
-      "checksum": "d6072e6fe67ab3fcce3a8462ea9459fbb4060a6b3c978233f53f3471379391d45fef97a16fa02be70fffea77e32fcca8f46fce01e72b3ed35f09aaea36d62fc6",
-      "resolution": {
-        "resolution": "unist-util-position-from-estree@npm:2.0.0",
-        "version": "2.0.0",
         "dependencies": {
           "@types/unist": "^3.0.0"
         }
@@ -21574,7 +17899,7 @@
         }
       }
     },
-    "unist-util-visit-parents@npm:^6.0.0, unist-util-visit-parents@npm:^6.0.1": {
+    "unist-util-visit-parents@npm:^6.0.0": {
       "checksum": "973ca256b5fb1171793f05f80b4851d01d6bddaa8de889bdebfacadd1e1300b32b2970a2a9c64e4531877fea5baf69e1b63a2bb015c2402211f2e68b58078fa1",
       "resolution": {
         "resolution": "unist-util-visit-parents@npm:6.0.1",
@@ -21615,65 +17940,6 @@
       "resolution": {
         "resolution": "unpipe@npm:1.0.0",
         "version": "1.0.0"
-      }
-    },
-    "unstorage@npm:^1.17.0": {
-      "checksum": "178fcdb5ac74bbdb484e9c5530f6189b16e965718e30dffa9c994beaad896ecb3c5f6672da9b71b17e356ed4af6cd84fd813012370ebb9083963bca2c20486ea",
-      "resolution": {
-        "resolution": "unstorage@npm:1.17.1",
-        "version": "1.17.1",
-        "dependencies": {
-          "anymatch": "^3.1.3",
-          "chokidar": "^4.0.3",
-          "destr": "^2.0.5",
-          "h3": "^1.15.4",
-          "lru-cache": "^10.4.3",
-          "node-fetch-native": "^1.6.7",
-          "ofetch": "^1.4.1",
-          "ufo": "^1.6.1"
-        },
-        "peerDependencies": {
-          "@azure/app-configuration": "^1.8.0",
-          "@azure/cosmos": "^4.2.0",
-          "@azure/data-tables": "^13.3.0",
-          "@azure/identity": "^4.6.0",
-          "@azure/keyvault-secrets": "^4.9.0",
-          "@azure/storage-blob": "^12.26.0",
-          "@capacitor/preferences": "^6.0.3 || ^7.0.0",
-          "@deno/kv": ">=0.9.0",
-          "@netlify/blobs": "^6.5.0 || ^7.0.0 || ^8.1.0 || ^9.0.0 || ^10.0.0",
-          "@planetscale/database": "^1.19.0",
-          "@upstash/redis": "^1.34.3",
-          "@vercel/blob": ">=0.27.1",
-          "@vercel/functions": "^2.2.12 || ^3.0.0",
-          "@vercel/kv": "^1.0.1",
-          "aws4fetch": "^1.0.20",
-          "db0": ">=0.2.1",
-          "idb-keyval": "^6.2.1",
-          "ioredis": "^5.4.2",
-          "uploadthing": "^7.4.4"
-        },
-        "optionalPeerDependencies": [
-          "@azure/app-configuration",
-          "@azure/cosmos",
-          "@azure/data-tables",
-          "@azure/identity",
-          "@azure/keyvault-secrets",
-          "@azure/storage-blob",
-          "@capacitor/preferences",
-          "@deno/kv",
-          "@netlify/blobs",
-          "@planetscale/database",
-          "@upstash/redis",
-          "@vercel/blob",
-          "@vercel/functions",
-          "@vercel/kv",
-          "aws4fetch",
-          "db0",
-          "idb-keyval",
-          "ioredis",
-          "uploadthing"
-        ]
       }
     },
     "unstorage@npm:^1.17.4": {
@@ -21759,7 +18025,7 @@
         }
       }
     },
-    "use-sync-external-store@npm:^1.0.0, use-sync-external-store@npm:^1.2.2, use-sync-external-store@npm:^1.4.0, use-sync-external-store@npm:^1.5.0, use-sync-external-store@npm:^1.6.0": {
+    "use-sync-external-store@npm:^1.4.0, use-sync-external-store@npm:^1.6.0": {
       "checksum": "6cd4699095cde3278147800f802d31e08f4b68f47ccbc4dd96ac27e6be4aacf1bb1bb37aa8a2bced80228fa6fdfb9680fc5586e3b8221a24b2d8b3ef5fbc577d",
       "resolution": {
         "resolution": "use-sync-external-store@npm:1.6.0",
@@ -21769,30 +18035,7 @@
         }
       }
     },
-    "usehooks-ts@npm:^3.1.1": {
-      "checksum": "520ce71e6c482212337c90ff2276ad1cb2d06bf2b1a2ee6853ca3b72231d25a4a47d8cdb4ac480045fa79f2d629f4896982949b7c188bb09f985ed1d441ed410",
-      "resolution": {
-        "resolution": "usehooks-ts@npm:3.1.1",
-        "version": "3.1.1",
-        "dependencies": {
-          "lodash.debounce": "^4.0.8"
-        },
-        "peerDependencies": {
-          "react": "^16.8.0  || ^17 || ^18 || ^19 || ^19.0.0-rc"
-        }
-      }
-    },
-    "util@npm:^0.10.3": {
-      "checksum": "9926ffd7f669f625a4bdc30598701d1ccc35b1c993ad5a8b3d3e4171f7e12564812cb3e7737c75208fd01c83780c4af5b578a3df015beaf28e5e5c5abfe7b2c9",
-      "resolution": {
-        "resolution": "util@npm:0.10.4",
-        "version": "0.10.4",
-        "dependencies": {
-          "inherits": "2.0.3"
-        }
-      }
-    },
-    "util-deprecate@npm:^1.0.1, util-deprecate@npm:^1.0.2, util-deprecate@npm:~1.0.1": {
+    "util-deprecate@npm:^1.0.1, util-deprecate@npm:~1.0.1": {
       "checksum": "a45bff6182b63811231d17662e20098174599aa15242d76009454678477a04213b394941b8620b893de3005d5c558f8d7a0a43b6b4f7afba94724343d56a26b5",
       "resolution": {
         "resolution": "util-deprecate@npm:1.0.2",
@@ -21825,7 +18068,7 @@
         }
       }
     },
-    "vfile@npm:^6.0.0, vfile@npm:^6.0.2, vfile@npm:^6.0.3": {
+    "vfile@npm:^6.0.0, vfile@npm:^6.0.3": {
       "checksum": "d9ee8eb51d90ea156956e178c9c15ffb394b2f5241f1a0299798d10ac6148426e816980248c8ec8fcda3540288bfb01f70b055963dd75a821aece32e90971514",
       "resolution": {
         "resolution": "vfile@npm:6.0.3",
@@ -21856,74 +18099,6 @@
           "@types/unist": "^3.0.0",
           "unist-util-stringify-position": "^4.0.0"
         }
-      }
-    },
-    "victory-vendor@npm:^37.0.2": {
-      "checksum": "d90665a05d016defca2b6e173c857afed566d530419d25af6f001219d3bde49d3bf571f723194ae6976b6647ab2d7dfb4fdb866b8406f6e436fb03c4456c9fe2",
-      "resolution": {
-        "resolution": "victory-vendor@npm:37.3.6",
-        "version": "37.3.6",
-        "dependencies": {
-          "@types/d3-array": "^3.0.3",
-          "@types/d3-ease": "^3.0.0",
-          "@types/d3-interpolate": "^3.0.1",
-          "@types/d3-scale": "^4.0.2",
-          "@types/d3-shape": "^3.1.0",
-          "@types/d3-time": "^3.0.0",
-          "@types/d3-timer": "^3.0.0",
-          "d3-array": "^3.1.6",
-          "d3-ease": "^3.0.1",
-          "d3-interpolate": "^3.0.1",
-          "d3-scale": "^4.0.2",
-          "d3-shape": "^3.1.0",
-          "d3-time": "^3.0.0",
-          "d3-timer": "^3.0.1"
-        }
-      }
-    },
-    "vite@npm:^6.3.6": {
-      "checksum": "6b7f5ba664d98370de97650d6cdf942feaf8a6d16a270d3ec1b40ed02aacbf476bfaf694ceb60bf25664f32251b6e6353ae6ef729f75071dd892c318ffaea38b",
-      "resolution": {
-        "resolution": "vite@npm:6.3.6",
-        "version": "6.3.6",
-        "dependencies": {
-          "esbuild": "^0.25.0",
-          "fdir": "^6.4.4",
-          "fsevents": "~2.3.3",
-          "picomatch": "^4.0.2",
-          "postcss": "^8.5.3",
-          "rollup": "^4.34.9",
-          "tinyglobby": "^0.2.13"
-        },
-        "peerDependencies": {
-          "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
-          "jiti": ">=1.21.0",
-          "less": "*",
-          "lightningcss": "^1.21.0",
-          "sass": "*",
-          "sass-embedded": "*",
-          "stylus": "*",
-          "sugarss": "*",
-          "terser": "^5.16.0",
-          "tsx": "^4.8.1",
-          "yaml": "^2.4.2"
-        },
-        "optionalDependencies": [
-          "fsevents"
-        ],
-        "optionalPeerDependencies": [
-          "@types/node",
-          "jiti",
-          "less",
-          "lightningcss",
-          "sass",
-          "sass-embedded",
-          "stylus",
-          "sugarss",
-          "terser",
-          "tsx",
-          "yaml"
-        ]
       }
     },
     "vite@npm:^6.4.1": {
@@ -22107,39 +18282,6 @@
         ]
       }
     },
-    "vite-plugin-svgr@npm:^4.3.0": {
-      "checksum": "0b6f8e787eaff6863c98e7f2ce1646f86e144401496d86c24e0fd6d4453eec4f431fd89358b989e59360f72426d14b794e6e0baecb90f6b2acc8e65710056920",
-      "resolution": {
-        "resolution": "vite-plugin-svgr@npm:4.5.0",
-        "version": "4.5.0",
-        "dependencies": {
-          "@rollup/pluginutils": "^5.2.0",
-          "@svgr/core": "^8.1.0",
-          "@svgr/plugin-jsx": "^8.1.0"
-        },
-        "peerDependencies": {
-          "vite": ">=2.6.0"
-        }
-      }
-    },
-    "vite-prerender-plugin@npm:^0.5.3": {
-      "checksum": "ead7797cfd0b4947446d0ab5d4c0444c5bd39d973c69e8904b1b4958c0efcc55c4987811a52875a4a641359bc4ef5eff46fdcb32777070e75931f4ef75a7616d",
-      "resolution": {
-        "resolution": "vite-prerender-plugin@npm:0.5.12",
-        "version": "0.5.12",
-        "dependencies": {
-          "kolorist": "^1.8.0",
-          "magic-string": "0.x >= 0.26.0",
-          "node-html-parser": "^6.1.12",
-          "simple-code-frame": "^1.3.0",
-          "source-map": "^0.7.4",
-          "stack-trace": "^1.0.0-pre2"
-        },
-        "peerDependencies": {
-          "vite": "5.x || 6.x || 7.x"
-        }
-      }
-    },
     "vitefu@npm:^1.1.1": {
       "checksum": "2b4f56d0fbe91ec1c9f5deef23c22c4cd7e5c0a713d6fd0b01fb963d45e17aae6a4b11f36ab3437e24c4b007b1ae545dfe73fbcd7192b13a74cb58ec42b3e4b7",
       "resolution": {
@@ -22177,24 +18319,6 @@
         "version": "0.4.1"
       }
     },
-    "webidl-conversions@npm:^3.0.0": {
-      "checksum": "0754c4a1e17fed9ad2459d324b9ac7974eb04b78f60af3a73272fb4fe93c66cf468fd7d89dc130285c87b11b743f97a1fb4689d932640934f328b1acf2802201",
-      "resolution": {
-        "resolution": "webidl-conversions@npm:3.0.1",
-        "version": "3.0.1"
-      }
-    },
-    "whatwg-url@npm:^5.0.0": {
-      "checksum": "64422c85cdf7bb41212e1b605535e94ccdea14072fd73d2a8fa68314bb003e4871bb5dc9c8ad74d50c29766bd332b714a015abfba35d0c8271114b34658b1b1a",
-      "resolution": {
-        "resolution": "whatwg-url@npm:5.0.0",
-        "version": "5.0.0",
-        "dependencies": {
-          "tr46": "~0.0.3",
-          "webidl-conversions": "^3.0.0"
-        }
-      }
-    },
     "which@npm:^2.0.1, which@npm:^2.0.2": {
       "checksum": "ecdc1eb2207b9174cdccf333b81f73429423582ebe7681dd0044e1dbf33c78c62c6f464e503a374635b5d38fff2bbfc6a62409caad6cf886a7cc30057b21e103",
       "resolution": {
@@ -22202,16 +18326,6 @@
         "version": "2.0.2",
         "dependencies": {
           "isexe": "^2.0.0"
-        }
-      }
-    },
-    "which@npm:^5.0.0": {
-      "checksum": "cc1c441e66a0cedc64b3ccbf607b1f300123a785cf6e10e72d1b3343e4c34fe68921fb3428a2de208debcaa145c2b77bef7a7a88109cdb9e0ddf8d55a776b5bb",
-      "resolution": {
-        "resolution": "which@npm:5.0.0",
-        "version": "5.0.0",
-        "dependencies": {
-          "isexe": "^3.1.1"
         }
       }
     },
@@ -22534,28 +18648,11 @@
         "version": "3.25.76"
       }
     },
-    "zod@npm:^4.1.8": {
-      "checksum": "6fe14945584df3e8d2cfe037b17cb44f208f5be9d54ff5999c8cf1b07204afe0548743ed4b620c1514e570a66f1f66482367db23bd9ed06bfed44c8c7142aa96",
-      "resolution": {
-        "resolution": "zod@npm:4.1.12",
-        "version": "4.1.12"
-      }
-    },
     "zod@npm:^4.3.6": {
       "checksum": "d4e0042287d321126e094937c57f426f8c5ad578eda4db6611626e25485b22a923d06c28313e0d6896fbf09c8ed1f42d58fd0eb53dca11f5621c75104ca64e9e",
       "resolution": {
         "resolution": "zod@npm:4.4.3",
         "version": "4.4.3"
-      }
-    },
-    "zod-to-json-schema@npm:^3.24.6": {
-      "checksum": "39036649c38d3fccd115f38b13a669d00ba8fca1caf0c098fc5381a3e5890b4b7452c7ee815cd5f0a4351edf53d5e26768ae87486c62413fbccae7ea5e0f2761",
-      "resolution": {
-        "resolution": "zod-to-json-schema@npm:3.24.6",
-        "version": "3.24.6",
-        "peerDependencies": {
-          "zod": "^3.24.1"
-        }
       }
     },
     "zod-to-json-schema@npm:^3.25.1": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7319,7 +7319,7 @@
       }
     },
     "@yarnpkg/shell@npm:^4.1.3": {
-      "checksum": "623cbae0157a8d6ecab50316d7eefb828f2688b9ffbb4118874f635ad24ef933513340094bcad7fb41109adaf88cd79e05934d58aede4107823583385a2c69c1",
+      "checksum": "70fdf47998d91864fcf5d3fb5076cbd6e2f3b7dd9cc4c0a0a0d9bd2bcc234819854ec62c23cee9892e025a07bac1498b8e108381fb645c09234595d8a9e1624a",
       "resolution": {
         "resolution": "@yarnpkg/shell@npm:4.1.3",
         "version": "4.1.3",
@@ -7993,7 +7993,7 @@
       }
     },
     "baseline-browser-mapping@npm:^2.8.9": {
-      "checksum": "e0fb68035d57c6046d22ab46c943c3a09c6092936b60a7a683ef447f39a72f98adcff8aa35f8be2b308b09b82b04a06fc41f29b2dcfcd59ea2126ba6c46ac8c4",
+      "checksum": "25591d29d4180b89168fe65c04eaf04a8c5a7c531508a978a8beaabb01895166e46921c2fe69ec81e981f0f633a19aeec1ba4a73368bba75e9c2256832d98c82",
       "resolution": {
         "resolution": "baseline-browser-mapping@npm:2.8.12",
         "version": "2.8.12"
@@ -12817,7 +12817,7 @@
       }
     },
     "js-yaml@npm:^3.10.0": {
-      "checksum": "cc97ebb0b4e0f1f7ccba6ee9d7f369e84307a5f2515dd121f2a49159aca163ccd41a1bf4d16ba7375187a35c7627f7355b01025ba7ca6d5d276ddb43ecd34d5f",
+      "checksum": "92168c66034e88e496c3c2dd6b7d8554ba87cc8a6a2b4e0ebd7a09992457154e45f66bacc762c1a9e6b67c25b3751671c04a81c506ac3e607d2b8e29b6a0db5e",
       "resolution": {
         "resolution": "js-yaml@npm:3.14.1",
         "version": "3.14.1",
@@ -12839,7 +12839,7 @@
       }
     },
     "js-yaml@npm:^4.1.0": {
-      "checksum": "f5ef6c38920d392cbb9aaf29191eed38de48f7ec44c23fc7c756c1c8a84a17ee450fe91a9cdfc80f3f8210d457683772ffcce4f5ee2a04edd4f05a1516938c82",
+      "checksum": "3191f2781c3b4635480964089f81f012c56e8cd0ee41e5497d33cd780a95cdd1567349555911c23de35e27fe69ed5dcadb3bd11df507eff746ceccd7660612ee",
       "resolution": {
         "resolution": "js-yaml@npm:4.1.0",
         "version": "4.1.0",
@@ -12901,7 +12901,7 @@
       }
     },
     "json5@npm:^2.2.3": {
-      "checksum": "5ed3059c81903c702494a0fe48b78caabc59225124afc5bd56a03bd51203df40d9ac40c0c90ec6b348b42104aab2ddbad22e36987d9f6a8227ebe19a8cc7f45b",
+      "checksum": "c12079f0d13730f343a47c0d92f9b214cd1e0ea20c589299499e7248f9ef465f2cfba6666324df4be0b692a824a17df51e9553d2ebad277cf2cab5d3d65f1ac2",
       "resolution": {
         "resolution": "json5@npm:2.2.3",
         "version": "2.2.3"


### PR DESCRIPTION
Our logging had two issues:

- The "build skipped" messages were sent before attempting the build. As a result they were not _truly_ part of the build, their hashes weren't stored anywhere, and they consistently showed up at every install.

- Both those messages and package extension messages weren't part of any log section, making them have a rather jarring style.

- The "lockfile would have changed" messages were incorrectly reporting the lockfile as being created (even when it already existed and was merely out-of-sync), and didn't show the actual changes. It made it a little difficult to figure out why changes were needed without running the command locally.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes touch install/build state persistence and immutable lockfile failure paths, which affect CI and repeat-install behavior, though logic is mostly reporting and clearer error classification.
> 
> **Overview**
> Install reporting is tightened so build skips, extension warnings, and immutable lockfile failures read more clearly and behave correctly across repeated installs.
> 
> **Build pipeline:** Packages with disabled scripts (or incompatible optional deps) now enqueue a `BuildStep::Skip` instead of being dropped before the build phase. Disabled-script warnings emit during **Building packages**, and build state is persisted for disabled skips so the same warning does not repeat every install until a `rebuild`. The install progress section label is **Building packages**.
> 
> **Package extensions:** Extension diagnostics are collected and printed under a **Package extension diagnostics** section instead of as loose lines.
> 
> **Immutable lockfiles:** `write_lockfile` compares on-disk `yarn.lock` to the generated content, splits errors into creation vs modification, and attaches a colorized unified diff (via `similar`, line-capped with a timeout) under **Lockfile changes** before failing.
> 
> **Reporting API:** Log attachments generalize from file paths only to titled formatted blocks (`add_log_format`), used for the lockfile diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10b004790c570c02e981932548cd37da896d4e15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->