### PR TITLE
Improve cold install concurrency

### DIFF
--- a/packages/zpm/src/cache.rs
+++ b/packages/zpm/src/cache.rs
@@ -425,7 +425,7 @@ impl DiskCache {
         let data
             = self.fetch_and_store_blob::<R, F>(key_path_buf, func).await?;
 
-        Ok(tokio::task::spawn(async move {
+        Ok(tokio::task::spawn_blocking(move || {
             let checksum
                 = Hash64::from_data(&data);
 
@@ -447,26 +447,23 @@ impl DiskCache {
         let data
             = func().await?;
 
-        let atomic_path
-            = Path::try_from(key_path.clone())?;
+        tokio::task::spawn_blocking(move || -> Result<Vec<u8>, Error> {
+            let atomic_path
+                = Path::try_from(key_path.clone())?;
 
-        let write_result
-            = atomic_path
-                .fs_write_atomic(|tmp_path| -> Result<(), PathError> {
-                    tmp_path.fs_write(&data)?;
-                    Ok(())
-                })
-                .ok_exists();
+            let write_result
+                = atomic_path
+                    .fs_write_atomic(|tmp_path| -> Result<(), PathError> {
+                        tmp_path.fs_write(&data)?;
+                        Ok(())
+                    })
+                    .ok_exists();
 
-        match write_result? {
-            Some(_) => {
-                Ok(data)
-            },
-
-            None => {
-                Ok(tokio::fs::read(key_path).await?)
-            },
-        }
+            match write_result? {
+                Some(_) => Ok(data),
+                None => Ok(std::fs::read(key_path)?),
+            }
+        }).await?
     }
 
     pub async fn clean(&self) -> Result<usize, Error> {

--- a/packages/zpm/src/fetchers/npm.rs
+++ b/packages/zpm/src/fetchers/npm.rs
@@ -89,7 +89,7 @@ pub async fn fetch_locator<'a>(context: &InstallContext<'a>, locator: &Locator, 
 
     let fetch_archive = || async {
         let bytes
-            = http_npm::get(&http_npm::NpmHttpParams {
+            = http_npm::get_uncached(&http_npm::NpmHttpParams {
                 http_client: &project.http_client,
                 registry: &fetch_registry,
                 path: &fetch_path,

--- a/packages/zpm/src/http_npm.rs
+++ b/packages/zpm/src/http_npm.rs
@@ -503,6 +503,25 @@ pub async fn get(params: &NpmHttpParams<'_>) -> Result<Bytes, Error> {
     Ok(bytes)
 }
 
+/// Fetch a response without retaining its body in the process-wide HTTP
+/// cache. Package archives are already deduplicated by the install fetch map
+/// and can be released as soon as they have been converted into cache zips.
+pub async fn get_uncached(params: &NpmHttpParams<'_>) -> Result<Bytes, Error> {
+    let url
+        = format!("{}{}", params.registry, params.path);
+
+    let response = params.http_client.get(&url)?
+        .header("authorization", params.authorization)
+        .enable_status_check(false)
+        .send().await?;
+
+    if params.authorization.is_some() {
+        handle_invalid_authentication_error(params, &response).await?;
+    }
+
+    Ok(response.error_for_status()?.bytes().await?)
+}
+
 const CACHED_VERSION_FIELDS: &[&str] = &[
     "bin",
     "cpu",

--- a/packages/zpm/src/install.rs
+++ b/packages/zpm/src/install.rs
@@ -1,4 +1,4 @@
-use std::{collections::{BTreeMap, BTreeSet, HashMap}, sync::{Arc, LazyLock, Mutex}};
+use std::{collections::{BTreeMap, BTreeSet, HashMap, HashSet}, sync::{Arc, LazyLock, Mutex}};
 
 use chrono::{DateTime, Utc};
 use colored::Colorize;
@@ -208,20 +208,25 @@ impl IntoResolutionResult for FetchResult {
 struct InstallMaps {
     resolution_map: Arc<WaitMap<Descriptor, ResolutionResult>>,
     fetch_map: Arc<WaitMap<Locator, FetchResult>>,
+    resolution_tx: tokio::sync::mpsc::UnboundedSender<ResolutionEvent>,
 }
 
-/// Resolve a single descriptor: runs `get_or_init` for the resolution + starts
-/// the fetch, then returns child descriptors to be resolved next.
-///
-/// The resolution logic is split: `get_or_init` runs only the core resolution +
-/// starts the fetch. Children are returned (not recursed into) so the caller
-/// can drive them iteratively, avoiding stack overflow on deep dependency trees.
+/// The work unlocked by resolving a descriptor. Child resolutions and the
+/// package fetch can be scheduled independently.
+struct ResolutionEvent {
+    children: Vec<Descriptor>,
+    locator: Locator,
+    is_mock_request: bool,
+}
+
+/// Resolve a single descriptor. The initializer emits a [`ResolutionEvent`]
+/// so its children and fetch can be scheduled independently.
 async fn resolve_one<'a>(
     descriptor: Descriptor,
     ctx: &'a InstallContext<'a>,
     lockfile: &'a Lockfile,
     maps: &'a InstallMaps,
-) -> Vec<Descriptor> {
+) {
     let cell
         = maps.resolution_map.entry(descriptor.clone());
 
@@ -229,53 +234,76 @@ async fn resolve_one<'a>(
         resolve_descriptor_impl(descriptor.clone(), ctx, lockfile, maps)
     }).await;
 
-    let Ok(result) = result else {
-        return vec![];
-    };
-
-    let children
-        = result.resolution.dependencies
-            .values()
-            .chain(result.resolution.variants.iter())
-            .cloned()
-            .collect();
-
-    children
+    // Errors are collected from the WaitMap after both worklists drain.
+    let _ = result;
 }
 
 /// Iteratively resolve all descriptors starting from the given roots.
-/// Uses `FuturesUnordered` to process descriptors concurrently without
-/// recursive async calls (which would overflow the stack on deep trees).
+/// Resolution and fetch use separate worklists so downloading and packing a
+/// parent archive never delays discovery of its child dependencies.
 async fn resolve_all<'a>(
     roots: impl IntoIterator<Item = Descriptor>,
     ctx: &'a InstallContext<'a>,
     lockfile: &'a Lockfile,
     maps: &'a InstallMaps,
+    mut resolution_rx: tokio::sync::mpsc::UnboundedReceiver<ResolutionEvent>,
 ) {
-    let mut in_flight
+    let mut resolving
         = FuturesUnordered::new();
+    let mut fetching
+        = FuturesUnordered::new();
+    let mut scheduled
+        = HashSet::new();
 
     for descriptor in roots {
-        in_flight.push(resolve_one(descriptor, ctx, lockfile, maps));
+        if scheduled.insert(descriptor.clone()) {
+            resolving.push(resolve_one(descriptor, ctx, lockfile, maps));
+        }
     }
 
-    while let Some(children) = in_flight.next().await {
-        for child in children {
-            // Only schedule children whose resolution hasn't been started yet.
-            // This prevents infinite loops on cyclic dependency graphs.
-            let cell
-                = maps.resolution_map.entry(child.clone());
+    enum Completed {
+        Resolution,
+        Fetch,
+        ResolutionEvent(ResolutionEvent),
+    }
 
-            if !cell.initialized() {
-                in_flight.push(resolve_one(child, ctx, lockfile, maps));
+    while !resolving.is_empty() || !fetching.is_empty() || !resolution_rx.is_empty() {
+        let completed = tokio::select! {
+            result = resolving.next(), if !resolving.is_empty() => {
+                result.expect("resolution worklist cannot be empty");
+                Completed::Resolution
+            },
+            result = fetching.next(), if !fetching.is_empty() => {
+                result.expect("fetch worklist cannot be empty");
+                Completed::Fetch
+            },
+            event = resolution_rx.recv() => {
+                Completed::ResolutionEvent(event.expect("resolution sender cannot close during resolution"))
+            },
+        };
+
+        if let Completed::ResolutionEvent(event) = completed {
+            fetching.push(ensure_fetched(
+                event.locator,
+                event.is_mock_request,
+                ctx,
+                maps,
+            ));
+
+            for child in event.children {
+                // Deduplicate at queue insertion time. Checking the OnceCell
+                // isn't sufficient because queued futures may not be polled yet.
+                if scheduled.insert(child.clone()) {
+                    resolving.push(resolve_one(child, ctx, lockfile, maps));
+                }
             }
         }
     }
 }
 
 /// The actual resolution logic for a single descriptor.
-/// Returns the resolution result; does NOT recurse into children (that happens
-/// in `resolve_one` after the OnceCell init completes, via the `resolve_all` worklist).
+/// Returns the resolution result and emits its children to the iterative
+/// `resolve_all` worklist instead of recursing into them.
 ///
 /// Returns a `BoxFuture` to support recursive calls for inner descriptors
 /// (e.g. alias->inner, patch->inner) without causing infinite future sizes.
@@ -302,7 +330,7 @@ fn resolve_descriptor_impl<'a>(
                             verify_resolution_consistency(&descriptor, &result.resolution.locator)
                         }).await.map_err(Arc::new)?;
                     }
-                    start_fetch(&result, ctx, maps).await;
+                    enqueue_resolution(&result, ctx, maps);
                     return Ok(result);
                 },
 
@@ -328,7 +356,7 @@ fn resolve_descriptor_impl<'a>(
                         ).await.map_err(|_| Error::TaskTimeout)?
                     }).await.map_err(Arc::new)?;
 
-                    start_fetch(&result, ctx, maps).await;
+                    enqueue_resolution(&result, ctx, maps);
                     return Ok(result);
                 },
             }
@@ -418,18 +446,18 @@ fn resolve_descriptor_impl<'a>(
             ).await.map_err(|_| Error::TaskTimeout)?
         }).await.map_err(Arc::new)?;
 
-        // Phase 4: Start fetch (children are handled by resolve_all worklist after init completes)
-        start_fetch(&result, ctx, maps).await;
+        enqueue_resolution(&result, ctx, maps);
 
         Ok(result)
     }.boxed()
 }
 
