### PR TITLE
fix: bound network concurrency through response bodies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4208,10 +4208,8 @@ dependencies = [
  "pin-project-lite",
  "sync_wrapper",
  "tokio",
- "tokio-util",
  "tower-layer",
  "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -5225,7 +5223,6 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-tungstenite",
- "tower",
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,7 +108,6 @@ timeago = "0.5.0"
 tikv-jemallocator = "0.6.0"
 tokio = { version = "1.39.2", features = ["full"] }
 tokio-tungstenite = "0.26"
-tower = { version = "0.5.2", features = ["limit"] }
 tracing = { version = "0.1.44", default-features = false, features = ["std"] }
 tracing-opentelemetry = { version = "0.33.0", default-features = false }
 tracing-subscriber = { version = "0.3.23", default-features = false, features = ["registry", "std"] }

--- a/packages/zpm/Cargo.toml
+++ b/packages/zpm/Cargo.toml
@@ -40,7 +40,6 @@ serde_yaml = { workspace = true }
 similar = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
-tower = { workspace = true, features = ["limit"] }
 tracing = { workspace = true }
 tracing-opentelemetry = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/packages/zpm/src/http.rs
+++ b/packages/zpm/src/http.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashSet, future::Future, net::SocketAddr, sync::{Arc, LazyLock, OnceLock}, time::Duration};
+use std::{collections::HashSet, future::Future, net::SocketAddr, ops::{Deref, DerefMut}, sync::{Arc, LazyLock, OnceLock}, time::Duration};
 
 use bytes::{Bytes, BytesMut};
 use dashmap::DashMap;
@@ -8,7 +8,7 @@ use itertools::Itertools;
 #[cfg(not(all(target_arch = "wasm64", target_vendor = "browserpod")))]
 use reqwest::Identity;
 use reqwest::{dns::{self, Addrs}, header::{HeaderName, HeaderValue}, Body, Certificate, Client, ClientBuilder, Method, Proxy, RequestBuilder, Response, Url};
-use tokio::sync::OnceCell;
+use tokio::sync::{OnceCell, OwnedSemaphorePermit, Semaphore};
 use wax::Program;
 use zpm_config::{Configuration, NetworkSettings, Setting};
 use zpm_utils::Glob;
@@ -118,6 +118,7 @@ pub struct HttpClient {
 
     client: Client,
     network_clients: Vec<(Glob, Client)>,
+    network_semaphore: Arc<Semaphore>,
 
     /// Cache for GET requests to avoid duplicate network calls for the same URL.
     /// Uses OnceCell for each URL to handle concurrent requests to the same URL.
@@ -130,8 +131,60 @@ impl std::fmt::Debug for HttpClient {
             .field("config", &self.config)
             .field("client", &self.client)
             .field("network_clients", &format!("<{} entries>", self.network_clients.len()))
+            .field("network_semaphore", &self.network_semaphore)
             .field("get_cache", &format!("<{} entries>", self.get_cache.len()))
             .finish()
+    }
+}
+
+#[derive(Debug)]
+pub struct HttpResponse {
+    response: Response,
+    permit: Option<OwnedSemaphorePermit>,
+}
+
+impl HttpResponse {
+    fn new(response: Response, permit: OwnedSemaphorePermit) -> Self {
+        Self {response, permit: Some(permit)}
+    }
+
+    fn release_permit(&mut self) {
+        self.permit.take();
+    }
+
+    pub async fn bytes(self) -> Result<Bytes, reqwest::Error> {
+        let Self {response, permit} = self;
+        let result = response.bytes().await;
+        drop(permit);
+        result
+    }
+
+    pub async fn text(self) -> Result<String, reqwest::Error> {
+        let Self {response, permit} = self;
+        let result = response.text().await;
+        drop(permit);
+        result
+    }
+
+    pub fn error_for_status(self) -> Result<Self, reqwest::Error> {
+        let Self {response, permit} = self;
+
+        response.error_for_status()
+            .map(|response| Self {response, permit})
+    }
+}
+
+impl Deref for HttpResponse {
+    type Target = Response;
+
+    fn deref(&self) -> &Self::Target {
+        &self.response
+    }
+}
+
+impl DerefMut for HttpResponse {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.response
     }
 }
 
