### PR TITLE
Run benchmarks across package manager matrix

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -42,15 +42,22 @@ jobs:
 
   benchmark:
     strategy:
+      fail-fast: false
       matrix:
+        packageManager: ${{ fromJSON(github.event_name == 'schedule' && '[["Yarn 6.x","zpm"],["Yarn 4.x","yarn"],["npm","npm"],["pnpm","pnpm"],["Yarn Classic","classic"]]' || '[["Yarn 6.x","zpm"]]') }}
         benchmark:
           - [Next.js, next]
           - [Gatsby, gatsby]
           - [Monorepo, monorepo]
+        scenario:
+          - [Full cold install, install-full-cold]
+          - [Cache only, install-cache-only]
+          - [Cache + lockfile, install-cache-and-lock]
+          - [Recurrent call, install-ready]
 
     needs: [build]
 
-    name: 'Running the ${{matrix.benchmark[0]}} benchmark'
+    name: 'Running ${{matrix.packageManager[0]}} on ${{matrix.benchmark[0]}} (${{matrix.scenario[0]}})'
     runs-on: ubuntu-latest
 
     steps:
@@ -69,10 +76,6 @@ jobs:
       run: |
         chmod +x local/{yarn,yarn-bin}
 
-    - name: Install Flamegraph
-      run: |
-        cargo install flamegraph@0.6.9
-
     - name: Install Hyperfine
       run: |
         wget https://github.com/sharkdp/hyperfine/releases/download/v1.10.0/hyperfine_1.10.0_amd64.deb
@@ -88,10 +91,10 @@ jobs:
 
     - name: 'Run the performance test'
       run: |
-        bash scripts/bench-run.sh zpm ${{matrix.benchmark[1]}} hyperfine "$BENCH_DIR" || true
+        bash scripts/bench-run.sh ${{matrix.packageManager[1]}} ${{matrix.benchmark[1]}} hyperfine "$BENCH_DIR" ${{matrix.scenario[1]}} || true
 
         if [[ '${{github.event.inputs.sendReport}}' != 'false' ]]; then
-          yarn node scripts/submit-bench-data.js zpm ${{matrix.benchmark[1]}} "$BENCH_DIR"
+          yarn node scripts/submit-bench-data.js ${{matrix.packageManager[1]}} ${{matrix.benchmark[1]}} "$BENCH_DIR"
         fi
       env:
         DD_API_KEY: ${{secrets.DD_API_KEY}}

--- a/scripts/bench-run.sh
+++ b/scripts/bench-run.sh
@@ -6,31 +6,69 @@ PACKAGE_MANAGER=$1; shift
 TEST_NAME=$1; shift
 TEST_MODE=$1; shift
 BENCH_DIR=$1; shift
+SELECTED_SUBTEST=${1:-}
+
+case "$SELECTED_SUBTEST" in
+  ""|install-full-cold|install-cache-only|install-cache-and-lock|install-ready) ;;
+  *)
+    echo "Invalid benchmark scenario ${SELECTED_SUBTEST}"
+    exit 1;;
+esac
 
 HERE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 
 echo "BENCH_DIR: $BENCH_DIR"
 cd "$BENCH_DIR"
 
+BASELINE_DIR=$(mktemp -d)
+PREPARE_DIR=$(mktemp -d)
+trap 'rm -rf "$BASELINE_DIR" "$PREPARE_DIR"' EXIT
+
+write-prepare-script() {
+  local subtest_name=$1
+  local prepare_command=$2
+  local prepare_script="$PREPARE_DIR/prepare-$subtest_name.sh"
+
+  {
+    echo '#!/usr/bin/env bash'
+    echo 'set -e'
+    printf 'rsync -a --delete --exclude %q --exclude %q %q/ %q/\n' 'bench-*.json' 'flamegraphs/' "$BASELINE_DIR" "$BENCH_DIR"
+    printf 'cd %q\n' "$BENCH_DIR"
+    printf '%s\n' "$prepare_command"
+  } > "$prepare_script"
+
+  chmod +x "$prepare_script"
+  echo "$prepare_script"
+}
+
 bench() {
   SUBTEST_NAME=$1; shift
   PREPARE_COMMAND=$1; shift
   BENCH_COMMAND=$1; shift
-  FLAMEGRAPH_COMMAND=$1; shift
+  FLAMEGRAPH_COMMAND=${1:-}
+
+  if [[ -n "$SELECTED_SUBTEST" && "$SUBTEST_NAME" != "$SELECTED_SUBTEST" ]]; then
+    return
+  fi
 
   echo "Testing $SUBTEST_NAME"
+  echo "Preparing baseline state"
+  bash -c "$BASELINE_COMMAND" >& /dev/null
+  rsync -a --delete --exclude 'bench-*.json' --exclude 'flamegraphs/' "$BENCH_DIR"/ "$BASELINE_DIR"/
+
+  PREPARE_SCRIPT=$(write-prepare-script "$SUBTEST_NAME" "$PREPARE_COMMAND")
 
   if [[ "$TEST_MODE" == "flamegraph" ]]; then
     mkdir -p "$BENCH_DIR/flamegraphs"
 
-    (bash -c "$PREPARE_COMMAND" && bash -c "$BENCH_COMMAND") >& /dev/null || true
+    ("$PREPARE_SCRIPT" && bash -c "$BENCH_COMMAND") >& /dev/null || true
 
-    bash -c "$PREPARE_COMMAND"
+    "$PREPARE_SCRIPT"
     bash -c "$FLAMEGRAPH_COMMAND"
   fi
 
   if [[ "$TEST_MODE" == "hyperfine" ]]; then
-    hyperfine ${HYPERFINE_OPTIONS:-} --export-json=bench-$SUBTEST_NAME.json --min-runs=10 --warmup=1 --prepare="$PREPARE_COMMAND" "$BENCH_COMMAND"
+    hyperfine ${HYPERFINE_OPTIONS:-} --export-json=bench-$SUBTEST_NAME.json --min-runs=10 --warmup=1 --prepare="$PREPARE_SCRIPT" "$BENCH_COMMAND"
   fi
 }
 