-/// Start a fetch for the resolved locator.
-async fn start_fetch<'a>(
+/// Emit the child resolutions and fetch unlocked by a successful resolution.
+/// The scheduler runs them independently so both pipelines can overlap.
+fn enqueue_resolution(
     result: &ResolutionResult,
-    ctx: &'a InstallContext<'a>,
-    maps: &'a InstallMaps,
+    ctx: &InstallContext<'_>,
+    maps: &InstallMaps,
 ) {
     let systems
         = ctx.systems.unwrap();
@@ -448,7 +476,16 @@ async fn start_fetch<'a>(
         }
     }
 
-    ensure_fetched(locator, is_mock_request, ctx, maps).await;
+    let children
+        = result.resolution.dependencies
+            .values()
+            .chain(result.resolution.variants.iter())
+            .cloned()
+            .collect();
+
+    maps.resolution_tx
+        .send(ResolutionEvent {children, locator, is_mock_request})
+        .expect("resolution receiver cannot close during resolution");
 }
 
 /// Ensure a locator is fetched. Uses the fetch WaitMap for deduplication.
@@ -1150,9 +1187,13 @@ impl<'a> InstallManager<'a> {
     }
 
     pub async fn resolve_and_fetch(mut self) -> Result<Install, Error> {
+        let (resolution_tx, resolution_rx)
+            = tokio::sync::mpsc::unbounded_channel();
+
         let maps = InstallMaps {
             resolution_map: Arc::new(WaitMap::new()),
             fetch_map: Arc::new(WaitMap::new()),
+            resolution_tx,
         };
 
         let lockfile
@@ -1216,7 +1257,7 @@ impl<'a> InstallManager<'a> {
         let roots = self.result.roots.clone();
 
         async_section("Installing packages", async {
-            let greedy_future = resolve_all(roots, &self.context, &lockfile, &maps);
+            let greedy_future = resolve_all(roots, &self.context, &lockfile, &maps, resolution_rx);
 
             if let Some(ref islands) = resolved_islands {
                 // Store resolved islands for use during linking

--- a/yarn.lock
+++ b/yarn.lock
@@ -7357,6 +7357,13 @@
         }
       }
     },
+    "abbrev@npm:^5.0.0": {
+      "checksum": "17873c9df94748d4f25935d7e5094d41d88a32827bb2ad927db7fbd36fe64b5f88fad6f3256b788cf699f97f6efef27a81a346e6518ddf5d5849642777415017",
+      "resolution": {
+        "resolution": "abbrev@npm:5.0.0",
+        "version": "5.0.0"
+      }
+    },
     "acorn@npm:^8.15.0": {
       "checksum": "ed7053eb83a8c131ffce1abb573ca45431ceb5ec684cedc7ef44523475157b8d96edd0a69d198ff8dbbbb9cbbd38c0d0584c77f553f6ad7b1cc62a825cd7f937",
       "resolution": {
@@ -9908,7 +9915,7 @@
         "version": "6.0.1"
       }
     },
-    "env-paths@npm:^2.2.1": {
+    "env-paths@npm:^2.2.0, env-paths@npm:^2.2.1": {
       "checksum": "f1740c5cfa1f277cb8f0c9751eec990828d430a524f70f770757cfdf569257a8ffbc43e1e6a724bda5fd96680f2a19ba02a647ea69364785804960e03ded0cdd",
       "resolution": {
         "resolution": "env-paths@npm:2.2.1",
@@ -10609,6 +10616,13 @@
         }
       }
     },
+    "exponential-backoff@npm:^3.1.1": {
+      "checksum": "77086c6d4cd6021765248683de9242cc3fce47179a662cd489b06d155a09045346a0df0b8561c9429f3e58c601ba837fc55c4e07af95bed9d6cd929204036b42",
+      "resolution": {
+        "resolution": "exponential-backoff@npm:3.1.3",
+        "version": "3.1.3"
+      }
+    },
     "extend@npm:^3.0.0": {
       "checksum": "b2750a8884cf6b4690409f9c56b81966819273d9f232e1300271499227e79f71cc71416ac4548fa6c544a831e15432e36e1c9282040682a87e79ebd3abc7a4dc",
       "resolution": {
@@ -11202,7 +11216,7 @@
         }
       }
     },
-    "graceful-fs@npm:^4.2.10, graceful-fs@npm:^4.2.4, graceful-fs@npm:^4.2.9": {
+    "graceful-fs@npm:^4.2.10, graceful-fs@npm:^4.2.4, graceful-fs@npm:^4.2.6, graceful-fs@npm:^4.2.9": {
       "checksum": "dff3c6ff874d12e505e1fdaa5425c880e8d8e0d720cddda38a28f2bbf1c37da241603fb9d05fc6fec3ff1120f07dffbdf23127dfa654da7ef18021931b1bc12d",
       "resolution": {
         "resolution": "graceful-fs@npm:4.2.11",
@@ -12223,6 +12237,13 @@
       "resolution": {
         "resolution": "isexe@npm:2.0.0",
         "version": "2.0.0"
+      }
+    },
+    "isexe@npm:^4.0.0": {
+      "checksum": "9be54001e72ff2efbca8e02ee5552b79d81c126ac47ee6e334506c7da8ffa987dc51aad879edc834c79bc2fd0ef53a8e3725dfbadb52031c3fe2f1ab0fa9cad6",
+      "resolution": {
+        "resolution": "isexe@npm:4.0.0",
+        "version": "4.0.0"
       }
     },
     "istanbul-lib-coverage@npm:^3.0.0, istanbul-lib-coverage@npm:^3.2.0": {
@@ -14612,6 +14633,25 @@
         "version": "1.6.7"
       }
     },
+    "node-gyp@npm:*": {
+      "checksum": "fd48a6b4775e3615654c16be20a8a812e32b117c9d12a43b5ac1c3506d3e3fb2e4e8a9eb677104bfb918a873c433e11695f9eee7d2733ac0564cb719c90626aa",
+      "resolution": {
+        "resolution": "node-gyp@npm:13.0.1",
+        "version": "13.0.1",
+        "dependencies": {
+          "env-paths": "^2.2.0",
+          "exponential-backoff": "^3.1.1",
+          "graceful-fs": "^4.2.6",
+          "nopt": "^10.0.0",
+          "proc-log": "^7.0.0",
+          "semver": "^7.3.5",
+          "tar": "^7.5.4",
+          "tinyglobby": "^0.2.12",
+          "undici": "^8.4.1",
+          "which": "^7.0.0"
+        }
+      }
+    },
     "node-int64@npm:^0.4.0": {
       "checksum": "163620e2657781fecff525af63868bbf9cb00a99c935a5e2e4408b99a0c9e8d4b3ac4432eb6c776daf92b6c04e326de2c40e8bde643a55fdf6ea219932d8e0d7",
       "resolution": {
@@ -14638,6 +14678,16 @@
       "resolution": {
         "resolution": "node-watch@npm:0.7.3",
         "version": "0.7.3"
+      }
+    },
+    "nopt@npm:^10.0.0": {
+      "checksum": "02d56c4870f8f0442243ff22877a980b77cce28648b909228147c630bc534aa7dec9de132994538691d41a8e221a74191836c51bda73684f6605109efe671918",
+      "resolution": {
+        "resolution": "nopt@npm:10.0.1",
+        "version": "10.0.1",
+        "dependencies": {
+          "abbrev": "^5.0.0"
+        }
       }
     },
     "normalize-path@npm:^3.0.0": {
@@ -15330,6 +15380,13 @@
       "resolution": {
         "resolution": "proc-log@npm:6.1.0",
         "version": "6.1.0"
+      }
+    },
+    "proc-log@npm:^7.0.0": {
+      "checksum": "8a31a22ebcdefc81cbcfac1b757211489eb9c33199938c378a0845fa3c76fedd5c9da89fe5ac64998cca8f3b855c937b09afa0f19c04d43621baf00726607ca3",
+      "resolution": {
+        "resolution": "proc-log@npm:7.0.0",
+        "version": "7.0.0"
       }
     },
     "process-nextick-args@npm:~2.0.0": {
@@ -17279,6 +17336,20 @@
         }
       }
     },
+    "tar@npm:^7.5.4": {
+      "checksum": "602985e860dec206f42c582076e088f4fd65e89adf2237ebf019c7060d604ec38e3d86883056703d3e80447e7d478561ef8888c72369cb6015369bb7254d63bc",
+      "resolution": {
+        "resolution": "tar@npm:7.5.20",
+        "version": "7.5.20",
+        "dependencies": {
+          "@isaacs/fs-minipass": "^4.0.0",
+          "chownr": "^3.0.0",
+          "minipass": "^7.1.2",
+          "minizlib": "^3.1.0",
+          "yallist": "^5.0.0"
+        }
+      }
+    },
     "tar-fs@npm:^1.16.0": {
       "checksum": "18ebfa1788a40ef3761a756d62adc328bda194916895f996d82fec210dd84b3a83497b0b88a969e671f82d9a852de38b73e8bd3754b64f18528bbc0d87b035c7",
       "resolution": {
@@ -17407,6 +17478,17 @@
       "resolution": {
         "resolution": "tinyexec@npm:1.1.2",
         "version": "1.1.2"
+      }
+    },
+    "tinyglobby@npm:^0.2.12": {
+      "checksum": "5a5f0e648836fbe413ba31d29204fdfc4f206a4878868cc926e528413637e27ab73997b7e4939444918b11c45e604ce706e39fee335474185b7b014ea7010733",
+      "resolution": {
+        "resolution": "tinyglobby@npm:0.2.17",
+        "version": "0.2.17",
+        "dependencies": {
+          "fdir": "^6.5.0",
+          "picomatch": "^4.0.4"
+        }
       }
     },
     "tinyglobby@npm:^0.2.13, tinyglobby@npm:^0.2.15": {
@@ -17725,6 +17807,13 @@
       "resolution": {
         "resolution": "uncrypto@npm:0.1.3",
         "version": "0.1.3"
+      }
+    },
+    "undici@npm:^8.4.1": {
+      "checksum": "fae70318a7ec30b40d168fdc034547777d3897578dd60a4cdbbc3c4f6be61533c7e3a665960d4dd3ea5949f34c860444905bd19a4c19cc9c904e968d4e0ce8dd",
+      "resolution": {
+        "resolution": "undici@npm:8.7.0",
+        "version": "8.7.0"
       }
     },
     "undici-types@npm:~7.16.0": {
@@ -18326,6 +18415,16 @@
         "version": "2.0.2",
         "dependencies": {
           "isexe": "^2.0.0"
+        }
+      }
+    },
+    "which@npm:^7.0.0": {
+      "checksum": "a51c8b81c57af84c8a94aac0d27faa2b4fef8c2fd72976a00c68ad5adf3de2e8011a53cdc34224a68338a41d82caa6559b7f325f31c76fff0c5c26cae4c310a9",
+      "resolution": {
+        "resolution": "which@npm:7.0.0",
+        "version": "7.0.0",
+        "dependencies": {
+          "isexe": "^4.0.0"
         }
       }
     },


### PR DESCRIPTION
## Summary

- decouple descriptor resolution from package fetching so child resolutions can continue while parent archives download and repack
- move package cache writes and checksum work onto blocking workers
- avoid retaining npm archive bodies in the process HTTP cache

## Benchmark

Gatsby full cold install against warmed proxy, 20 paired/counterbalanced runs:

```text
baseline median: 3.525s
final median:    2.740s
improvement:     22.3%
```

Raw paired data: `/tmp/zpm-paired-final-20.tsv`

## Validation

```text
cargo build -r
yarn test:integration protocols/patch.test.ts features/islands.test.ts features/cache.test.ts protocols/npm.test.js --runInBand
cargo fmt --all --check
git diff --check
```

Integration result: 4 suites passed, 79 tests passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Install resolution/fetch ordering and concurrency changed in core `install.rs`; regressions could affect deep trees, cycles, or auth/npm fetch paths, though integration tests passed.
> 
> **Overview**
> **Cold install throughput** improves by running dependency resolution and package fetching on separate worklists instead of blocking child resolution on parent archive download/repack.
> 
> After each descriptor resolves, **`enqueue_resolution`** sends child descriptors and the locator fetch through an **unbounded channel**; **`resolve_all`** uses **`tokio::select!`** to schedule resolution futures, fetch futures, and resolution events in parallel, with **`HashSet`** deduplication when queueing children.
> 
> **Disk cache and HTTP behavior** shift blocking work off the async runtime: package cache **checksum** work and **atomic blob writes** use **`spawn_blocking`** (sync **`std::fs::read`** on write races); npm tarball fetches use new **`get_uncached`** so large archive bodies are not kept in the process-wide HTTP cache after they are packed to zip.
> 
> **`yarn.lock`** updates add transitive entries (e.g. **`node-gyp`** and its deps) consistent with refreshed resolution/fetch behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dac241b97e530ed15b4a3520e8884a50f7e801d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->