@@ -183,7 +236,7 @@ impl<'a> HttpRequest<'a> {
 
     async fn send_with<T, F, Fut>(self, consume: F) -> Result<T, reqwest::Error>
     where
-        F: Fn(Response) -> Fut,
+        F: Fn(HttpResponse) -> Fut,
         Fut: Future<Output = Result<T, reqwest::Error>>,
     {
         let mut retry_count
@@ -194,6 +247,12 @@ impl<'a> HttpRequest<'a> {
                 .map(|s| s.to_string());
 
         loop {
+            let permit
+                = self.client.network_semaphore.clone()
+                    .acquire_owned()
+                    .await
+                    .expect("network semaphore should remain open");
+
             let mut fetch_future = Box::pin(async {
                 self.builder.try_clone()
                     .expect("builder should be clonable")
@@ -233,6 +292,8 @@ impl<'a> HttpRequest<'a> {
 
             if self.enable_retry && retry_count < self.client.config.http_retry && is_failure {
                 retry_count += 1;
+                drop(response);
+                drop(permit);
 
                 let sleep_duration
                     = 2_u64.saturating_pow(retry_count as u32);
@@ -253,10 +314,11 @@ impl<'a> HttpRequest<'a> {
             };
 
             let result
-                = consume(response).await;
+                = consume(HttpResponse::new(response, permit)).await;
 
             if self.enable_retry && retry_count < self.client.config.http_retry && result.is_err() {
                 retry_count += 1;
+                drop(result);
 
                 let sleep_duration
                     = 2_u64.saturating_pow(retry_count as u32);
@@ -271,7 +333,7 @@ impl<'a> HttpRequest<'a> {
         }
     }
 
-    pub async fn send(self) -> Result<Response, reqwest::Error> {
+    pub async fn send(self) -> Result<HttpResponse, reqwest::Error> {
         self.send_with(|response| async move {
             Ok(response)
         }).await
@@ -283,7 +345,7 @@ impl<'a> HttpRequest<'a> {
 
     /// Buffers the response body inside the retry loop while retaining the
     /// drained response so callers can inspect its status and headers.
-    pub async fn send_bytes(self) -> Result<(Response, Bytes), reqwest::Error> {
+    pub async fn send_bytes(self) -> Result<(HttpResponse, Bytes), reqwest::Error> {
         let enable_status_check
             = self.enable_status_check;
 
@@ -307,6 +369,7 @@ impl<'a> HttpRequest<'a> {
                 body.extend_from_slice(&chunk);
             }
 
+            response.release_permit();
             Ok((response, body.freeze()))
         }).await
     }
@@ -378,8 +441,6 @@ impl HttpClient {
 
             // Enable connection keep-alive
             .tcp_keepalive(Duration::from_secs(60))
-
-            .connector_layer(tower::limit::concurrency::ConcurrencyLimitLayer::new(config.settings.network_concurrency.value))
 
             .dns_resolver(Arc::new(HickoryDnsResolver::default()));
 
@@ -483,6 +544,9 @@ impl HttpClient {
     }
 
     pub fn new(config: &Configuration) -> Result<Arc<Self>, Error> {
+        let network_concurrency
+            = config.settings.network_concurrency.value;
+
         let network_settings: Vec<_> = config.settings.network_settings.clone()
             .into_iter()
             // Sort the config by key length to match on the most specific pattern.
@@ -516,6 +580,7 @@ impl HttpClient {
         Ok(Arc::new(Self {
             client,
             network_clients,
+            network_semaphore: Arc::new(Semaphore::new(network_concurrency)),
             config,
             get_cache: DashMap::new(),
         }))
@@ -600,5 +665,147 @@ impl HttpClient {
 
     pub fn put(&self, url: impl AsRef<str>) -> Result<HttpRequest<'_>, Error> {
         self.request(url, Method::PUT)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{collections::BTreeMap, convert::Infallible, sync::atomic::{AtomicUsize, Ordering}};
+
+    use futures::stream;
+    use http_body_util::{BodyExt, StreamBody};
+    use hyper::{body::Frame, server::conn::http1, service::service_fn, Request, StatusCode};
+    use hyper_util::rt::TokioIo;
+    use tokio::{net::TcpListener, task::JoinHandle};
+    use zpm_config::ConfigurationContext;
+    use zpm_utils::LastModifiedAt;
+
+    use super::*;
+
+    const REQUEST_COUNT: usize = 20;
+    const REQUEST_DELAY: Duration = Duration::from_millis(50);
+
+    #[derive(Default)]
+    struct ServerState {
+        active: AtomicUsize,
+        peak: AtomicUsize,
+    }
+
+    struct ActiveRequest(Arc<ServerState>);
+
+    impl ActiveRequest {
+        fn new(state: Arc<ServerState>) -> Self {
+            let active = state.active.fetch_add(1, Ordering::SeqCst) + 1;
+            state.peak.fetch_max(active, Ordering::SeqCst);
+            Self(state)
+        }
+    }
+
+    impl Drop for ActiveRequest {
+        fn drop(&mut self) {
+            self.0.active.fetch_sub(1, Ordering::SeqCst);
+        }
+    }
+
+    fn test_client(network_concurrency: usize) -> Arc<HttpClient> {
+        let context = ConfigurationContext {
+            env: BTreeMap::new(),
+            user_cwd: None,
+            project_cwd: None,
+            package_cwd: None,
+        };
+        let mut last_modified_at = LastModifiedAt::new();
+        let mut config = Configuration::load(&context, &mut last_modified_at).unwrap();
+
+        config.settings.enforce_unsafe_http.value = true;
+        config.settings.http_retry.value = 0;
+        config.settings.network_concurrency.value = network_concurrency;
+
+        HttpClient::new(&config).unwrap()
+    }
+
+    async fn start_server() -> (String, Arc<ServerState>, JoinHandle<()>) {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let state = Arc::new(ServerState::default());
+        let server_state = state.clone();
+
+        let task = tokio::spawn(async move {
+            loop {
+                let (stream, _) = listener.accept().await.unwrap();
+                let connection_state = server_state.clone();
+
+                tokio::spawn(async move {
+                    let service = service_fn(move |request: Request<hyper::body::Incoming>| {
+                        let request_state = connection_state.clone();
+
+                        async move {
+                            let status = if request.uri().path() == "/failure" {
+                                StatusCode::INTERNAL_SERVER_ERROR
+                            } else {
+                                StatusCode::OK
+                            };
+                            let active_request = ActiveRequest::new(request_state);
+                            let body = StreamBody::new(stream::once(async move {
+                                tokio::time::sleep(REQUEST_DELAY).await;
+                                drop(active_request);
+                                Ok::<_, Infallible>(Frame::data(Bytes::from_static(b"ok")))
+                            })).boxed();
+
+                            Ok::<_, Infallible>(http::Response::builder()
+                                .status(status)
+                                .body(body)
+                                .unwrap())
+                        }
+                    });
+
+                    let _ = http1::Builder::new()
+                        .serve_connection(TokioIo::new(stream), service)
+                        .await;
+                });
+            }
+        });
+
+        (format!("http://{address}"), state, task)
+    }
+
+    #[tokio::test]
+    async fn network_concurrency_limits_in_flight_response_bodies() {
+        let network_concurrency = 2;
+        let client = test_client(network_concurrency);
+        let (server_url, state, server_task) = start_server().await;
+
+        futures::future::try_join_all((0..REQUEST_COUNT).map(|request_index| {
+            let client = client.clone();
+            let url = format!("{server_url}/{request_index}");
+
+            async move {
+                client.get(url)?.send().await?.bytes().await?;
+                Ok::<_, Error>(())
+            }
+        })).await.unwrap();
+
+        assert_eq!(state.peak.load(Ordering::SeqCst), network_concurrency);
+        assert_eq!(state.active.load(Ordering::SeqCst), 0);
+
+        server_task.abort();
+    }
+
+    #[tokio::test]
+    async fn network_concurrency_permit_is_released_after_failure() {
+        let client = test_client(1);
+        let (server_url, state, server_task) = start_server().await;
+
+        assert!(client.get(format!("{server_url}/failure")).unwrap().send().await.is_err());
+
+        tokio::time::timeout(Duration::from_secs(1), async {
+            client.get(format!("{server_url}/success"))?.send().await?.bytes().await?;
+            Ok::<_, Error>(())
+        }).await.unwrap().unwrap();
+
+        assert_eq!(state.peak.load(Ordering::SeqCst), 1);
+        assert_eq!(state.active.load(Ordering::SeqCst), 0);
+
+        server_task.abort();
     }
 }

--- a/packages/zpm/src/http_npm.rs
+++ b/packages/zpm/src/http_npm.rs
@@ -16,7 +16,7 @@ use zpm_utils::{DataType, Path};
 
 use crate::{
     error::Error,
-    http::{HttpClient, HttpRequest},
+    http::{HttpClient, HttpRequest, HttpResponse},
     npm,
     report::{current_report, PromptType},
 };
@@ -487,7 +487,8 @@ pub async fn get(params: &NpmHttpParams<'_>) -> Result<Bytes, Error> {
                 .enable_status_check(false)
                 .send_bytes().await?;
 
-            handle_invalid_authentication_error(params, &response).await?;
+            let response
+                = handle_invalid_authentication_error(params, response).await?;
 
             response.error_for_status()?;
             bytes
@@ -513,9 +514,11 @@ pub async fn get_uncached(params: &NpmHttpParams<'_>) -> Result<Bytes, Error> {
         .enable_status_check(false)
         .send_bytes().await?;
 
-    if params.authorization.is_some() {
-        handle_invalid_authentication_error(params, &response).await?;
-    }
+    let response = if params.authorization.is_some() {
+        handle_invalid_authentication_error(params, response).await?
+    } else {
+        response
+    };
 
     response.error_for_status()?;
     Ok(bytes)
@@ -742,7 +745,7 @@ async fn fetch_metadata_with_disk_cache(params: &GetPackageMetadataParams<'_>) -
     let (response, fresh_body)
         = request.send_bytes().await?;
 
-    if params.authorization.is_some() {
+    let response = if params.authorization.is_some() {
         let npm_params = NpmHttpParams {
             http_client: params.http_client,
             registry: params.registry,
@@ -750,8 +753,10 @@ async fn fetch_metadata_with_disk_cache(params: &GetPackageMetadataParams<'_>) -
             authorization: params.authorization,
             otp: None,
         };
-        handle_invalid_authentication_error(&npm_params, &response).await?;
-    }
+        handle_invalid_authentication_error(&npm_params, response).await?
+    } else {
+        response
+    };
 
     if response.status().as_u16() == 304 {
         if let Some(cached) = cached {
@@ -837,7 +842,7 @@ fn merge_versions_into_fresh(stale: &[u8], fresh: &[u8]) -> Vec<u8> {
     serde_json::to_vec(&fresh_json).unwrap_or_else(|_| fresh.to_vec())
 }
 
-pub async fn post(params: &NpmHttpParams<'_>, body: String) -> Result<Response, Error> {
+pub async fn post(params: &NpmHttpParams<'_>, body: String) -> Result<HttpResponse, Error> {
     let url
         = format!("{}{}", params.registry, params.path);
 
@@ -860,15 +865,17 @@ pub async fn post(params: &NpmHttpParams<'_>, body: String) -> Result<Response, 
             = ask_for_otp(params, &response).await?;
 
         request = inject_otp_headers(request, otp);
+        drop(response);
         response = request.send().await?;
     }
 
-    handle_invalid_authentication_error(params, &response).await?;
+    let response
+        = handle_invalid_authentication_error(params, response).await?;
 
     Ok(response.error_for_status()?)
 }
 
-pub async fn put(params: &NpmHttpParams<'_>, body: String) -> Result<Response, Error> {
+pub async fn put(params: &NpmHttpParams<'_>, body: String) -> Result<HttpResponse, Error> {
     let url
         = format!("{}{}", params.registry, params.path);
 
@@ -891,10 +898,12 @@ pub async fn put(params: &NpmHttpParams<'_>, body: String) -> Result<Response, E
             = ask_for_otp(params, &response).await?;
 
         request = inject_otp_headers(request, otp);
+        drop(response);
         response = request.send().await?;
     }
 
-    handle_invalid_authentication_error(params, &response).await?;
+    let response
+        = handle_invalid_authentication_error(params, response).await?;
 
     if let Err(error) = response.error_for_status_ref() {
         let body
@@ -920,14 +929,16 @@ fn inject_otp_headers(request: HttpRequest<'_>, otp: String) -> HttpRequest<'_> 
     request.header("npm-otp", Some(otp))
 }
 
-async fn handle_invalid_authentication_error(params: &NpmHttpParams<'_>, response: &Response) -> Result<(), Error> {
-    if is_otp_error(response) {
+async fn handle_invalid_authentication_error(params: &NpmHttpParams<'_>, response: HttpResponse) -> Result<HttpResponse, Error> {
+    if is_otp_error(&response) {
         return Err(Error::AuthenticationError(
             "Invalid OTP token".to_string()
         ));
     }
 
     if response.status().as_u16() == 401 {
+        drop(response);
+
         let attempted_as = match whoami(params.http_client, params.registry, params.authorization).await {
             Ok(Some(username)) => username,
             Ok(None) => "an anonymous user".to_string(),
@@ -939,7 +950,7 @@ async fn handle_invalid_authentication_error(params: &NpmHttpParams<'_>, respons
         ));
     }
 
-    Ok(())
+    Ok(response)
 }
 
 fn is_otp_error(response: &Response) -> bool {

--- a/tests/acceptance-tests/pkg-tests-specs/sources/commands/npm/login.test.ts
+++ b/tests/acceptance-tests/pkg-tests-specs/sources/commands/npm/login.test.ts
@@ -108,7 +108,9 @@ describe(`Commands`, () => {
 
     test(
       `it should throw an error when credentials are incorrect`,
-      makeTemporaryEnv({}, async ({path, run, source}) => {
+      makeTemporaryEnv({}, {
+        networkConcurrency: 1,
+      }, async ({path, run, source}) => {
         await expect(
           run(`npm`, `login`, {
             env: {

--- a/tests/acceptance-tests/pkg-tests-specs/sources/features/httpRetry.test.ts
+++ b/tests/acceptance-tests/pkg-tests-specs/sources/features/httpRetry.test.ts
@@ -28,6 +28,7 @@ describe(`Features`, () => {
       `it should retry truncated response bodies`,
       makeTemporaryEnv({}, {
         httpRetry: 1,
+        networkConcurrency: 1,
         unsafeHttpWhitelist: [`127.0.0.1`],
       }, async ({path, run, source}) => {
         const archivePath = await tests.getPackageArchivePath(`no-deps`, `1.0.0`);


### PR DESCRIPTION
## Motivation

`networkConcurrency` seems intended to restrict active network work. It currently limits connection establishment instead, so in reality more requests can be triggered while others are downloading response bodies beyond the configured limit.

Large monorepo installs may enqueue thousands of fetches. Without a request-lifecycle bound, concurrent downloads can exceed the expected limits, which is problematic on constrained network scenarios.

## Changes

Use a shared lifecycle permit for each HTTP request. The permit is acquired before the request starts and held until its response body completes, errors, or is dropped.

Permits are released before retry backoff and before authentication follow-up requests, avoiding self-starvation at low limits. This is the smallest correct direction because connection-pool or HTTP/2 settings do not bound active response bodies. Response-body retry behavior is unchanged.

## QA Instructions

Run the focused local tests:

```sh
cargo test -p zpm http::tests::network_concurrency -- --nocapture
```

The test server returns headers immediately, delays each body by 50 ms, and records peak active bodies while 20 GET requests run with `networkConcurrency: 2`.

| Revision | Peak active bodies | Elapsed | Throughput |
| --- | ---: | ---: | ---: |
| `origin/main` (`210b13e`) | 20 | 57 ms | 350.8 req/s |
| PR branch | 2 | 534 ms | 37.4 req/s |

The lower throughput is intentional and matches the configured resource bound. A separate limit-1 test verifies that a failed request releases its permit so the next request can proceed. Relevant npm, cache, login, and authentication integration suites also passed: 4 suites and 42 tests.

## Blast Radius

The change applies to requests made through `HttpClient`, including metadata and package downloads. The default limit remains 100.

Low configured limits may reduce install throughput as intended while bounding active network resource use. Connection pooling, HTTP/2, request retry policy, timeouts, and response-body retry behavior are otherwise unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the shared HTTP client used for registry and package downloads. Default limit is unchanged, but low `networkConcurrency` will now actually throttle throughput; permit-release bugs could stall installs.
> 
> **Overview**
> `networkConcurrency` now limits in-flight HTTP work through **response body completion**, not just connection setup. Previously tower’s connector limit let many downloads run at once after headers arrived.
> 
> `HttpClient` uses a shared `Semaphore`. Each request acquires a permit before `send` and wraps the result in `HttpResponse` so the permit lives until `bytes`/`text` finish, the body is drained, or the response is dropped. Permits are released before retry backoff and before auth follow-ups (`whoami`, OTP retry) so a limit of 1 cannot deadlock.
> 
> Removes the `tower` concurrency layer. Adds tests that peak concurrent bodies match the configured limit and that failed requests free the permit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 591e201a3ee6d07cb8f5e93b960f257cf23613c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->