@@ -109,6 +147,7 @@ setup-pnpm() {
 case $PACKAGE_MANAGER in
   zpm)
     setup-zpm
+    BASELINE_COMMAND="$ZPM_PATH install"
     bench install-full-cold \
       'rm -rf .yarn .pnp.* yarn.lock .yarn-global' \
       "$ZPM_PATH install" \
@@ -127,6 +166,7 @@ case $PACKAGE_MANAGER in
       "~/.cargo/bin/flamegraph -o flamegraphs/zpm-install-ready.svg -- $ZPM_PATH add dummy-pkg@link:./dummy-pkg"
     ;;
   classic)
+    BASELINE_COMMAND='yarn install'
     bench install-full-cold \
       'rm -rf node_modules yarn.lock && yarn cache clean' \
       'yarn install'
@@ -142,6 +182,7 @@ case $PACKAGE_MANAGER in
     ;;
   yarn)
     setup-yarn2
+    BASELINE_COMMAND='yarn install'
     bench install-full-cold \
       'rm -rf .yarn .pnp.* yarn.lock .yarn-global' \
       'yarn install'
@@ -158,6 +199,7 @@ case $PACKAGE_MANAGER in
   yarn-nm)
     setup-yarn2
     setup-yarn2-nm
+    BASELINE_COMMAND='yarn install'
     bench install-full-cold \
       'rm -rf .yarn node_modules yarn.lock .yarn-global' \
       'yarn install'
@@ -174,6 +216,7 @@ case $PACKAGE_MANAGER in
   yarn-pnpm)
     setup-yarn2
     setup-yarn2-pnpm
+    BASELINE_COMMAND='yarn install'
     bench install-full-cold \
       'rm -rf .yarn node_modules yarn.lock .yarn-global' \
       'yarn install'
@@ -188,6 +231,7 @@ case $PACKAGE_MANAGER in
       'yarn add dummy-pkg@link:./dummy-pkg'
     ;;
   npm)
+    BASELINE_COMMAND='npm install'
     bench install-full-cold \
       'rm -rf node_modules package-lock.json && npm cache clean --force' \
       'npm install'
@@ -203,6 +247,7 @@ case $PACKAGE_MANAGER in
     ;;
   pnpm)
     setup-pnpm
+    BASELINE_COMMAND='pnpm install'
     bench install-full-cold \
       'rm -rf node_modules pnpm-lock.yaml ~/.local/share/pnpm/store ~/.cache/pnpm' \
       'pnpm install'


### PR DESCRIPTION
## Summary
- Add benchmark matrix axes for package manager and install scenario
- Run the full package-manager set only on scheduled benchmark runs; use zpm only otherwise
- Let the benchmark runner execute a selected scenario and tolerate package managers without flamegraph commands

## Tests
- bash -n scripts/bench-run.sh
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/benchmarks.yml"); puts "ok"'
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to benchmark workflow and shell scripting; no application runtime or security-sensitive paths.
> 
> **Overview**
> Expands the **benchmarks** workflow into a larger matrix: each job runs one **package manager** (zpm, Yarn 4, npm, pnpm, Yarn Classic on **scheduled** runs; **zpm only** on push/dispatch), one **fixture** (Next/Gatsby/monorepo), and one **install scenario** (full cold, cache-only, cache+lockfile, recurrent add). Jobs use **`fail-fast: false`** and pass the scenario id into `bench-run.sh`; reporting still uses the package manager slug from the matrix. The workflow drops the **flamegraph** install step because CI runs **hyperfine** only.
> 
> **`scripts/bench-run.sh`** gains an optional fifth argument to run a single scenario, validates scenario names, and makes **flamegraph** commands optional for non-zpm managers. Each hyperfine run now seeds a **baseline** install, snapshots the bench dir, and uses a generated **prepare** script that rsyncs from baseline before the scenario prep—so repeated runs start from a consistent state. Matrix jobs therefore produce one `bench-*.json` per job instead of four scenarios in one invocation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc683ae4c4980d0c28e7fe79dc860cdb629e474b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->