### PR TITLE
Install performance: up-to-date fast path, incremental linking, parallel extraction, clonefile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5403,6 +5403,7 @@ name = "zpm-sync"
 version = "0.0.0"
 dependencies = [
  "itertools 0.14.0",
+ "rayon",
  "serde",
  "thiserror 2.0.18",
  "zpm-formats",

--- a/packages/zpm-primitives/src/reference.rs
+++ b/packages/zpm-primitives/src/reference.rs
@@ -124,11 +124,16 @@ pub enum Reference {
         path: String,
     },
 
-    #[pattern(r"portal:(?<path>.*)")]
-    #[to_file_string(|params| format!("portal:{}", params.path))]
-    #[to_print_string(|params| DataType::Reference.colorize(&format!("portal:{}", params.path)))]
+    #[pattern(r"portal:(?<path>.*?)(?:#(?<hash>[a-f0-9]*))?")]
+    #[to_file_string(|params| format_local("portal", &params.path, &params.hash))]
+    #[to_print_string(|params| DataType::Reference.colorize(&format_local("portal", &params.path, &params.hash)))]
     Portal {
         path: String,
+
+        /// Hash of the portal target's manifest. Portals aren't
+        /// copied, but their manifest feeds the resolution, so the
+        /// locator must change when it does.
+        hash: Option<Hash64>,
     },
 
     #[pattern(r"exec:(?<path>.*?)(?:#(?<hash>[a-f0-9]*))?")]

--- a/packages/zpm-sync/Cargo.toml
+++ b/packages/zpm-sync/Cargo.toml
@@ -4,6 +4,7 @@ edition = "2021"
 
 [dependencies]
 itertools = { workspace = true }
+rayon = { workspace = true }
 serde = { workspace = true }
 thiserror = { workspace = true }
 zpm-formats = { workspace = true }

--- a/packages/zpm-sync/src/lib.rs
+++ b/packages/zpm-sync/src/lib.rs
@@ -217,17 +217,34 @@ impl<'a> SyncTree<'a> {
     }
 
     pub fn run(&self, root_path: Path) -> Result<Vec<FileOp>, SyncError> {
+        use rayon::prelude::*;
+
         let mut file_ops
             = Vec::new();
 
-        let mut queue
+        // Nodes are processed level by level so parents always exist
+        // before their children; within a level every node is
+        // independent and can run in parallel.
+        let mut current_level
             = vec![(root_path, 0)];
 
-        while let Some((path, node_idx)) = queue.pop() {
-            let next_tasks
-                = self.process_node(path, node_idx, &mut file_ops)?;
+        while !current_level.is_empty() {
+            let results = current_level
+                .into_par_iter()
+                .map(|(path, node_idx)| {
+                    let mut ops = Vec::new();
+                    let next_tasks = self.process_node(path, node_idx, &mut ops)?;
 
-            queue.extend(next_tasks);
+                    Ok((ops, next_tasks))
+                })
+                .collect::<Result<Vec<_>, SyncError>>()?;
+
+            current_level = Vec::new();
+
+            for (ops, next_tasks) in results {
+                file_ops.extend(ops);
+                current_level.extend(next_tasks);
+            }
         }
 
         Ok(file_ops)

--- a/packages/zpm-sync/src/lib.rs
+++ b/packages/zpm-sync/src/lib.rs
@@ -25,6 +25,13 @@ pub enum SyncItem<'a> {
 
     Folder {
         template: Option<SyncTemplate>,
+
+        /// The caller vouches that the on-disk content of this folder
+        /// already matches its template; the sync keeps the folder
+        /// without expanding the template. Explicitly registered
+        /// children are still visited.
+        #[serde(default)]
+        assume_up_to_date: bool,
     },
 
     Symlink {
@@ -68,6 +75,7 @@ impl From<std::io::Error> for SyncError {
 pub struct SyncCheck {
     pub must_remove: bool,
     pub must_create: bool,
+    pub exists: bool,
 }
 
 pub struct SyncTree<'a> {
@@ -113,6 +121,7 @@ impl<'a> SyncTree<'a> {
             dry_run: true,
             nodes: vec![SyncNode::Folder {
                 template: None,
+                assume_up_to_date: false,
                 children: BTreeMap::new(),
             }],
         }
@@ -154,7 +163,7 @@ impl<'a> SyncTree<'a> {
         let node
             = &self.nodes[node_idx];
 
-        matches!(node, SyncNode::Folder {template: None, children} if children.is_empty())
+        matches!(node, SyncNode::Folder {template: None, children, ..} if children.is_empty())
     }
 
     pub fn register_entry(&mut self, rel_path: Path, entry: SyncItem<'a>) -> Result<(), SyncError> {
@@ -192,9 +201,10 @@ impl<'a> SyncTree<'a> {
         let existing_node
             = &mut self.nodes[existing_node_idx];
 
-        if let SyncNode::Folder {template: existing_template, ..} = existing_node {
-            if let SyncItem::Folder {template: new_template, ..} = &entry {
+        if let SyncNode::Folder {template: existing_template, assume_up_to_date: existing_assume, ..} = existing_node {
+            if let SyncItem::Folder {template: new_template, assume_up_to_date: new_assume} = &entry {
                 *existing_template = new_template.clone();
+                *existing_assume = *new_assume;
                 return Ok(());
             }
         }
@@ -251,6 +261,7 @@ impl<'a> SyncTree<'a> {
 
             self.nodes.push(SyncNode::Folder {
                 template: None,
+                assume_up_to_date: false,
                 children: BTreeMap::new(),
             });
         }
@@ -263,6 +274,7 @@ impl<'a> SyncTree<'a> {
             return Ok(SyncCheck {
                 must_remove: false,
                 must_create: false,
+                exists: true,
             });
         }
 
@@ -270,6 +282,7 @@ impl<'a> SyncTree<'a> {
             return Ok(SyncCheck {
                 must_remove: false,
                 must_create: true,
+                exists: false,
             });
         };
 
@@ -285,6 +298,7 @@ impl<'a> SyncTree<'a> {
                 Ok(SyncCheck {
                     must_remove: !is_dir,
                     must_create: !is_dir && template.is_none(),
+                    exists: true,
                 })
             },
 
@@ -301,6 +315,7 @@ impl<'a> SyncTree<'a> {
                 Ok(SyncCheck {
                     must_remove: !is_file_up_to_date,
                     must_create: !is_file_up_to_date,
+                    exists: true,
                 })
             },
 
@@ -316,6 +331,7 @@ impl<'a> SyncTree<'a> {
                 Ok(SyncCheck {
                     must_remove: !is_symlink_up_to_date,
                     must_create: !is_symlink_up_to_date,
+                    exists: true,
                 })
             },
         }
@@ -346,7 +362,7 @@ impl<'a> SyncTree<'a> {
                 Ok(vec![])
             },
 
-            SyncNode::Folder {template, children, ..} => {
+            SyncNode::Folder {template, assume_up_to_date, children} => {
                 if check.must_create {
                     if self.dry_run {
                         file_ops.push(FileOp::CreateFolder(path.clone()));
@@ -355,9 +371,15 @@ impl<'a> SyncTree<'a> {
                     }
                 }
 
+                // An assumed folder that turns out to be missing (or of
+                // the wrong type) self-heals through the regular
+                // template expansion.
+                let expand_template
+                    = !assume_up_to_date || !check.exists || check.must_remove;
+
                 if let Some(template) = &template {
                     match template {
-                        SyncTemplate::Zip {archive_path, inner_path} => {
+                        SyncTemplate::Zip {archive_path, inner_path} if expand_template => {
                             let zip_buffer
                                 = archive_path.fs_read()?;
 
@@ -382,6 +404,10 @@ impl<'a> SyncTree<'a> {
                                 = template_tree.run(path.clone())?;
 
                             file_ops.extend(inner_file_ops);
+                        },
+
+                        SyncTemplate::Zip {..} => {
+                            // Assumed up-to-date; leave the folder as is.
                         },
                     }
                 } else {
@@ -454,6 +480,7 @@ pub enum SyncNode<'a> {
 
     Folder {
         template: Option<SyncTemplate>,
+        assume_up_to_date: bool,
         children: BTreeMap<String, usize>,
     },
 
@@ -472,8 +499,9 @@ impl<'a> From<SyncItem<'a>> for SyncNode<'a> {
         match entry {
             SyncItem::Any => SyncNode::Any,
 
-            SyncItem::Folder {template} => SyncNode::Folder {
+            SyncItem::Folder {template, assume_up_to_date} => SyncNode::Folder {
                 template,
+                assume_up_to_date,
                 children: BTreeMap::new(),
             },
 

--- a/packages/zpm-utils/src/hash.rs
+++ b/packages/zpm-utils/src/hash.rs
@@ -68,6 +68,11 @@ impl Hash64 {
         hex::encode(&self.state[0..3])
     }
 
+    /// First byte of the hash; handy for sharding locks or maps.
+    pub fn first_byte(&self) -> u8 {
+        self.state.first().copied().unwrap_or(0)
+    }
+
     pub fn short(&self) -> String {
         hex::encode(&self.state[0..16])
     }

--- a/packages/zpm-utils/src/path.rs
+++ b/packages/zpm-utils/src/path.rs
@@ -859,6 +859,35 @@ impl Path {
         Ok(self)
     }
 
+    /**
+     * Clone this file or directory tree to `new_path` using the OS
+     * copy-on-write primitive (`clonefile` on macOS). The destination
+     * must not exist. Fails on platforms or filesystems without
+     * support; callers are expected to fall back to a regular copy.
+     */
+    pub fn fs_clonefile(&self, new_path: &Path) -> Result<&Self, PathError> {
+        #[cfg(target_os = "macos")]
+        {
+            let source = std::ffi::CString::new(self.to_path_buf().as_os_str().as_bytes())
+                .map_err(|_| std::io::Error::from(std::io::ErrorKind::InvalidInput))?;
+            let target = std::ffi::CString::new(new_path.to_path_buf().as_os_str().as_bytes())
+                .map_err(|_| std::io::Error::from(std::io::ErrorKind::InvalidInput))?;
+
+            if unsafe {libc::clonefile(source.as_ptr(), target.as_ptr(), 0)} != 0 {
+                return Err(std::io::Error::last_os_error().into());
+            }
+
+            Ok(self)
+        }
+
+        #[cfg(not(target_os = "macos"))]
+        {
+            let _ = new_path;
+
+            Err(std::io::Error::new(std::io::ErrorKind::Unsupported, "clonefile is not supported on this platform").into())
+        }
+    }
+
     pub fn fs_copy(&self, new_path: &Path) -> Result<&Self, PathError> {
         match self.fs_is_dir() {
             true => {

--- a/packages/zpm/src/commands/install.rs
+++ b/packages/zpm/src/commands/install.rs
@@ -3,7 +3,7 @@ use zpm_config::Source;
 use zpm_parsers::JsonDocument;
 use zpm_utils::is_terminal;
 
-use crate::{error::Error, immutable, project::{self, InstallMode, RunInstallOptions}};
+use crate::{error::Error, immutable, project::{self, InstallMode, RunInstallOptions}, report::{self, StreamReport, StreamReportConfig, with_report_result}};
 
 /// Install dependencies
 ///
@@ -140,6 +140,21 @@ impl Install {
             && self.mode.is_none()
             && project.is_install_up_to_date()?
         {
+            let report = StreamReport::new(StreamReportConfig {
+                include_version: true,
+                json: self.json,
+                silent_or_error: self.silent,
+                ..StreamReportConfig::from_config(&project.config)
+            });
+
+            with_report_result(report, async {
+                report::if_active(|report| {
+                    report.info("All dependencies are up-to-date, nothing to do. Run with `--force` to ignore this check.".to_string());
+                });
+
+                Ok(())
+            }).await?;
+
             return Ok(());
         }
 

--- a/packages/zpm/src/commands/install.rs
+++ b/packages/zpm/src/commands/install.rs
@@ -1,7 +1,7 @@
 use clipanion::cli;
 use zpm_config::Source;
 use zpm_parsers::JsonDocument;
-use zpm_utils::is_terminal;
+use zpm_utils::{DataType, is_terminal};
 
 use crate::{error::Error, immutable, project::{self, InstallMode, RunInstallOptions}, report::{self, StreamReport, StreamReportConfig, with_report_result}};
 
@@ -149,7 +149,7 @@ impl Install {
 
             with_report_result(report, async {
                 report::if_active(|report| {
-                    report.info("All dependencies are up-to-date, nothing to do. Run with `--force` to ignore this check.".to_string());
+                    report.info(format!("All dependencies are up-to-date, nothing to do. Run with {} to ignore this check.", DataType::Code.colorize("--force")));
                 });
 
                 Ok(())

--- a/packages/zpm/src/commands/install.rs
+++ b/packages/zpm/src/commands/install.rs
@@ -175,6 +175,7 @@ impl Install {
             silent_or_error: self.silent,
             json: self.json,
             inline_builds: self.inline_builds,
+            force,
             ..Default::default()
         }).await?;
 

--- a/packages/zpm/src/commands/install.rs
+++ b/packages/zpm/src/commands/install.rs
@@ -64,8 +64,8 @@ pub struct Install {
     refresh_lockfile: bool,
 
     /// Run a full install even when everything looks up-to-date; defaults to true in interactive terminals
-    #[cli::option("-f,--force")]
-    force: Option<bool>,
+    #[cli::option("-f,--force", default = is_terminal())]
+    force: bool,
 
     /// Select which install artifacts Yarn should generate
     #[cli::option("--mode")]
@@ -133,10 +133,7 @@ impl Install {
         // install is provably still current. Interactive runs skip this
         // fast path so that a manually damaged project (say, a deleted
         // package folder) heals when the user reaches for `yarn install`.
-        let force = self.force
-            .unwrap_or_else(is_terminal);
-
-        if !force
+        if !self.force
             && !self.check_resolutions
             && !self.check_checksums
             && !refresh_lockfile
@@ -175,7 +172,7 @@ impl Install {
             silent_or_error: self.silent,
             json: self.json,
             inline_builds: self.inline_builds,
-            force,
+            force: self.force,
             ..Default::default()
         }).await?;
 

--- a/packages/zpm/src/commands/install.rs
+++ b/packages/zpm/src/commands/install.rs
@@ -1,6 +1,7 @@
 use clipanion::cli;
 use zpm_config::Source;
 use zpm_parsers::JsonDocument;
+use zpm_utils::is_terminal;
 
 use crate::{error::Error, immutable, project::{self, InstallMode, RunInstallOptions}};
 
@@ -61,6 +62,10 @@ pub struct Install {
     /// Refresh package metadata stored in the lockfile
     #[cli::option("--refresh-lockfile", default = false)]
     refresh_lockfile: bool,
+
+    /// Run a full install even when everything looks up-to-date; defaults to true in interactive terminals
+    #[cli::option("-f,--force")]
+    force: Option<bool>,
 
     /// Select which install artifacts Yarn should generate
     #[cli::option("--mode")]
@@ -123,6 +128,23 @@ impl Install {
 
         let refresh_lockfile = self.refresh_lockfile
             || project.config.settings.enable_hardened_mode.value;
+
+        // A plain `yarn install` can stop right away when the previous
+        // install is provably still current. Interactive runs skip this
+        // fast path so that a manually damaged project (say, a deleted
+        // package folder) heals when the user reaches for `yarn install`.
+        let force = self.force
+            .unwrap_or_else(is_terminal);
+
+        if !force
+            && !self.check_resolutions
+            && !self.check_checksums
+            && !refresh_lockfile
+            && self.mode.is_none()
+            && project.is_install_up_to_date()?
+        {
+            return Ok(());
+        }
 
         sort_workspace_dependencies(&project)?;
 

--- a/packages/zpm/src/install.rs
+++ b/packages/zpm/src/install.rs
@@ -846,6 +846,13 @@ pub struct InstallState {
     /// install states deserialize.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub nm_mode: Option<String>,
+
+    /// Modification time of the lockfile as of when this install state
+    /// was written. The manifest mtime guard can't see out-of-band
+    /// lockfile edits (a `git pull` touching only `yarn.lock`), so the
+    /// up-to-date fast path compares against this instead.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub lockfile_changed_at: Option<u128>,
 }
 
 impl Default for InstallState {
@@ -867,6 +874,7 @@ impl Default for InstallState {
             island_normalized_resolutions: BTreeMap::new(),
             cache_checksums: BTreeMap::new(),
             nm_mode: None,
+            lockfile_changed_at: None,
         }
     }
 }
@@ -1080,27 +1088,44 @@ impl Install {
             self.install_state.install_config_hash
                 = Some(project.install_config_hash());
 
-            project.attach_install_state(self.install_state)?;
-
+            // The lockfile must hit the disk before we record its mtime
+            // in the install state, so the state is only persisted once
+            // everything it vouches for actually exists.
             if !self.skip_lockfile_update {
                 project.write_lockfile(&self.lockfile)?;
             }
+
+            self.install_state.lockfile_changed_at
+                = project.lockfile_changed_at()?;
+
+            project.attach_install_state(self.install_state)?;
 
             if !self.skip_build && !link_result.build_requests.entries.is_empty() {
                 let build_future
                     = build::BuildManager::new(link_result.build_requests).run(project);
 
                 let build_result
-                    = async_section("Building packages", build_future).await?;
+                    = async_section("Building packages", build_future).await;
 
-                if !build_result.build_errors.is_empty() {
-                    return Err(Error::SilentError);
+                let build_failed = match &build_result {
+                    Ok(build) => !build.build_errors.is_empty(),
+                    Err(_) => true,
+                };
+
+                if build_failed {
+                    invalidate_install_freshness(project)?;
+                }
+
+                match build_result {
+                    Err(e) => return Err(e),
+                    Ok(build) if !build.build_errors.is_empty() => return Err(Error::SilentError),
+                    Ok(_) => {},
                 }
             }
         }
 
         if self.constraints_check {
-            async_section("Checking constraints", async {
+            let constraints_result = async_section("Checking constraints", async {
                 let output
                     = check_constraints(project, false).await?;
 
@@ -1109,7 +1134,12 @@ impl Install {
                 }
 
                 Ok(())
-            }).await?;
+            }).await;
+
+            if let Err(e) = constraints_result {
+                invalidate_install_freshness(project)?;
+                return Err(e);
+            }
         }
 
         project.ignore_path()
@@ -1121,6 +1151,19 @@ impl Install {
             package_data: self.package_data,
         })
     }
+}
+
+/// Drops the freshness marker from the persisted install state so the
+/// next `yarn install` can't take the up-to-date fast path — used when
+/// an install completed its link step but failed afterwards (builds,
+/// constraints), leaving the project in a state that needs another pass.
+fn invalidate_install_freshness(project: &mut Project) -> Result<(), Error> {
+    if let Some(mut install_state) = project.install_state.take() {
+        install_state.lockfile_changed_at = None;
+        project.attach_install_state(install_state)?;
+    }
+
+    Ok(())
 }
 
 pub struct InstallManager<'a> {

--- a/packages/zpm/src/install.rs
+++ b/packages/zpm/src/install.rs
@@ -1096,25 +1096,38 @@ impl Install {
                 project.write_lockfile(&self.lockfile)?;
             }
 
-            self.install_state.lockfile_changed_at
-                = project.lockfile_changed_at()?;
+            let has_pending_builds
+                = !link_result.build_requests.entries.is_empty();
+
+            // The freshness marker only goes in once the builds went
+            // through: stamping earlier would let an interrupted (or
+            // `--mode=skip-build`) install pass the fast path with
+            // builds still pending.
+            self.install_state.lockfile_changed_at = if has_pending_builds {
+                None
+            } else {
+                project.lockfile_changed_at()?
+            };
 
             project.attach_install_state(self.install_state)?;
 
-            if !self.skip_build && !link_result.build_requests.entries.is_empty() {
+            if !self.skip_build && has_pending_builds {
                 let build_future
                     = build::BuildManager::new(link_result.build_requests).run(project);
 
                 let build_result
                     = async_section("Building packages", build_future).await;
 
-                let build_failed = match &build_result {
-                    Ok(build) => !build.build_errors.is_empty(),
-                    Err(_) => true,
+                let build_succeeded = match &build_result {
+                    Ok(build) => build.build_errors.is_empty(),
+                    Err(_) => false,
                 };
 
-                if build_failed {
-                    invalidate_install_freshness(project)?;
+                if build_succeeded {
+                    if let Some(mut install_state) = project.install_state.take() {
+                        install_state.lockfile_changed_at = project.lockfile_changed_at()?;
+                        project.attach_install_state(install_state)?;
+                    }
                 }
 
                 match build_result {

--- a/packages/zpm/src/install.rs
+++ b/packages/zpm/src/install.rs
@@ -893,6 +893,7 @@ pub struct Install {
     pub skip_lockfile_update: bool,
     pub constraints_check: bool,
     pub inline_builds: bool,
+    pub force: bool,
     pub extension_tracking: Arc<Mutex<ExtensionTracking>>,
 }
 
@@ -1226,6 +1227,11 @@ impl<'a> InstallManager<'a> {
 
     pub fn with_skip_lockfile_update(mut self, skip_lockfile_update: bool) -> Self {
         self.result.skip_lockfile_update = skip_lockfile_update;
+        self
+    }
+
+    pub fn with_force(mut self, force: bool) -> Self {
+        self.result.force = force;
         self
     }
 

--- a/packages/zpm/src/install.rs
+++ b/packages/zpm/src/install.rs
@@ -853,12 +853,6 @@ pub struct InstallState {
     /// up-to-date fast path compares against this instead.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub lockfile_changed_at: Option<u128>,
-
-    /// Fingerprint of the local files feeding resolutions (file:
-    /// tarballs, patch files, portal manifests) as of when this state
-    /// was written; see `Project::local_sources_fingerprint`.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub local_sources_hash: Option<Hash64>,
 }
 
 impl Default for InstallState {
@@ -881,7 +875,6 @@ impl Default for InstallState {
             cache_checksums: BTreeMap::new(),
             nm_mode: None,
             lockfile_changed_at: None,
-            local_sources_hash: None,
         }
     }
 }
@@ -1105,9 +1098,6 @@ impl Install {
 
             self.install_state.lockfile_changed_at
                 = project.lockfile_changed_at()?;
-
-            self.install_state.local_sources_hash
-                = project.local_sources_fingerprint()?;
 
             project.attach_install_state(self.install_state)?;
 

--- a/packages/zpm/src/install.rs
+++ b/packages/zpm/src/install.rs
@@ -853,6 +853,12 @@ pub struct InstallState {
     /// up-to-date fast path compares against this instead.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub lockfile_changed_at: Option<u128>,
+
+    /// Fingerprint of the local files feeding resolutions (file:
+    /// tarballs, patch files, portal manifests) as of when this state
+    /// was written; see `Project::local_sources_fingerprint`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub local_sources_hash: Option<Hash64>,
 }
 
 impl Default for InstallState {
@@ -875,6 +881,7 @@ impl Default for InstallState {
             cache_checksums: BTreeMap::new(),
             nm_mode: None,
             lockfile_changed_at: None,
+            local_sources_hash: None,
         }
     }
 }
@@ -1098,6 +1105,9 @@ impl Install {
 
             self.install_state.lockfile_changed_at
                 = project.lockfile_changed_at()?;
+
+            self.install_state.local_sources_hash
+                = project.local_sources_fingerprint()?;
 
             project.attach_install_state(self.install_state)?;
 

--- a/packages/zpm/src/linker/helpers.rs
+++ b/packages/zpm/src/linker/helpers.rs
@@ -3,7 +3,7 @@ use std::{collections::{BTreeMap, BTreeSet}, fs::Permissions, os::unix::fs::Perm
 use zpm_formats::iter_ext::IterExt;
 use zpm_parsers::JsonDocument;
 use zpm_primitives::{Descriptor, VersionFilter, Locator, Reference};
-use zpm_utils::{Path, PathError, System};
+use zpm_utils::{IoResultExt, Path, PathError, System};
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 
@@ -279,6 +279,138 @@ fn link_into_local_index(
     drop(shard);
 
     ensure_hardlink(target_path, &canonical_path)
+}
+
+/// Extracts every entry of the package archive under `destination`,
+/// with no completion marker; used for the unpacked store and as the
+/// fallback when a clone fails halfway.
+pub(crate) fn extract_zip_entries_to(destination: &Path, package_data: &PackageData) -> Result<(), Error> {
+    let package_subpath
+        = package_data.package_subpath();
+
+    let package_bytes = match package_data {
+        PackageData::Zip {archive_path, ..} => archive_path.fs_read()?,
+        _ => panic!("Expected a zip archive"),
+    };
+
+    let entries
+        = zpm_formats::zip::entries_from_zip(&package_bytes)?
+            .into_iter()
+            .strip_path_prefix(&package_subpath)
+            .collect::<Vec<_>>();
+
+    for entry in entries {
+        let target_path = destination
+            .with_join(&entry.name);
+
+        target_path.fs_create_parent()?;
+
+        target_path
+            .fs_write(&entry.data)?
+            .fs_set_permissions(Permissions::from_mode(entry.mode as u32))?;
+    }
+
+    Ok(())
+}
+
+/// Whether copy-on-write clones work between the unpacked store and
+/// the project. Probed once per process by cloning a marker file; any
+/// failure (other platform, other filesystem, cross-volume setup)
+/// simply disables clone-based materialization.
+pub fn clonefile_supported(store_root: &Path, project_cwd: &Path) -> bool {
+    use std::sync::OnceLock;
+
+    static SUPPORTED: OnceLock<bool> = OnceLock::new();
+
+    *SUPPORTED.get_or_init(|| {
+        let probe = || -> Result<(), Error> {
+            store_root.fs_create_dir_all()?;
+
+            let source = store_root
+                .with_join_str(format!(".clone-probe-{}", std::process::id()));
+            let target = project_cwd
+                .with_join_str(format!(".clone-probe-{}", std::process::id()));
+
+            source.fs_write([])?;
+            let _ = target.fs_rm_file().ok_missing();
+
+            let cloned = source.fs_clonefile(&target);
+
+            let _ = source.fs_rm_file().ok_missing();
+            let _ = target.fs_rm_file().ok_missing();
+
+            cloned?;
+
+            Ok(())
+        };
+
+        probe().is_ok()
+    })
+}
+
+/// Ensures the unpacked store holds a pristine copy of the package,
+/// keyed by locator and content checksum, and returns its path. The
+/// entry is built in a temp folder and renamed in place so concurrent
+/// installs can race safely.
+pub fn ensure_unpacked_store_entry(
+    store_root: &Path,
+    locator: &Locator,
+    checksum: &zpm_utils::Hash64,
+    package_data: &PackageData,
+) -> Result<Path, Error> {
+    let entry_path = store_root.with_join_str(format!(
+        "{}-{}-{}",
+        locator.ident.slug(),
+        locator.reference.slug(),
+        checksum.short(),
+    ));
+
+    if entry_path.fs_exists() {
+        return Ok(entry_path);
+    }
+
+    // The nonce keeps parallel extractions of the same package (the
+    // tree may materialize one locator at several locations) from
+    // clobbering each other's temp folder.
+    static STORE_TMP_NONCE: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
+    let tmp_path = store_root.with_join_str(format!(
+        ".tmp-{}-{}-{}",
+        std::process::id(),
+        STORE_TMP_NONCE.fetch_add(1, std::sync::atomic::Ordering::Relaxed),
+        checksum.short(),
+    ));
+
+    tmp_path.fs_create_dir_all()?;
+
+    if let Err(error) = extract_zip_entries_to(&tmp_path, package_data) {
+        let _ = tmp_path.fs_rm().ok_missing();
+        return Err(error);
+    }
+
+    if let Err(error) = tmp_path.fs_rename(&entry_path) {
+        let _ = tmp_path.fs_rm().ok_missing();
+
+        // Another process finished the same entry first; use theirs.
+        if !entry_path.fs_exists() {
+            return Err(error.into());
+        }
+    }
+
+    Ok(entry_path)
+}
+
+/// Materializes `destination` as a copy-on-write clone of the store
+/// entry, replacing whatever was there.
+pub fn clone_package_from_store(destination: &Path, store_entry: &Path) -> Result<(), Error> {
+    if destination.fs_exists() {
+        destination.fs_rm()?;
+    }
+
+    destination.fs_create_parent()?;
+    store_entry.fs_clonefile(destination)?;
+
+    Ok(())
 }
 
 /// Stamped on every CAS entry. An mtime that doesn't match flags

--- a/packages/zpm/src/linker/helpers.rs
+++ b/packages/zpm/src/linker/helpers.rs
@@ -96,22 +96,64 @@ pub fn fs_extract_archive_with_cas(destination: &Path, package_data: &PackageDat
 
 /// Project-local dedup with no side-channel index. The first
 /// destination for a given content hash is written normally and
-/// recorded in `local_index`; later destinations hardlink to it.
+/// recorded in the index; later destinations hardlink to it.
 pub fn fs_extract_archive_with_local_dedup(
     destination: &Path,
     package_data: &PackageData,
-    local_index: &mut BTreeMap<zpm_utils::Hash64, Path>,
+    local_index: &LocalDedupIndex,
 ) -> Result<bool, Error> {
     fs_extract_archive_impl(destination, package_data, ExtractMode::LocalDedup { local_index })
+}
+
+const DEDUP_SHARDS: usize = 64;
+
+/// Content-hash index shared between parallel extractions. Sharded by
+/// the hash's first byte so identical contents serialize on one lock
+/// while unrelated files proceed concurrently.
+pub struct LocalDedupIndex {
+    shards: Vec<std::sync::Mutex<BTreeMap<zpm_utils::Hash64, Path>>>,
+}
+
+impl LocalDedupIndex {
+    pub fn new() -> Self {
+        Self {
+            shards: (0..DEDUP_SHARDS)
+                .map(|_| std::sync::Mutex::new(BTreeMap::new()))
+                .collect(),
+        }
+    }
+
+    fn shard(&self, hash: &zpm_utils::Hash64) -> &std::sync::Mutex<BTreeMap<zpm_utils::Hash64, Path>> {
+        &self.shards[hash.first_byte() as usize % DEDUP_SHARDS]
+    }
+}
+
+impl Default for LocalDedupIndex {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Serializes concurrent global-CAS writes of identical contents;
+/// without it, two threads could interleave writes to the same index
+/// entry. Keyed by the entry's content hash.
+fn cas_shard_lock(first_byte: u8) -> &'static std::sync::Mutex<()> {
+    use std::sync::OnceLock;
+
+    static LOCKS: OnceLock<Vec<std::sync::Mutex<()>>> = OnceLock::new();
+
+    let locks = LOCKS.get_or_init(|| (0..DEDUP_SHARDS).map(|_| std::sync::Mutex::new(())).collect());
+
+    &locks[first_byte as usize % DEDUP_SHARDS]
 }
 
 enum ExtractMode<'a> {
     Classic,
     Cas { index_root: &'a Path },
-    LocalDedup { local_index: &'a mut BTreeMap<zpm_utils::Hash64, Path> },
+    LocalDedup { local_index: &'a LocalDedupIndex },
 }
 
-fn fs_extract_archive_impl(destination: &Path, package_data: &PackageData, mut mode: ExtractMode<'_>) -> Result<bool, Error> {
+fn fs_extract_archive_impl(destination: &Path, package_data: &PackageData, mode: ExtractMode<'_>) -> Result<bool, Error> {
     let ready_path = destination
         .with_join_str(".ready");
 
@@ -144,7 +186,7 @@ fn fs_extract_archive_impl(destination: &Path, package_data: &PackageData, mut m
 
         target_path.fs_create_parent()?;
 
-        match &mut mode {
+        match &mode {
             ExtractMode::Cas { index_root } => {
                 link_into_cas(&target_path, &entry.data, entry.mode as u32, index_root)?;
             },
@@ -212,21 +254,29 @@ fn link_into_local_index(
     target_path: &Path,
     data: &[u8],
     mode: u32,
-    local_index: &mut BTreeMap<zpm_utils::Hash64, Path>,
+    local_index: &LocalDedupIndex,
 ) -> Result<(), Error> {
     let mode_bits = mode & 0o777;
     let hash = zpm_utils::Hash64::from_data(data);
 
+    let mut shard = local_index.shard(&hash)
+        .lock()
+        .unwrap();
+
     // Fall through to write_canonical when the recorded path is gone;
-    // that re-registers a new home for this hash.
-    let canonical_path = local_index.get(&hash).cloned()
+    // that re-registers a new home for this hash. The canonical write
+    // happens under the shard lock so a concurrent extraction of the
+    // same content can't hardlink to a half-written file.
+    let canonical_path = shard.get(&hash).cloned()
         .filter(|p| p.fs_exists());
 
     let Some(canonical_path) = canonical_path else {
         write_canonical(target_path, data, mode_bits)?;
-        local_index.insert(hash, target_path.clone());
+        shard.insert(hash, target_path.clone());
         return Ok(());
     };
+
+    drop(shard);
 
     ensure_hardlink(target_path, &canonical_path)
 }
@@ -261,6 +311,12 @@ fn link_into_cas(target_path: &Path, data: &[u8], mode: u32, index_root: &Path) 
         .with_join_str(&index_filename);
 
     index_dir.fs_create_dir_all()?;
+
+    // Serialize on the content hash so parallel extractions of the
+    // same file can't interleave their writes to the index entry.
+    let _shard_guard = cas_shard_lock(u8::from_str_radix(&hash[..2], 16).unwrap_or(0))
+        .lock()
+        .unwrap();
 
     let mut needs_rewrite = !index_path.fs_exists();
 

--- a/packages/zpm/src/linker/helpers.rs
+++ b/packages/zpm/src/linker/helpers.rs
@@ -381,6 +381,11 @@ pub fn ensure_unpacked_store_entry(
         checksum.short(),
     ));
 
+    // A crashed run can leave this exact path behind (pids and the
+    // nonce both reset, typically in containers); extracting over its
+    // leftovers would graft stale files into an immutable store entry.
+    let _ = tmp_path.fs_rm().ok_missing();
+
     tmp_path.fs_create_dir_all()?;
 
     if let Err(error) = extract_zip_entries_to(&tmp_path, package_data) {

--- a/packages/zpm/src/linker/nm/mod.rs
+++ b/packages/zpm/src/linker/nm/mod.rs
@@ -226,6 +226,21 @@ impl PreviousPackageMap {
 /// Builds the sync tree for one workspace's node_modules. The caller
 /// runs the returned trees (possibly in parallel; they cover disjoint
 /// folders) once every workspace was planned.
+/// Resolves the unpacked store used for clonefile materialization:
+/// `Some` only for the classic nmMode on systems where copy-on-write
+/// clones between the store and the project actually work.
+fn clone_store_for(project: &Project) -> Option<Path> {
+    if project.config.settings.nm_mode.value != zpm_config::NmMode::Classic {
+        return None;
+    }
+
+    let store_root = project.config.settings.global_folder.value
+        .with_join_str("unpacked");
+
+    linker::helpers::clonefile_supported(&store_root, &project.project_cwd)
+        .then_some(store_root)
+}
+
 fn generate_workspace_node_modules(
     project: &Project,
     install: &Install,
@@ -233,10 +248,12 @@ fn generate_workspace_node_modules(
     workspace_node_idx: usize,
     package_map_builder: Option<&mut NodeModulesPackageMapBuilder>,
     previous_map: Option<&PreviousPackageMap>,
+    clone_store: Option<&Path>,
     packages_by_location: &mut BTreeMap<Path, zpm_primitives::Locator>,
     canonical_build_locations: &mut BTreeMap<Locator, Path>,
     force_rebuild_locators: &mut BTreeSet<Locator>,
     cas_extractions: &mut Vec<(Path, Locator)>,
+    clone_extractions: &mut Vec<(Path, Locator)>,
 ) -> Result<(SyncTree<'static>, Path), Error> {
     let mut package_map_builder
         = package_map_builder;
@@ -445,6 +462,17 @@ fn generate_workspace_node_modules(
                             previous_map.matches_package(&abs_path, &child_node.locator, checksum)
                         });
 
+                    // Leaf packages with a known checksum can be
+                    // materialized as a copy-on-write clone of the
+                    // unpacked store instead of file-by-file writes.
+                    // Only fresh folders qualify: reconciling an
+                    // existing one in place preserves its inode, which
+                    // file watchers rely on across updates.
+                    let use_clone = clone_store.is_some()
+                        && !dest_exists
+                        && !has_nested_children
+                        && checksum.is_some();
+
                     if hardlinks_mode {
                         // Hand off to the CAS extractor; `Any` keeps
                         // the parent walk from treating the folder as
@@ -454,6 +482,9 @@ fn generate_workspace_node_modules(
                         if !assume_up_to_date {
                             cas_extractions.push((dest_abs_path.clone(), child_node.locator.clone()));
                         }
+                    } else if use_clone {
+                        workspace_nm_tree.register_entry(child_rel_path, SyncItem::Any)?;
+                        clone_extractions.push((dest_abs_path.clone(), child_node.locator.clone()));
                     } else {
                         workspace_nm_tree.register_entry(child_rel_path, SyncItem::Folder {
                             template: Some(SyncTemplate::Zip {
@@ -516,14 +547,16 @@ fn generate_workspace_node_modules(
     Ok((workspace_nm_tree, workspace_abs_path))
 }
 
-/// Runs every workspace tree, then the CAS extractions, on the rayon
-/// pool. `block_in_place` keeps the heavy filesystem work from
-/// starving the tokio worker the linker runs on.
+/// Runs every workspace tree, then the CAS and clone extractions, on
+/// the rayon pool. `block_in_place` keeps the heavy filesystem work
+/// from starving the tokio worker the linker runs on.
 fn run_workspace_trees(
     project: &Project,
     install: &Install,
     workspace_trees: Vec<(SyncTree<'static>, Path)>,
     cas_extractions: &[(Path, Locator)],
+    clone_store: Option<&Path>,
+    clone_extractions: &[(Path, Locator)],
 ) -> Result<(), Error> {
     tokio::task::block_in_place(|| {
         use rayon::prelude::*;
@@ -541,6 +574,40 @@ fn run_workspace_trees(
 
                 Ok(())
             })?;
+
+        if let Some(store_root) = clone_store {
+            clone_extractions.par_iter().try_for_each(|(dest_abs_path, locator)| -> Result<(), Error> {
+                let physical_locator
+                    = locator.physical_locator();
+
+                let package_data = install.package_data
+                    .get(&physical_locator)
+                    .unwrap_or_else(|| panic!("Expected package_data for {}", locator.to_print_string()));
+
+                let checksum = install.lockfile.entries
+                    .get(&physical_locator)
+                    .and_then(|entry| entry.checksum.clone())
+                    .or_else(|| install.install_state.cache_checksums.get(&physical_locator).cloned())
+                    .expect("Clone extractions are only planned for packages with a checksum");
+
+                let store_entry = linker::helpers::ensure_unpacked_store_entry(
+                    store_root,
+                    &physical_locator,
+                    &checksum,
+                    package_data,
+                )?;
+
+                if linker::helpers::clone_package_from_store(dest_abs_path, &store_entry).is_err() {
+                    // The volumes may not support clones after all
+                    // (say, the store was probed against another
+                    // mount); extract the archive like before.
+                    let _ = dest_abs_path.fs_rm().ok_missing();
+                    linker::helpers::extract_zip_entries_to(dest_abs_path, package_data)?;
+                }
+
+                Ok(())
+            })?;
+        }
 
         run_cas_extractions(project, install, cas_extractions)
     })
@@ -628,10 +695,15 @@ pub async fn link_island_nm(
         = BTreeSet::new();
     let mut cas_extractions
         = Vec::new();
+    let mut clone_extractions
+        = Vec::new();
     let mut package_maps
         = Vec::new();
     let mut workspace_trees
         = Vec::new();
+
+    let clone_store
+        = clone_store_for(project);
 
     for workspace_ident in &island.workspace_idents {
         let workspace = project.workspace_by_ident(workspace_ident)?;
@@ -666,10 +738,12 @@ pub async fn link_island_nm(
             0,
             Some(&mut package_map_builder),
             previous_map.as_ref(),
+            clone_store.as_ref(),
             &mut packages_by_location,
             &mut canonical_build_locations,
             &mut force_rebuild_locators,
             &mut cas_extractions,
+            &mut clone_extractions,
         )?);
 
         package_maps.push((
@@ -678,7 +752,7 @@ pub async fn link_island_nm(
         ));
     }
 
-    run_workspace_trees(project, install, workspace_trees, &cas_extractions)?;
+    run_workspace_trees(project, install, workspace_trees, &cas_extractions, clone_store.as_ref(), &clone_extractions)?;
 
     for (package_map_path, package_map) in package_maps {
         persist_package_map_at(&package_map_path, &package_map)?;
@@ -933,6 +1007,8 @@ pub async fn link_project_nm(project: &Project, install: &Install) -> Result<Lin
         = BTreeSet::new();
     let mut cas_extractions
         = Vec::new();
+    let mut clone_extractions
+        = Vec::new();
 
     hoister.hoist();
 
@@ -948,6 +1024,9 @@ pub async fn link_project_nm(project: &Project, install: &Install) -> Result<Lin
         project.nm_path(),
     );
 
+    let clone_store
+        = clone_store_for(project);
+
     let mut project_queue
         = vec![0usize];
 
@@ -962,16 +1041,18 @@ pub async fn link_project_nm(project: &Project, install: &Install) -> Result<Lin
             workspace_node_idx,
             Some(&mut package_map_builder),
             previous_map.as_ref(),
+            clone_store.as_ref(),
             &mut packages_by_location,
             &mut canonical_build_locations,
             &mut force_rebuild_locators,
             &mut cas_extractions,
+            &mut clone_extractions,
         )?);
 
         project_queue.extend_from_slice(&work_tree.nodes[workspace_node_idx].workspaces_idx);
     }
 
-    run_workspace_trees(project, install, workspace_trees, &cas_extractions)?;
+    run_workspace_trees(project, install, workspace_trees, &cas_extractions, clone_store.as_ref(), &clone_extractions)?;
 
     persist_package_map(project, &package_map_builder.build()?)?;
 

--- a/packages/zpm/src/linker/nm/mod.rs
+++ b/packages/zpm/src/linker/nm/mod.rs
@@ -5,7 +5,7 @@ use zpm_sync::{SyncItem, SyncTemplate, SyncTree};
 use zpm_utils::{FromFileString, IoResultExt, Path, ToHumanString};
 
 use crate::{
-    build::{self, BuildRequest, BuildRequests}, content_flags, error::Error, fetchers::PackageData, install::Install, linker::{self, LinkResult, helpers::PackageMeta, nm::hoist::{Hoister, WorkTree}, package_map::{NodeModulesPackageMapBuilder, persist_package_map, persist_package_map_at}}, project::Project
+    build::{self, BuildRequest, BuildRequests}, content_flags, error::Error, fetchers::PackageData, install::Install, linker::{self, LinkResult, helpers::PackageMeta, nm::hoist::{Hoister, WorkTree}, package_map::{self, NodeModulesPackageMapBuilder, PackageMap, persist_package_map, persist_package_map_at}}, project::Project
 };
 
 pub mod hoist;
@@ -194,12 +194,42 @@ fn register_workspace_bin_symlinks(workspace_nm_tree: &mut SyncTree, workspace_p
     Ok(())
 }
 
+/// Context for the incremental link: the package map left by the last
+/// completed install, and the base its package ids are relative to.
+pub(crate) struct PreviousPackageMap {
+    map: PackageMap,
+    base_path: Path,
+}
+
+impl PreviousPackageMap {
+    /// Loads the previous package map, unless incremental linking is
+    /// disabled for this pass (`--force`, or an `nmMode` transition
+    /// that requires rewriting existing folders).
+    fn load(project: &Project, install: &Install, package_map_path: &Path, base_path: Path) -> Option<Self> {
+        if install.force || nm_mode_transitioned(project) {
+            return None;
+        }
+
+        Some(Self {
+            map: package_map::load_package_map(package_map_path)?,
+            base_path,
+        })
+    }
+
+    fn matches_package(&self, abs_path: &Path, locator: &Locator, checksum: Option<&zpm_utils::Hash64>) -> bool {
+        let id = package_map::get_package_id(&self.base_path, &abs_path.without_trailing_separators());
+
+        self.map.matches_package(&id, locator, checksum)
+    }
+}
+
 fn generate_workspace_node_modules(
     project: &Project,
     install: &Install,
     work_tree: &WorkTree,
     workspace_node_idx: usize,
     package_map_builder: Option<&mut NodeModulesPackageMapBuilder>,
+    previous_map: Option<&PreviousPackageMap>,
     packages_by_location: &mut BTreeMap<Path, zpm_primitives::Locator>,
     canonical_build_locations: &mut BTreeMap<Locator, Path>,
     force_rebuild_locators: &mut BTreeSet<Locator>,
@@ -381,22 +411,53 @@ fn generate_workspace_node_modules(
                         let _ = dest_abs_path.fs_rm().ok_missing();
                     }
 
-                    if !dest_abs_path.fs_exists() {
+                    let dest_exists
+                        = dest_abs_path.fs_exists();
+
+                    if !dest_exists {
                         force_rebuild_locators.insert(child_node.locator.clone());
                     }
+
+                    // The folder can be left alone when the previous
+                    // install already materialized this exact archive
+                    // here and nothing nests packages inside it (in
+                    // either the previous or the new layout).
+                    let has_nested_children
+                        = child_node.children.as_ref().is_some_and(|children| !children.is_empty());
+
+                    // Same source as the map builder: lockfile checksum
+                    // first, install-state shadow for conditional
+                    // locators.
+                    let physical_locator
+                        = child_node.locator.physical_locator();
+
+                    let checksum = install.lockfile.entries
+                        .get(&physical_locator)
+                        .and_then(|entry| entry.checksum.as_ref())
+                        .or_else(|| install.install_state.cache_checksums.get(&physical_locator));
+
+                    let assume_up_to_date = dest_exists
+                        && !has_nested_children
+                        && previous_map.is_some_and(|previous_map| {
+                            previous_map.matches_package(&abs_path, &child_node.locator, checksum)
+                        });
 
                     if hardlinks_mode {
                         // Hand off to the CAS extractor; `Any` keeps
                         // the parent walk from treating the folder as
                         // extraneous while leaving its contents alone.
                         workspace_nm_tree.register_entry(child_rel_path, SyncItem::Any)?;
-                        cas_extractions.push((dest_abs_path.clone(), child_node.locator.clone()));
+
+                        if !assume_up_to_date {
+                            cas_extractions.push((dest_abs_path.clone(), child_node.locator.clone()));
+                        }
                     } else {
                         workspace_nm_tree.register_entry(child_rel_path, SyncItem::Folder {
                             template: Some(SyncTemplate::Zip {
                                 archive_path: archive_path.clone(),
                                 inner_path: package_directory.relative_to(&archive_path),
                             }),
+                            assume_up_to_date,
                         })?;
                     }
 
@@ -552,6 +613,13 @@ pub async fn link_island_nm(
         let mut package_map_builder
             = NodeModulesPackageMapBuilder::new_at(project, install, package_map_base_path.clone());
 
+        let previous_map = PreviousPackageMap::load(
+            project,
+            install,
+            &project.package_map_path(Some(workspace)),
+            package_map_base_path.clone(),
+        );
+
         let mut work_tree = WorkTree::new_for_island_workspace(
             project,
             &install.install_state,
@@ -569,6 +637,7 @@ pub async fn link_island_nm(
             &work_tree,
             0,
             Some(&mut package_map_builder),
+            previous_map.as_ref(),
             &mut packages_by_location,
             &mut canonical_build_locations,
             &mut force_rebuild_locators,
@@ -840,6 +909,13 @@ pub async fn link_project_nm(project: &Project, install: &Install) -> Result<Lin
     let mut package_map_builder
         = NodeModulesPackageMapBuilder::new(project, install);
 
+    let previous_map = PreviousPackageMap::load(
+        project,
+        install,
+        &project.package_map_path(None),
+        project.nm_path(),
+    );
+
     let mut project_queue
         = vec![0usize];
 
@@ -850,6 +926,7 @@ pub async fn link_project_nm(project: &Project, install: &Install) -> Result<Lin
             &work_tree,
             workspace_node_idx,
             Some(&mut package_map_builder),
+            previous_map.as_ref(),
             &mut packages_by_location,
             &mut canonical_build_locations,
             &mut force_rebuild_locators,

--- a/packages/zpm/src/linker/nm/mod.rs
+++ b/packages/zpm/src/linker/nm/mod.rs
@@ -223,6 +223,9 @@ impl PreviousPackageMap {
     }
 }
 
+/// Builds the sync tree for one workspace's node_modules. The caller
+/// runs the returned trees (possibly in parallel; they cover disjoint
+/// folders) once every workspace was planned.
 fn generate_workspace_node_modules(
     project: &Project,
     install: &Install,
@@ -234,7 +237,7 @@ fn generate_workspace_node_modules(
     canonical_build_locations: &mut BTreeMap<Locator, Path>,
     force_rebuild_locators: &mut BTreeSet<Locator>,
     cas_extractions: &mut Vec<(Path, Locator)>,
-) -> Result<(), Error> {
+) -> Result<(SyncTree<'static>, Path), Error> {
     let mut package_map_builder
         = package_map_builder;
 
@@ -271,7 +274,7 @@ fn generate_workspace_node_modules(
         = workspace_dir
             .with_join_str("node_modules");
 
-    let mut workspace_nm_tree
+    let mut workspace_nm_tree: SyncTree<'static>
         = SyncTree::new();
 
     workspace_nm_tree.dry_run = false;
@@ -510,14 +513,37 @@ fn generate_workspace_node_modules(
         register_bin_symlinks_at_path(&mut workspace_nm_tree, &node_rel_path, &binaries)?;
     }
 
-    workspace_nm_tree
-        .run(workspace_abs_path.clone())?;
+    Ok((workspace_nm_tree, workspace_abs_path))
+}
 
-    // Always materialize node_modules: tools (and tests) expect the
-    // directory to exist even when the workspace has no deps.
-    workspace_abs_path.fs_create_dir_all()?;
+/// Runs every workspace tree, then the CAS extractions, on the rayon
+/// pool. `block_in_place` keeps the heavy filesystem work from
+/// starving the tokio worker the linker runs on.
+fn run_workspace_trees(
+    project: &Project,
+    install: &Install,
+    workspace_trees: Vec<(SyncTree<'static>, Path)>,
+    cas_extractions: &[(Path, Locator)],
+) -> Result<(), Error> {
+    tokio::task::block_in_place(|| {
+        use rayon::prelude::*;
 
-    Ok(())
+        workspace_trees
+            .par_iter()
+            .try_for_each(|(workspace_nm_tree, workspace_abs_path)| -> Result<(), Error> {
+                workspace_nm_tree
+                    .run(workspace_abs_path.clone())?;
+
+                // Always materialize node_modules: tools (and tests)
+                // expect the directory to exist even when the
+                // workspace has no deps.
+                workspace_abs_path.fs_create_dir_all()?;
+
+                Ok(())
+            })?;
+
+        run_cas_extractions(project, install, cas_extractions)
+    })
 }
 
 fn build_requests_from_locations(
@@ -604,6 +630,8 @@ pub async fn link_island_nm(
         = Vec::new();
     let mut package_maps
         = Vec::new();
+    let mut workspace_trees
+        = Vec::new();
 
     for workspace_ident in &island.workspace_idents {
         let workspace = project.workspace_by_ident(workspace_ident)?;
@@ -631,7 +659,7 @@ pub async fn link_island_nm(
 
         hoister.hoist();
 
-        generate_workspace_node_modules(
+        workspace_trees.push(generate_workspace_node_modules(
             project,
             install,
             &work_tree,
@@ -642,7 +670,7 @@ pub async fn link_island_nm(
             &mut canonical_build_locations,
             &mut force_rebuild_locators,
             &mut cas_extractions,
-        )?;
+        )?);
 
         package_maps.push((
             project.package_map_path(Some(workspace)),
@@ -650,7 +678,7 @@ pub async fn link_island_nm(
         ));
     }
 
-    run_cas_extractions(project, install, &cas_extractions)?;
+    run_workspace_trees(project, install, workspace_trees, &cas_extractions)?;
 
     for (package_map_path, package_map) in package_maps {
         persist_package_map_at(&package_map_path, &package_map)?;
@@ -706,10 +734,13 @@ fn run_cas_extractions(
         return Ok(());
     }
 
+    use rayon::prelude::*;
+
     match project.config.settings.nm_mode.value {
         zpm_config::NmMode::HardlinksLocal => {
-            let mut local_index = BTreeMap::new();
-            for (dest_abs_path, locator) in cas_extractions {
+            let local_index = linker::helpers::LocalDedupIndex::new();
+
+            cas_extractions.par_iter().try_for_each(|(dest_abs_path, locator)| {
                 let package_data = install.package_data
                     .get(&locator.physical_locator())
                     .unwrap_or_else(|| panic!("Expected package_data for {}", locator.to_print_string()));
@@ -717,21 +748,22 @@ fn run_cas_extractions(
                 linker::helpers::fs_extract_archive_with_local_dedup(
                     dest_abs_path,
                     package_data,
-                    &mut local_index,
-                )?;
-            }
+                    &local_index,
+                ).map(|_| ())
+            })?;
         },
         zpm_config::NmMode::HardlinksGlobal => {
             let index_root = project.config.settings.global_folder.value
                 .with_join_str("index");
 
-            for (dest_abs_path, locator) in cas_extractions {
+            cas_extractions.par_iter().try_for_each(|(dest_abs_path, locator)| {
                 let package_data = install.package_data
                     .get(&locator.physical_locator())
                     .unwrap_or_else(|| panic!("Expected package_data for {}", locator.to_print_string()));
 
-                linker::helpers::fs_extract_archive_with_cas(dest_abs_path, package_data, &index_root)?;
-            }
+                linker::helpers::fs_extract_archive_with_cas(dest_abs_path, package_data, &index_root)
+                    .map(|_| ())
+            })?;
         },
         zpm_config::NmMode::Classic => {},
     }
@@ -919,8 +951,11 @@ pub async fn link_project_nm(project: &Project, install: &Install) -> Result<Lin
     let mut project_queue
         = vec![0usize];
 
+    let mut workspace_trees
+        = Vec::new();
+
     while let Some(workspace_node_idx) = project_queue.pop() {
-        generate_workspace_node_modules(
+        workspace_trees.push(generate_workspace_node_modules(
             project,
             install,
             &work_tree,
@@ -931,12 +966,12 @@ pub async fn link_project_nm(project: &Project, install: &Install) -> Result<Lin
             &mut canonical_build_locations,
             &mut force_rebuild_locators,
             &mut cas_extractions,
-        )?;
+        )?);
 
         project_queue.extend_from_slice(&work_tree.nodes[workspace_node_idx].workspaces_idx);
     }
 
-    run_cas_extractions(project, install, &cas_extractions)?;
+    run_workspace_trees(project, install, workspace_trees, &cas_extractions)?;
 
     persist_package_map(project, &package_map_builder.build()?)?;
 

--- a/packages/zpm/src/linker/nm/mod.rs
+++ b/packages/zpm/src/linker/nm/mod.rs
@@ -223,9 +223,6 @@ impl PreviousPackageMap {
     }
 }
 
-/// Builds the sync tree for one workspace's node_modules. The caller
-/// runs the returned trees (possibly in parallel; they cover disjoint
-/// folders) once every workspace was planned.
 /// Resolves the unpacked store used for clonefile materialization:
 /// `Some` only for the classic nmMode on systems where copy-on-write
 /// clones between the store and the project actually work.
@@ -241,6 +238,9 @@ fn clone_store_for(project: &Project) -> Option<Path> {
         .then_some(store_root)
 }
 
+/// Builds the sync tree for one workspace's node_modules. The caller
+/// runs the returned trees (possibly in parallel; they cover disjoint
+/// folders) once every workspace was planned.
 fn generate_workspace_node_modules(
     project: &Project,
     install: &Install,

--- a/packages/zpm/src/linker/package_map.rs
+++ b/packages/zpm/src/linker/package_map.rs
@@ -1,28 +1,75 @@
 use std::{collections::{BTreeMap, BTreeSet}, str::FromStr};
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use zpm_config::NodePackageMapType;
 use zpm_parsers::JsonDocument;
 use zpm_primitives::{Ident, Locator};
-use zpm_utils::{Path, ToFileString, ToHumanString};
+use zpm_utils::{Hash64, Path, ToFileString, ToHumanString};
 
 use crate::{error::Error, install::Install, project::Project, tree_resolver::ResolutionTree};
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct PackageMap {
-    packages: BTreeMap<String, PackageMapPackage>,
+    pub(crate) packages: BTreeMap<String, PackageMapPackage>,
 }
 
-#[derive(Debug, Serialize)]
-struct PackageMapPackage {
-    url: String,
-    dependencies: BTreeMap<String, String>,
+#[derive(Debug, Serialize, Deserialize)]
+pub(crate) struct PackageMapPackage {
+    pub(crate) url: String,
+    pub(crate) dependencies: BTreeMap<String, String>,
+
+    /// Which package (and archive content) this location was last
+    /// materialized from. The incremental nm linker compares these
+    /// against its plan to skip re-extracting unchanged packages.
+    /// Runtime consumers of the map ignore them.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) locator: Option<Locator>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) checksum: Option<Hash64>,
+}
+
+impl PackageMap {
+    /// True when the previous install materialized `id` from the exact
+    /// same package archive, and nothing was nested inside its folder.
+    pub(crate) fn matches_package(&self, id: &str, locator: &Locator, checksum: Option<&Hash64>) -> bool {
+        let Some(previous) = self.packages.get(id) else {
+            return false;
+        };
+
+        if previous.locator.as_ref() != Some(locator) {
+            return false;
+        }
+
+        if previous.checksum.is_none() || previous.checksum.as_ref() != checksum {
+            return false;
+        }
+
+        // A package that previously hosted nested packages can't be
+        // skipped wholesale: the nested folders may have to disappear,
+        // and only a template expansion prunes them.
+        let nested_prefix = format!("{id}/");
+
+        !self.packages
+            .range(nested_prefix.clone()..)
+            .next()
+            .is_some_and(|(key, _)| key.starts_with(&nested_prefix))
+    }
+}
+
+/// Reads a package map left by a previous install; `None` when absent
+/// or unreadable (in which case the linker just syncs everything).
+pub fn load_package_map(package_map_path: &Path) -> Option<PackageMap> {
+    let src = package_map_path.fs_read_text().ok()?;
+
+    JsonDocument::hydrate_from_str(&src).ok()
 }
 
 #[derive(Debug)]
 struct PackageMapNode {
     id: String,
     package_path: Path,
+    locator: Locator,
     dependency_names: Option<BTreeSet<String>>,
 }
 
@@ -71,6 +118,7 @@ impl<'a> NodeModulesPackageMapBuilder<'a> {
         let package_map_node = PackageMapNode {
             id: get_package_id(&self.base_path, &normalized_location),
             package_path: normalized_package_path.clone(),
+            locator: locator.clone(),
             dependency_names: Some(get_package_dependency_names(self.project, self.install, locator, &normalized_package_path)),
         };
 
@@ -92,6 +140,17 @@ impl<'a> NodeModulesPackageMapBuilder<'a> {
             = BTreeMap::new();
 
         for package_map_node in self.package_map_nodes.values() {
+            // Conditional locators keep their checksum out of the
+            // lockfile (arch-stability), so fall back to the shadow
+            // copy in the install state.
+            let physical_locator
+                = package_map_node.locator.physical_locator();
+
+            let checksum = self.install.lockfile.entries
+                .get(&physical_locator)
+                .and_then(|entry| entry.checksum.clone())
+                .or_else(|| self.install.install_state.cache_checksums.get(&physical_locator).cloned());
+
             packages.insert(package_map_node.id.clone(), PackageMapPackage {
                 url: get_relative_url(&self.base_path, &package_map_node.package_path),
                 dependencies: self.get_package_dependencies(
@@ -101,6 +160,8 @@ impl<'a> NodeModulesPackageMapBuilder<'a> {
                         NodePackageMapType::Loose => None,
                     },
                 )?,
+                locator: Some(package_map_node.locator.clone()),
+                checksum,
             });
         }
 
@@ -229,6 +290,8 @@ impl PnpmPackageMapBuilder {
             packages.insert(get_package_id(&self.base_path, &package_map_node.package_location), PackageMapPackage {
                 url: get_relative_url(&self.base_path, &package_map_node.package_location),
                 dependencies: serialize_pnpm_dependencies(&dependencies, &package_ids_by_locator)?,
+                locator: None,
+                checksum: None,
             });
         }
 
@@ -345,7 +408,7 @@ fn get_relative_url(from: &Path, to: &Path) -> String {
     }
 }
 
-fn get_package_id(base_path: &Path, location: &Path) -> String {
+pub(crate) fn get_package_id(base_path: &Path, location: &Path) -> String {
     let relative_path
         = location.relative_to(base_path);
 

--- a/packages/zpm/src/project.rs
+++ b/packages/zpm/src/project.rs
@@ -1023,6 +1023,112 @@ impl Project {
         )
     }
 
+    /// Fingerprints the local files that feed resolution and fetch but
+    /// escape the manifest mtime guard: `file:` tarballs, patch files,
+    /// portal manifests. Returns `None` when the project depends on
+    /// sources that can't be cheaply fingerprinted (`exec:`, `file:`
+    /// folders), in which case an install can never be skipped.
+    /// Registry-backed ranges (including `npm:` aliases) are immutable
+    /// and don't participate.
+    pub fn local_sources_fingerprint(&self) -> Result<Option<Hash64>, Error> {
+        fn record(entries: &mut BTreeMap<Path, u128>, path: Path) -> Result<(), Error> {
+            let mtime = match path.fs_metadata() {
+                Ok(metadata) => metadata.modified()?
+                    .duration_since(UNIX_EPOCH).unwrap()
+                    .as_nanos(),
+
+                // A deleted source fails the install on its own; the
+                // fingerprint only has to change when it comes back.
+                Err(_) => 0,
+            };
+
+            entries.insert(path, mtime);
+
+            Ok(())
+        }
+
+        fn scan_range(project: &Project, base_path: &Path, range: &Range, entries: &mut BTreeMap<Path, u128>) -> Result<bool, Error> {
+            match range {
+                Range::Exec(_) | Range::Folder(_) => {
+                    return Ok(false);
+                },
+
+                Range::Tarball(params) => {
+                    record(entries, base_path.with_join_str(&params.path))?;
+                },
+
+                Range::Portal(params) => {
+                    // Portals aren't copied, but their manifest feeds
+                    // the resolution.
+                    record(entries, base_path.with_join_str(&params.path).with_join_str(MANIFEST_NAME))?;
+                },
+
+                Range::Patch(params) => {
+                    // Path handling mirrors the patch fetcher: builtin
+                    // patches ship with Yarn, `~/` is project-relative,
+                    // and anything else resolves against the parent.
+                    match params.path.as_str() {
+                        "<builtin>" => {},
+
+                        path if path.starts_with("~/") => {
+                            record(entries, project.project_cwd.with_join_str(&path[2..]))?;
+                        },
+
+                        path => {
+                            let patch_path = Path::try_from(path)?;
+
+                            if patch_path.is_absolute() {
+                                record(entries, patch_path)?;
+                            } else {
+                                record(entries, base_path.with_join(&patch_path))?;
+                            }
+                        },
+                    }
+
+                    if !scan_range(project, base_path, &params.inner.0.range, entries)? {
+                        return Ok(false);
+                    }
+                },
+
+                _ => {},
+            }
+
+            Ok(true)
+        }
+
+        let mut entries
+            = BTreeMap::new();
+
+        for workspace in &self.workspaces {
+            let manifest
+                = &workspace.manifest;
+
+            let ranges = manifest.remote.dependencies.values()
+                .chain(manifest.remote.optional_dependencies.values())
+                .chain(manifest.dev_dependencies.values())
+                .map(|descriptor| &descriptor.range)
+                .chain(manifest.resolutions.iter().map(|(_, range)| range));
+
+            for range in ranges {
+                if !scan_range(self, &workspace.path, range, &mut entries)? {
+                    return Ok(None);
+                }
+            }
+        }
+
+        let mut digest
+            = String::new();
+
+        for (path, mtime) in &entries {
+            digest.push_str(&path.to_file_string());
+            digest.push('\n');
+            digest.push_str(&mtime.to_string());
+            digest.push('\n');
+        }
+
+        Ok(Some(Hash64::from_data(digest)))
+    }
+
     /// Modification time of the lockfile, in nanoseconds since the
     /// epoch; `None` when the lockfile doesn't exist.
     pub fn lockfile_changed_at(&self) -> Result<Option<u128>, Error> {
@@ -1081,26 +1187,16 @@ impl Project {
             return Ok(false);
         }
 
-        // Some ranges resolve or fetch from mutable local state (file:,
-        // exec:, patches, catalogs, ...); their content can change with
-        // no manifest or lockfile edit, so they always need a real pass.
-        let has_transient_ranges = install_state.descriptor_to_locator.keys()
-            .any(|descriptor| {
-                // Workspace ranges are nominally transient but their
-                // sources are already covered by the manifest mtime
-                // guard above.
-                if descriptor.range.is_workspace() {
-                    return false;
-                }
+        // Some ranges resolve or fetch from mutable local files (file:
+        // tarballs, patches, portal manifests); those aren't covered by
+        // the manifest mtime guard, so compare their fingerprint
+        // against the one recorded at install time. `None` means the
+        // project uses sources that can't be fingerprinted at all
+        // (exec:, file: folders) and always needs a real pass.
+        let local_sources
+            = self.local_sources_fingerprint()?;
 
-                let range_details = descriptor.range.details();
-
-                range_details.transient_resolution
-                    || range_details.fetch_before_resolve
-                    || matches!(descriptor.range, Range::Catalog(_))
-            });
-
-        if has_transient_ranges {
+        if local_sources.is_none() || install_state.local_sources_hash != local_sources {
             return Ok(false);
         }
 

--- a/packages/zpm/src/project.rs
+++ b/packages/zpm/src/project.rs
@@ -7,7 +7,7 @@ use zpm_macro_enum::zpm_enum;
 use zpm_parsers::JsonDocument;
 use zpm_primitives::{Descriptor, Ident, Locator, Range, Reference, WorkspaceIdentReference, WorkspaceMagicRange, WorkspacePathReference};
 use zpm_tasks::{parse as parse_taskfile, ResolvedTasks, TaskFile, TaskId};
-use zpm_utils::{DataType, Glob, Hash64, IoResultExt, LastModifiedAt, Path, ToFileString, ToHumanString, is_terminal, start_progress};
+use zpm_utils::{DataType, Glob, Hash64, Hash64Writer, IoResultExt, LastModifiedAt, Path, ToFileString, ToHumanString, is_terminal, start_progress};
 use serde::Deserialize;
 use zpm_formats::zip::ZipSupport;
 
@@ -23,6 +23,7 @@ use crate::{
     lockfile::{Lockfile, LockfileMetadata, from_legacy_berry_lockfile, from_pnpm_node_modules},
     manifest::{Manifest, helpers::read_manifest_with_size},
     manifest_finder::CachedManifestFinder,
+    npm::NpmEntryExt,
     primitives_exts::RangeExt,
     report::{StreamReport, StreamReportConfig, async_section, current_report, with_report_result},
     script::{Binary, ScriptEnvironment},
@@ -1023,110 +1024,181 @@ impl Project {
         )
     }
 
-    /// Fingerprints the local files that feed resolution and fetch but
-    /// escape the manifest mtime guard: `file:` tarballs, patch files,
-    /// portal manifests. Returns `None` when the project depends on
-    /// sources that can't be cheaply fingerprinted (`exec:`, `file:`
-    /// folders), in which case an install can never be skipped.
-    /// Registry-backed ranges (including `npm:` aliases) are immutable
-    /// and don't participate.
-    pub fn local_sources_fingerprint(&self) -> Result<Option<Hash64>, Error> {
-        fn record(entries: &mut BTreeMap<Path, u128>, path: Path) -> Result<(), Error> {
-            let mtime = match path.fs_metadata() {
-                Ok(metadata) => metadata.modified()?
-                    .duration_since(UNIX_EPOCH).unwrap()
-                    .as_nanos(),
+    /// The "quick pass" behind the up-to-date fast path: re-derives
+    /// the content hashes feeding transient resolutions (`file:`
+    /// tarballs and folders, `exec:` scripts, patch files, portal
+    /// manifests) and compares them with the locators recorded by the
+    /// previous install. Registry-backed ranges (including `npm:`
+    /// aliases) are immutable and never checked, so this costs nothing
+    /// for projects without local sources. Returns `false` when
+    /// anything changed - the regular install then redoes the work for
+    /// real - or when a hash can't be re-derived cheaply.
+    fn transient_resolutions_unchanged(&self, install_state: &InstallState) -> Result<bool, Error> {
+        fn resolve_local_path(context_directory: &Path, raw_path: &str) -> Result<Path, Error> {
+            let path = Path::try_from(raw_path)?;
 
-                // A deleted source fails the install on its own; the
-                // fingerprint only has to change when it comes back.
-                Err(_) => 0,
-            };
-
-            entries.insert(path, mtime);
-
-            Ok(())
+            Ok(if path.is_absolute() {
+                path
+            } else {
+                context_directory.with_join(&path)
+            })
         }
 
-        fn scan_range(project: &Project, base_path: &Path, range: &Range, entries: &mut BTreeMap<Path, u128>) -> Result<bool, Error> {
-            match range {
-                Range::Exec(_) | Range::Folder(_) => {
-                    return Ok(false);
-                },
+        let mut cache_packer
+            = None;
 
-                Range::Tarball(params) => {
-                    record(entries, base_path.with_join_str(&params.path))?;
-                },
+        for (descriptor, locator) in &install_state.descriptor_to_locator {
+            let range = descriptor.range.physical_range();
 
-                Range::Portal(params) => {
-                    // Portals aren't copied, but their manifest feeds
-                    // the resolution.
-                    record(entries, base_path.with_join_str(&params.path).with_join_str(MANIFEST_NAME))?;
-                },
-
-                Range::Patch(params) => {
-                    // Path handling mirrors the patch fetcher: builtin
-                    // patches ship with Yarn, `~/` is project-relative,
-                    // and anything else resolves against the parent.
-                    match params.path.as_str() {
-                        "<builtin>" => {},
-
-                        path if path.starts_with("~/") => {
-                            record(entries, project.project_cwd.with_join_str(&path[2..]))?;
-                        },
-
-                        path => {
-                            let patch_path = Path::try_from(path)?;
-
-                            if patch_path.is_absolute() {
-                                record(entries, patch_path)?;
-                            } else {
-                                record(entries, base_path.with_join(&patch_path))?;
-                            }
-                        },
-                    }
-
-                    if !scan_range(project, base_path, &params.inner.0.range, entries)? {
-                        return Ok(false);
-                    }
-                },
-
-                _ => {},
+            if !matches!(range, Range::Tarball(_) | Range::Folder(_) | Range::Exec(_) | Range::Patch(_) | Range::Portal(_)) {
+                continue;
             }
 
-            Ok(true)
-        }
+            if let Range::Patch(params) = range {
+                // Builtin patches ship with the binary; nothing on
+                // disk to watch.
+                if params.path == "<builtin>" {
+                    continue;
+                }
 
-        let mut entries
-            = BTreeMap::new();
-
-        for workspace in &self.workspaces {
-            let manifest
-                = &workspace.manifest;
-
-            let ranges = manifest.remote.dependencies.values()
-                .chain(manifest.remote.optional_dependencies.values())
-                .chain(manifest.dev_dependencies.values())
-                .map(|descriptor| &descriptor.range)
-                .chain(manifest.resolutions.iter().map(|(_, range)| range));
-
-            for range in ranges {
-                if !scan_range(self, &workspace.path, range, &mut entries)? {
-                    return Ok(None);
+                // A patch over another transient package would need
+                // its inner source re-derived through the parent
+                // chain; too exotic to bother, never skip.
+                if matches!(
+                    params.inner.0.range.physical_range(),
+                    Range::Tarball(_) | Range::Folder(_) | Range::Exec(_) | Range::Portal(_),
+                ) {
+                    return Ok(false);
                 }
             }
+
+            // Relative paths hang from the parent package. Workspace
+            // parents are mutable and re-derivable; zip-backed parents
+            // are immutable snapshots whose inner files can't change
+            // under us; disk-backed parents (portals, links) are
+            // mutable but can't be verified from here.
+            let context_directory = match &descriptor.parent {
+                Some(parent) => {
+                    let physical = parent.physical_locator();
+
+                    match self.try_workspace_by_locator(&physical)? {
+                        Some(workspace) => workspace.path.clone(),
+
+                        None => {
+                            let parent_reference = physical.reference.physical_reference();
+
+                            if parent_reference.is_portal() || parent_reference.is_link() {
+                                return Ok(false);
+                            }
+
+                            continue;
+                        },
+                    }
+                },
+
+                None => self.project_cwd.clone(),
+            };
+
+            let unchanged = match (range, locator.reference.physical_reference()) {
+                (Range::Tarball(_), Reference::Tarball(reference_params)) => {
+                    let tarball_path
+                        = resolve_local_path(&context_directory, &reference_params.path)?;
+
+                    match tarball_path.fs_read() {
+                        Ok(data) => reference_params.hash == Some(Hash64::from_data(data)),
+                        Err(_) => false,
+                    }
+                },
+
+                (Range::Exec(_), Reference::Exec(reference_params)) => {
+                    let script_path
+                        = resolve_local_path(&context_directory, &reference_params.path)?;
+
+                    match script_path.fs_read() {
+                        Ok(data) => {
+                            // Mirrors `resolvers::exec::compute_exec_hash`.
+                            let mut writer = Hash64Writer::new();
+                            writer.update(b"exec-v2");
+                            writer.update(data);
+
+                            reference_params.hash == Some(writer.finalize())
+                        },
+                        Err(_) => false,
+                    }
+                },
+
+                (Range::Folder(_), Reference::Folder(reference_params)) => {
+                    let folder_path
+                        = resolve_local_path(&context_directory, &reference_params.path)?;
+
+                    let packer = match &cache_packer {
+                        Some(packer) => packer,
+                        None => cache_packer.insert(self.package_cache()?.packer()),
+                    };
+
+                    // Mirrors `resolvers::folder::compute_folder_hash`.
+                    let hash = zpm_formats::entries_from_folder(&folder_path)
+                        .map_err(Error::from)
+                        .and_then(|entries| {
+                            entries
+                                .into_iter()
+                                .prepare_npm_entries(&descriptor.ident.nm_subdir())
+                                .map_err(Error::from)
+                        })
+                        .and_then(|entries| packer.pack(entries).map_err(Error::from))
+                        .map(|archive| {
+                            let mut writer = Hash64Writer::new();
+                            writer.update(b"file-folder-v2");
+                            writer.update(archive);
+
+                            writer.finalize()
+                        });
+
+                    match hash {
+                        Ok(hash) => reference_params.hash == Some(hash),
+                        Err(_) => false,
+                    }
+                },
+
+                (Range::Portal(_), Reference::Portal(reference_params)) => {
+                    let manifest_path = resolve_local_path(&context_directory, &reference_params.path)?
+                        .with_join_str(MANIFEST_NAME);
+
+                    match manifest_path.fs_read_text() {
+                        Ok(manifest_text) => {
+                            reference_params.hash
+                                == Some(crate::resolvers::portal::compute_portal_manifest_hash(&manifest_text))
+                        },
+                        Err(_) => false,
+                    }
+                },
+
+                (Range::Patch(_), Reference::Patch(reference_params)) => {
+                    // Path handling mirrors the patch fetcher: `~/` is
+                    // project-relative, anything else resolves against
+                    // the parent.
+                    let patch_path = match reference_params.path.as_str() {
+                        path if path.starts_with("~/") => self.project_cwd.with_join_str(&path[2..]),
+                        path => resolve_local_path(&context_directory, path)?,
+                    };
+
+                    match patch_path.fs_read_text() {
+                        Ok(patch_content) => reference_params.checksum == Some(Hash64::from_string(&patch_content)),
+                        Err(_) => false,
+                    }
+                },
+
+                // The recorded locator doesn't match the range shape;
+                // never skip on inconsistent state.
+                _ => false,
+            };
+
+            if !unchanged {
+                return Ok(false);
+            }
         }
 
-        let mut digest
-            = String::new();
-
-        for (path, mtime) in &entries {
-            digest.push_str(&path.to_file_string());
-            digest.push('\n');
-            digest.push_str(&mtime.to_string());
-            digest.push('\n');
-        }
-
-        Ok(Some(Hash64::from_data(digest)))
+        Ok(true)
     }
 
     /// Modification time of the lockfile, in nanoseconds since the
@@ -1187,16 +1259,11 @@ impl Project {
             return Ok(false);
         }
 
-        // Some ranges resolve or fetch from mutable local files (file:
-        // tarballs, patches, portal manifests); those aren't covered by
-        // the manifest mtime guard, so compare their fingerprint
-        // against the one recorded at install time. `None` means the
-        // project uses sources that can't be fingerprinted at all
-        // (exec:, file: folders) and always needs a real pass.
-        let local_sources
-            = self.local_sources_fingerprint()?;
-
-        if local_sources.is_none() || install_state.local_sources_hash != local_sources {
+        // Transient ranges (file:, exec:, patches, portals) resolve
+        // from content that can change without any manifest or
+        // lockfile edit; re-derive their hashes and compare them with
+        // the recorded resolutions.
+        if !self.transient_resolutions_unchanged(install_state)? {
             return Ok(false);
         }
 

--- a/packages/zpm/src/project.rs
+++ b/packages/zpm/src/project.rs
@@ -1259,14 +1259,6 @@ impl Project {
             return Ok(false);
         }
 
-        // Transient ranges (file:, exec:, patches, portals) resolve
-        // from content that can change without any manifest or
-        // lockfile edit; re-derive their hashes and compare them with
-        // the recorded resolutions.
-        if !self.transient_resolutions_unchanged(install_state)? {
-            return Ok(false);
-        }
-
         if install_state.lockfile_changed_at.is_none()
             || install_state.lockfile_changed_at != self.lockfile_changed_at()?
         {
@@ -1303,6 +1295,15 @@ impl Project {
             if needs_unplugged && !self.unplugged_path().fs_exists() {
                 return Ok(false);
             }
+        }
+
+        // Transient ranges (file:, exec:, patches, portals) resolve
+        // from content that can change without any manifest or
+        // lockfile edit; re-derive their hashes and compare them with
+        // the recorded resolutions. This is the costliest check
+        // (packing file: folders reads them in full), so it runs last.
+        if !self.transient_resolutions_unchanged(install_state)? {
+            return Ok(false);
         }
 
         Ok(true)

--- a/packages/zpm/src/project.rs
+++ b/packages/zpm/src/project.rs
@@ -1290,6 +1290,19 @@ impl Project {
             return Ok(false);
         }
 
+        // The nm linker guarantees every workspace a node_modules
+        // folder, so a missing one means the tree was wiped and needs
+        // relinking. (Deletions *inside* a package folder are on
+        // --force, like any other manual damage.)
+        if self.config.settings.node_linker.value == zpm_config::NodeLinker::NodeModules {
+            let all_workspace_trees_present = self.workspaces.iter()
+                .all(|workspace| workspace.path.with_join_str("node_modules").fs_exists());
+
+            if !all_workspace_trees_present {
+                return Ok(false);
+            }
+        }
+
         // PnP installs materialize some packages on disk (build scripts,
         // `prefer_extracted`, optional zips); if any package may be in
         // that situation, a missing unplugged folder means the project

--- a/packages/zpm/src/project.rs
+++ b/packages/zpm/src/project.rs
@@ -6,6 +6,7 @@ use zpm_config::{Configuration, ConfigurationContext, IslandLinker, Source};
 use zpm_macro_enum::zpm_enum;
 use zpm_parsers::JsonDocument;
 use zpm_primitives::{Descriptor, Ident, Locator, Range, Reference, WorkspaceIdentReference, WorkspaceMagicRange, WorkspacePathReference};
+use zpm_switch::get_bin_version;
 use zpm_tasks::{parse as parse_taskfile, ResolvedTasks, TaskFile, TaskId};
 use zpm_utils::{DataType, Glob, Hash64, Hash64Writer, IoResultExt, LastModifiedAt, Path, ToFileString, ToHumanString, is_terminal, start_progress};
 use serde::Deserialize;
@@ -1018,10 +1019,19 @@ impl Project {
     }
 
     pub(crate) fn install_config_hash(&self) -> Hash64 {
-        Hash64::from_data(
-            serde_json::to_vec(&self.config.settings)
-                .expect("configuration settings should always be serializable"),
-        )
+        let mut writer
+            = Hash64Writer::new();
+
+        // The binary version participates so that an upgraded Yarn
+        // always runs one full install: builtin patches, linker
+        // layouts, and install fix-ups can all change across releases
+        // in ways the other freshness checks can't see.
+        writer.update(get_bin_version().as_bytes());
+
+        writer.update(serde_json::to_vec(&self.config.settings)
+            .expect("configuration settings should always be serializable"));
+
+        writer.finalize()
     }
 
     /// The "quick pass" behind the up-to-date fast path: re-derives

--- a/packages/zpm/src/project.rs
+++ b/packages/zpm/src/project.rs
@@ -124,6 +124,7 @@ pub struct RunInstallOptions {
     pub silent_or_error: bool,
     pub json: bool,
     pub inline_builds: bool,
+    pub force: bool,
 }
 
 pub struct Project {
@@ -1471,6 +1472,7 @@ impl Project {
                     .with_constraints_check(!options.silent_or_error && self.config.settings.enable_constraints_checks.value && options.roots.is_none())
                     .with_skip_link_step(options.mode == Some(InstallMode::UpdateLockfile))
                     .with_skip_lockfile_update(options.roots.is_some())
+                    .with_force(options.force)
                     .resolve_and_fetch().await?
                     .link_and_build(self).await?;
 

--- a/packages/zpm/src/project.rs
+++ b/packages/zpm/src/project.rs
@@ -1022,6 +1022,128 @@ impl Project {
         )
     }
 
+    /// Modification time of the lockfile, in nanoseconds since the
+    /// epoch; `None` when the lockfile doesn't exist.
+    pub fn lockfile_changed_at(&self) -> Result<Option<u128>, Error> {
+        let metadata = match self.lockfile_path().fs_metadata() {
+            Ok(metadata) => metadata,
+            Err(err) => return match err.io_kind() {
+                Some(ErrorKind::NotFound) | Some(ErrorKind::NotADirectory) => Ok(None),
+                _ => Err(err.into()),
+            },
+        };
+
+        Ok(Some(metadata.modified()?
+            .duration_since(UNIX_EPOCH).unwrap()
+            .as_nanos()))
+    }
+
+    /// Cheap check that the artifacts of the last install are still
+    /// current: the install state is fresh, the configuration didn't
+    /// change, the lockfile wasn't edited out-of-band, and the cache
+    /// and linker outputs are still on disk. `yarn install` uses this
+    /// to skip installs that are provably no-ops; anything uncertain
+    /// falls through to a full install.
+    pub fn is_install_up_to_date(&mut self) -> Result<bool, Error> {
+        match self.import_install_state() {
+            Ok(_) => {},
+
+            Err(Error::InstallStateNotFound | Error::InvalidInstallState) => {
+                self.install_state = None;
+                return Ok(false);
+            },
+
+            Err(e) => {
+                return Err(e);
+            },
+        };
+
+        let Some(install_state) = &self.install_state else {
+            return Ok(false);
+        };
+
+        // A focused install may have skipped part of the project; an
+        // explicit `yarn install` must bring everything up to date.
+        if install_state.installed_workspaces.is_some() {
+            return Ok(false);
+        }
+
+        if self.last_modified_at.has_changed_since(install_state.last_installed_at) {
+            return Ok(false);
+        }
+
+        if install_state.install_config_hash.as_ref() != Some(&self.install_config_hash()) {
+            return Ok(false);
+        }
+
+        if !self.config.settings.unstable_islands.is_empty() {
+            return Ok(false);
+        }
+
+        // Some ranges resolve or fetch from mutable local state (file:,
+        // exec:, patches, catalogs, ...); their content can change with
+        // no manifest or lockfile edit, so they always need a real pass.
+        let has_transient_ranges = install_state.descriptor_to_locator.keys()
+            .any(|descriptor| {
+                // Workspace ranges are nominally transient but their
+                // sources are already covered by the manifest mtime
+                // guard above.
+                if descriptor.range.is_workspace() {
+                    return false;
+                }
+
+                let range_details = descriptor.range.details();
+
+                range_details.transient_resolution
+                    || range_details.fetch_before_resolve
+                    || matches!(descriptor.range, Range::Catalog(_))
+            });
+
+        if has_transient_ranges {
+            return Ok(false);
+        }
+
+        if install_state.lockfile_changed_at.is_none()
+            || install_state.lockfile_changed_at != self.lockfile_changed_at()?
+        {
+            return Ok(false);
+        }
+
+        if !self.preferred_cache_path().fs_exists() {
+            return Ok(false);
+        }
+
+        let linker_artifact = match self.config.settings.node_linker.value {
+            zpm_config::NodeLinker::Pnp
+                => self.pnp_path(),
+            zpm_config::NodeLinker::NodeModules | zpm_config::NodeLinker::Pnpm
+                => self.package_map_path(None),
+        };
+
+        if !linker_artifact.fs_exists() {
+            return Ok(false);
+        }
+
+        // PnP installs materialize some packages on disk (build scripts,
+        // `prefer_extracted`, optional zips); if any package may be in
+        // that situation, a missing unplugged folder means the project
+        // needs a repair pass. Over-approximating is fine — it only
+        // costs a full install when the folder is legitimately absent.
+        if self.config.settings.node_linker.value == zpm_config::NodeLinker::Pnp {
+            let needs_unplugged = !install_state.optional_packages.is_empty()
+                || install_state.content_flags.values().any(|flags| {
+                    flags.prefer_extracted
+                        .unwrap_or(flags.suggest_extracted || !flags.build_commands.is_empty())
+                });
+
+            if needs_unplugged && !self.unplugged_path().fs_exists() {
+                return Ok(false);
+            }
+        }
+
+        Ok(true)
+    }
+
     fn find_visible_dependency_location(&self, issuer_location: &Path, ident: &Ident, locator: &Locator) -> Result<Option<Path>, Error> {
         let install_state = self.install_state.as_ref()
             .ok_or(Error::InstallStateNotFound)?;

--- a/packages/zpm/src/resolvers/portal.rs
+++ b/packages/zpm/src/resolvers/portal.rs
@@ -1,5 +1,6 @@
 use zpm_formats::zip::ZipSupport;
 use zpm_primitives::{Descriptor, Locator, PortalRange, PortalReference, Reference};
+use zpm_utils::{Hash64, Path};
 
 use crate::{
     error::Error,
@@ -8,9 +9,32 @@ use crate::{
     resolvers::Resolution,
 };
 
+/// Domain-separated hash of the portal target's manifest; shared with
+/// the up-to-date fast path, which re-derives it to detect changes.
+pub fn compute_portal_manifest_hash(manifest_text: &str) -> Hash64 {
+    let mut writer = zpm_utils::Hash64Writer::new();
+    writer.update(b"portal-manifest-v1");
+    writer.update(manifest_text.as_bytes());
+
+    writer.finalize()
+}
+
+fn portal_manifest_path(context_directory: &Path, portal_path: &str) -> Path {
+    context_directory
+        .with_join_str(portal_path)
+        .with_join_str("package.json")
+}
+
 pub fn resolve_descriptor(ctx: &InstallContext, descriptor: &Descriptor, params: &PortalRange, dependencies: Vec<InstallOpResult>) -> Result<ResolutionResult, Error> {
+    let parent_data
+        = dependencies[0].as_fetched();
+
+    let manifest_text = portal_manifest_path(parent_data.package_data.context_directory(), &params.path)
+        .fs_read_text_with_zip()?;
+
     let reference = PortalReference {
         path: params.path.clone(),
+        hash: Some(compute_portal_manifest_hash(&manifest_text)),
     };
 
     let locator
@@ -27,14 +51,9 @@ pub fn resolve_locator(context: &InstallContext, locator: &Locator, params: &Por
     let parent_data
         = dependencies[0].as_fetched();
 
-    let package_directory = parent_data.package_data
-        .context_directory()
-        .with_join_str(params.path.clone());
-
-    let manifest_path = package_directory
-        .with_join_str("package.json");
-    let manifest_text = manifest_path
+    let manifest_text = portal_manifest_path(parent_data.package_data.context_directory(), &params.path)
         .fs_read_text_with_zip()?;
+
     let manifest
         = parse_manifest(&manifest_text)?;
 

--- a/tests/acceptance-tests/pkg-tests-specs/sources/commands/install.test.ts
+++ b/tests/acceptance-tests/pkg-tests-specs/sources/commands/install.test.ts
@@ -1184,6 +1184,69 @@ describe(`Commands`, () => {
       );
 
       test(
+        `it should take the fast path with file: folders until their content changes`,
+        makeTemporaryEnv({
+          dependencies: {
+            [`local-pkg`]: `file:./local-pkg`,
+          },
+        }, async ({path, run, source}) => {
+          await xfs.mkdirPromise(ppath.join(path, `local-pkg`));
+          await xfs.writeJsonPromise(ppath.join(path, `local-pkg/package.json`), {name: `local-pkg`, version: `1.0.0`});
+          await xfs.writeFilePromise(ppath.join(path, `local-pkg/index.js`), `module.exports = 1;\n`);
+
+          await run(`install`);
+
+          const pnpPath = ppath.join(path, Filename.pnpCjs);
+          await xfs.writeFilePromise(pnpPath, `corrupted`);
+
+          // The folder didn't change: fast path.
+          await run(`install`);
+          await expect(xfs.readFilePromise(pnpPath, `utf8`)).resolves.toEqual(`corrupted`);
+
+          // The folder content changed: full install.
+          await xfs.writeFilePromise(ppath.join(path, `local-pkg/index.js`), `module.exports = 2;\n`);
+          await run(`install`);
+
+          await expect(xfs.readFilePromise(pnpPath, `utf8`)).resolves.not.toEqual(`corrupted`);
+          await expect(source(`require('local-pkg')`)).resolves.toEqual(2);
+        }),
+      );
+
+      test(
+        `it should re-run the install when a portal target's manifest changes`,
+        makeTemporaryEnv({
+          dependencies: {
+            [`portaled`]: `portal:./portaled`,
+          },
+        }, async ({path, run, source}) => {
+          await xfs.mkdirPromise(ppath.join(path, `portaled`));
+          await xfs.writeJsonPromise(ppath.join(path, `portaled/package.json`), {name: `portaled`, version: `1.0.0`});
+
+          await run(`install`);
+
+          const pnpPath = ppath.join(path, Filename.pnpCjs);
+          await xfs.writeFilePromise(pnpPath, `corrupted`);
+
+          // Nothing changed: fast path.
+          await run(`install`);
+          await expect(xfs.readFilePromise(pnpPath, `utf8`)).resolves.toEqual(`corrupted`);
+
+          // The portal target's manifest changed: full install.
+          await xfs.writeJsonPromise(ppath.join(path, `portaled/package.json`), {
+            name: `portaled`,
+            version: `1.0.0`,
+            dependencies: {
+              [`no-deps`]: `1.0.0`,
+            },
+          });
+
+          await run(`install`);
+
+          await expect(xfs.readFilePromise(pnpPath, `utf8`)).resolves.not.toEqual(`corrupted`);
+        }),
+      );
+
+      test(
         `it should run a full install when the configuration changed`,
         makeTemporaryEnv({
           dependencies: {

--- a/tests/acceptance-tests/pkg-tests-specs/sources/commands/install.test.ts
+++ b/tests/acceptance-tests/pkg-tests-specs/sources/commands/install.test.ts
@@ -1019,7 +1019,9 @@ describe(`Commands`, () => {
 
           const {stdout} = await run(`install`);
 
-          expect(stdout).toContain(`All dependencies are up-to-date, nothing to do. Run with \`--force\` to ignore this check.`);
+          // The `--force` part of the message is colorized, so only
+          // assert the stable prefix.
+          expect(stdout).toContain(`All dependencies are up-to-date, nothing to do.`);
           await expect(xfs.readFilePromise(pnpPath, `utf8`)).resolves.toEqual(`corrupted`);
         }),
       );

--- a/tests/acceptance-tests/pkg-tests-specs/sources/commands/install.test.ts
+++ b/tests/acceptance-tests/pkg-tests-specs/sources/commands/install.test.ts
@@ -1,5 +1,5 @@
-import {Filename, xfs, ppath, npath} from '@yarnpkg/fslib';
-import {tests, misc}                 from 'pkg-tests-core';
+import {Filename, PortablePath, xfs, ppath, npath} from '@yarnpkg/fslib';
+import {tests, misc}                               from 'pkg-tests-core';
 
 const {getPackageArchivePath} = tests;
 
@@ -1247,6 +1247,66 @@ describe(`Commands`, () => {
 
           await expect(xfs.readFilePromise(pnpPath, `utf8`)).resolves.not.toEqual(`corrupted`);
         }),
+      );
+
+      test(
+        `it should not take the fast path while builds are pending after --mode=skip-build`,
+        makeTemporaryEnv({
+          dependencies: {
+            [`no-deps-scripted`]: `1.0.0`,
+          },
+        }, async ({path, run, source}) => {
+          await run(`install`, `--mode=skip-build`);
+
+          // The skipped builds are still pending; a plain install must
+          // run them rather than declare the project up-to-date.
+          const {stdout} = await run(`install`, `--inline-builds`);
+
+          expect(stdout).toContain(`no-deps-scripted@npm:1.0.0 must be built because it never has been before`);
+
+          // Once the builds went through, the fast path resumes.
+          const {stdout: secondStdout} = await run(`install`);
+
+          expect(secondStdout).toContain(`All dependencies are up-to-date, nothing to do.`);
+        }),
+      );
+
+      test(
+        `it should run a full install when a workspace's node_modules was removed`,
+        makeTemporaryEnv(
+          {
+            private: true,
+            workspaces: [`ws`],
+            dependencies: {
+              [`no-deps`]: `2.0.0`,
+            },
+          },
+          {
+            nodeLinker: `node-modules`,
+          },
+          async ({path, run, source}) => {
+            await xfs.mkdirPromise(ppath.join(path, `ws`));
+            await xfs.writeJsonPromise(ppath.join(path, `ws/package.json`), {
+              name: `ws`,
+              dependencies: {
+                [`no-deps`]: `1.0.0`,
+              },
+            });
+
+            await run(`install`);
+
+            // The conflicting version nests inside the workspace's own
+            // node_modules; wiping that folder must not be masked by
+            // the fast path.
+            await expect(xfs.existsPromise(ppath.join(path, `ws/node_modules/no-deps` as PortablePath))).resolves.toEqual(true);
+
+            await xfs.removePromise(ppath.join(path, `ws/node_modules` as PortablePath));
+
+            await run(`install`);
+
+            await expect(xfs.existsPromise(ppath.join(path, `ws/node_modules/no-deps` as PortablePath))).resolves.toEqual(true);
+          },
+        ),
       );
 
       test(

--- a/tests/acceptance-tests/pkg-tests-specs/sources/commands/install.test.ts
+++ b/tests/acceptance-tests/pkg-tests-specs/sources/commands/install.test.ts
@@ -1,6 +1,8 @@
 import {Filename, xfs, ppath, npath} from '@yarnpkg/fslib';
 import {tests, misc}                 from 'pkg-tests-core';
 
+const {getPackageArchivePath} = tests;
+
 describe(`Commands`, () => {
   describe(`install`, () => {
     test(
@@ -1125,6 +1127,60 @@ describe(`Commands`, () => {
             await expect(source(`require('no-deps')`)).resolves.toEqual({name: `no-deps`, version: `1.0.0`});
           },
         ),
+      );
+
+      test(
+        `it should take the fast path when dependencies use registry aliases`,
+        makeTemporaryEnv({
+          dependencies: {
+            [`aliased`]: `npm:no-deps@1.0.0`,
+          },
+        }, async ({path, run, source}) => {
+          await run(`install`);
+
+          // Registry aliases are immutable; they must not disable the
+          // fast path. A corrupted artifact surviving the second
+          // install proves it was skipped.
+          const pnpPath = ppath.join(path, Filename.pnpCjs);
+          await xfs.writeFilePromise(pnpPath, `corrupted`);
+
+          await run(`install`);
+
+          await expect(xfs.readFilePromise(pnpPath, `utf8`)).resolves.toEqual(`corrupted`);
+        }),
+      );
+
+      test(
+        `it should take the fast path with file: tarballs until they change`,
+        makeTemporaryEnv({
+          dependencies: {
+            [`pkg`]: `file:./pkg.tgz`,
+          },
+        }, async ({path, run, source}) => {
+          const noDeps1 = await getPackageArchivePath(`no-deps`, `1.0.0`);
+          const noDeps2 = await getPackageArchivePath(`no-deps`, `2.0.0`);
+
+          const destination = ppath.join(path, `pkg.tgz`);
+
+          await xfs.copyPromise(destination, noDeps1);
+          await run(`install`);
+
+          const pnpPath = ppath.join(path, Filename.pnpCjs);
+          await xfs.writeFilePromise(pnpPath, `corrupted`);
+
+          // The tarball didn't change: fast path.
+          await run(`install`);
+          await expect(xfs.readFilePromise(pnpPath, `utf8`)).resolves.toEqual(`corrupted`);
+
+          // The tarball changed: full install.
+          await xfs.copyPromise(destination, noDeps2);
+          await run(`install`);
+
+          await expect(xfs.readFilePromise(pnpPath, `utf8`)).resolves.not.toEqual(`corrupted`);
+          await expect(source(`require('pkg/package.json')`)).resolves.toMatchObject({
+            version: `2.0.0`,
+          });
+        }),
       );
 
       test(

--- a/tests/acceptance-tests/pkg-tests-specs/sources/commands/install.test.ts
+++ b/tests/acceptance-tests/pkg-tests-specs/sources/commands/install.test.ts
@@ -998,5 +998,156 @@ describe(`Commands`, () => {
         await run(`install`);
       }),
     );
+
+    describe(`up-to-date fast path`, () => {
+      test(
+        `it should skip the install when nothing changed since the previous one`,
+        makeTemporaryEnv({
+          dependencies: {
+            [`no-deps`]: `1.0.0`,
+          },
+        }, async ({path, run, source}) => {
+          await run(`install`);
+
+          // The fast path doesn't validate artifact contents; a
+          // corrupted artifact surviving the second install proves the
+          // install was skipped.
+          const pnpPath = ppath.join(path, Filename.pnpCjs);
+          await xfs.writeFilePromise(pnpPath, `corrupted`);
+
+          await run(`install`);
+
+          await expect(xfs.readFilePromise(pnpPath, `utf8`)).resolves.toEqual(`corrupted`);
+        }),
+      );
+
+      test(
+        `it should run a full install when --force is set`,
+        makeTemporaryEnv({
+          dependencies: {
+            [`no-deps`]: `1.0.0`,
+          },
+        }, async ({path, run, source}) => {
+          await run(`install`);
+
+          const pnpPath = ppath.join(path, Filename.pnpCjs);
+          await xfs.writeFilePromise(pnpPath, `corrupted`);
+
+          await run(`install`, `--force`);
+
+          await expect(xfs.readFilePromise(pnpPath, `utf8`)).resolves.not.toEqual(`corrupted`);
+          await expect(source(`require('no-deps')`)).resolves.toEqual({name: `no-deps`, version: `1.0.0`});
+        }),
+      );
+
+      test(
+        `it should run a full install when the lockfile was modified out-of-band`,
+        makeTemporaryEnv({
+          dependencies: {
+            [`no-deps`]: `1.0.0`,
+          },
+        }, async ({path, run, source}) => {
+          await run(`install`);
+
+          const pnpPath = ppath.join(path, Filename.pnpCjs);
+          await xfs.writeFilePromise(pnpPath, `corrupted`);
+
+          // Only bump the lockfile mtime; its content is already correct.
+          const lockfilePath = ppath.join(path, Filename.lockfile);
+          const newTime = new Date(Date.now() + 5000);
+          await xfs.utimesPromise(lockfilePath, newTime, newTime);
+
+          await run(`install`);
+
+          await expect(xfs.readFilePromise(pnpPath, `utf8`)).resolves.not.toEqual(`corrupted`);
+        }),
+      );
+
+      test(
+        `it should run a full install when a workspace manifest changed`,
+        makeTemporaryEnv({
+          dependencies: {
+            [`no-deps`]: `1.0.0`,
+          },
+        }, async ({path, run, source}) => {
+          await run(`install`);
+
+          const pnpPath = ppath.join(path, Filename.pnpCjs);
+          await xfs.writeFilePromise(pnpPath, `corrupted`);
+
+          const manifestPath = ppath.join(path, Filename.manifest);
+          const newTime = new Date(Date.now() + 5000);
+          await xfs.utimesPromise(manifestPath, newTime, newTime);
+
+          await run(`install`);
+
+          await expect(xfs.readFilePromise(pnpPath, `utf8`)).resolves.not.toEqual(`corrupted`);
+        }),
+      );
+
+      test(
+        `it should run a full install when the linker artifacts are missing`,
+        makeTemporaryEnv({
+          dependencies: {
+            [`no-deps`]: `1.0.0`,
+          },
+        }, async ({path, run, source}) => {
+          await run(`install`);
+
+          const pnpPath = ppath.join(path, Filename.pnpCjs);
+          await xfs.removePromise(pnpPath);
+
+          await run(`install`);
+
+          await expect(xfs.existsPromise(pnpPath)).resolves.toEqual(true);
+          await expect(source(`require('no-deps')`)).resolves.toEqual({name: `no-deps`, version: `1.0.0`});
+        }),
+      );
+
+      test(
+        `it should run a full install when node_modules was removed`,
+        makeTemporaryEnv(
+          {
+            dependencies: {
+              [`no-deps`]: `1.0.0`,
+            },
+          },
+          {
+            nodeLinker: `node-modules`,
+          },
+          async ({path, run, source}) => {
+            await run(`install`);
+
+            await xfs.removePromise(ppath.join(path, Filename.nodeModules));
+
+            await run(`install`);
+
+            await expect(source(`require('no-deps')`)).resolves.toEqual({name: `no-deps`, version: `1.0.0`});
+          },
+        ),
+      );
+
+      test(
+        `it should run a full install when the configuration changed`,
+        makeTemporaryEnv({
+          dependencies: {
+            [`no-deps`]: `1.0.0`,
+          },
+        }, async ({path, run, source}) => {
+          await run(`install`);
+
+          const pnpPath = ppath.join(path, Filename.pnpCjs);
+          await xfs.writeFilePromise(pnpPath, `corrupted`);
+
+          await run(`install`, {
+            env: {
+              YARN_ENABLE_TIMERS: `true`,
+            },
+          });
+
+          await expect(xfs.readFilePromise(pnpPath, `utf8`)).resolves.not.toEqual(`corrupted`);
+        }),
+      );
+    });
   });
 });

--- a/tests/acceptance-tests/pkg-tests-specs/sources/commands/install.test.ts
+++ b/tests/acceptance-tests/pkg-tests-specs/sources/commands/install.test.ts
@@ -1017,8 +1017,9 @@ describe(`Commands`, () => {
           const pnpPath = ppath.join(path, Filename.pnpCjs);
           await xfs.writeFilePromise(pnpPath, `corrupted`);
 
-          await run(`install`);
+          const {stdout} = await run(`install`);
 
+          expect(stdout).toContain(`All dependencies are up-to-date, nothing to do. Run with \`--force\` to ignore this check.`);
           await expect(xfs.readFilePromise(pnpPath, `utf8`)).resolves.toEqual(`corrupted`);
         }),
       );

--- a/tests/acceptance-tests/pkg-tests-specs/sources/features/contentAddressedIndex.test.ts
+++ b/tests/acceptance-tests/pkg-tests-specs/sources/features/contentAddressedIndex.test.ts
@@ -107,7 +107,9 @@ describe(`Features`, () => {
 
         await xfs.writeFilePromise(referenceFile, newContent);
 
-        await run(`install`);
+        // Repairing damage inside node_modules needs --force (the
+        // default in interactive terminals).
+        await run(`install`, `--force`);
 
         await expect(xfs.readFilePromise(referenceFile, `utf8`)).resolves.toEqual(originalContent);
       }),
@@ -141,7 +143,9 @@ describe(`Features`, () => {
 
           await xfs.writeFilePromise(referenceFileA, newContent);
 
-          await run(`install`, {cwd: path});
+          // Repairing damage inside node_modules needs --force (the
+          // default in interactive terminals).
+          await run(`install`, `--force`, {cwd: path});
 
           await expect(xfs.readFilePromise(referenceFileA, `utf8`)).resolves.toEqual(originalContent);
           await expect(xfs.readFilePromise(referenceFileB, `utf8`)).resolves.toEqual(originalContent);

--- a/tests/acceptance-tests/pkg-tests-specs/sources/features/localMirror.test.js
+++ b/tests/acceptance-tests/pkg-tests-specs/sources/features/localMirror.test.js
@@ -25,7 +25,11 @@ describe(`Features`, () => {
     }, async ({path, run, source}) => {
       await run(`install`);
       await xfs.removePromise(`${path}/.yarn/global/cache`);
-      await run(`install`);
+
+      // A plain up-to-date install would be skipped and wouldn't
+      // recreate the mirror folder; the assertion is about what a real
+      // install pass stores in it.
+      await run(`install`, `--force`);
 
       const fileCount = (await xfs.readdirPromise(`${path}/.yarn/global/cache`)).length;
       expect(fileCount).toEqual(0);

--- a/tests/acceptance-tests/pkg-tests-specs/sources/features/otel.test.ts
+++ b/tests/acceptance-tests/pkg-tests-specs/sources/features/otel.test.ts
@@ -199,7 +199,9 @@ describe(`Features`, () => {
         ]);
 
         const hotRecording = await startRegistryRecording(async () => {
-          await run(`install`, {env});
+          // A plain up-to-date install takes the fast path and emits no
+          // spans; the hot expectations describe a full install pass.
+          await run(`install`, `--force`, {env});
         });
 
         const hotPayload = getOtelPayload(hotRecording);

--- a/tests/acceptance-tests/pkg-tests-specs/sources/node-modules.test.ts
+++ b/tests/acceptance-tests/pkg-tests-specs/sources/node-modules.test.ts
@@ -2442,6 +2442,41 @@ describe(`Node Modules`, () => {
       ),
     );
 
+    testIf(
+      () => process.platform === `darwin`,
+      `should materialize packages from the unpacked store via clonefile`,
+      makeTemporaryEnv(
+        {
+          dependencies: {
+            [`no-deps`]: `1.0.0`,
+          },
+        },
+        {
+          nodeLinker: `node-modules`,
+        },
+        async ({path, run, source}) => {
+          await run(`install`);
+
+          // The unpacked store should hold a pristine copy of the
+          // package, keyed by locator and checksum.
+          const storePath = ppath.join(path, `.yarn/global/unpacked` as PortablePath);
+          const storeEntries = await xfs.readdirPromise(storePath);
+          expect(storeEntries.some(entry => entry.startsWith(`no-deps-npm-1.0.0-`))).toBe(true);
+
+          // A reinstall into an empty node_modules goes through the
+          // clone path and must produce a working package.
+          await xfs.removePromise(ppath.join(path, Filename.nodeModules));
+          await touchManifest(path);
+          await run(`install`);
+
+          await expect(source(`require('no-deps')`)).resolves.toEqual({
+            name: `no-deps`,
+            version: `1.0.0`,
+          });
+        },
+      ),
+    );
+
     it(`should leave unchanged packages untouched in hardlink modes`,
       makeTemporaryEnv(
         {

--- a/tests/acceptance-tests/pkg-tests-specs/sources/node-modules.test.ts
+++ b/tests/acceptance-tests/pkg-tests-specs/sources/node-modules.test.ts
@@ -154,7 +154,9 @@ describe(`Node Modules`, () => {
 
         await writeFile(npath.toPortablePath(`${path}/dist/bin/index.js`), ``);
 
-        await expect(run(`install`)).resolves.toBeTruthy();
+        // The bin target appeared without any manifest change, so this
+        // repair needs --force (the default in interactive terminals).
+        await expect(run(`install`, `--force`)).resolves.toBeTruthy();
         const stats = await xfs.lstatPromise(npath.toPortablePath(`${path}/node_modules/.bin/pkg`));
 
         expect(stats).toBeDefined();
@@ -1910,7 +1912,9 @@ describe(`Node Modules`, () => {
         await run(`install`);
         await xfs.removePromise(`${path}/node_modules/one-dep-scripted` as PortablePath);
 
-        const {stdout} = await run(`install`);
+        // Repairing damage inside node_modules needs --force (the
+        // default in interactive terminals).
+        const {stdout} = await run(`install`, `--force`);
 
         // Yarn must reinstall and rebuild only the removed package
         expect(stdout).not.toMatch(new RegExp(`no-deps-scripted@npm:1.0.0 must be built`));
@@ -1991,7 +1995,10 @@ describe(`Node Modules`, () => {
       async ({path, run}) => {
         await run(`install`);
         await xfs.removePromise(`${path}/node_modules/has-bin-entries` as PortablePath);
-        await run(`install`);
+
+        // Repairing damage inside node_modules needs --force (the
+        // default in interactive terminals).
+        await run(`install`, `--force`);
         const {mode} = await xfs.lstatPromise(npath.toPortablePath(`${path}/node_modules/has-bin-entries/bin.js`));
         const permissions = (mode & 0o777).toString(8);
         expect(permissions).toBe(process.platform === `win32` ? `666` : `755`);

--- a/tests/acceptance-tests/pkg-tests-specs/sources/node-modules.test.ts
+++ b/tests/acceptance-tests/pkg-tests-specs/sources/node-modules.test.ts
@@ -2250,4 +2250,226 @@ describe(`Node Modules`, () => {
       },
     ),
   );
+
+  describe(`incremental linking`, () => {
+    // Bumps the manifest mtime so the install isn't skipped wholesale
+    // by the up-to-date fast path; the linker still runs and gets to
+    // make its own per-package decisions.
+    const touchManifest = async (path: PortablePath) => {
+      const newTime = new Date(Date.now() + 5000);
+      await xfs.utimesPromise(ppath.join(path, Filename.manifest), newTime, newTime);
+    };
+
+    it(`should leave unchanged packages untouched on subsequent installs`,
+      makeTemporaryEnv(
+        {
+          dependencies: {
+            [`no-deps`]: `1.0.0`,
+          },
+        },
+        {
+          nodeLinker: `node-modules`,
+        },
+        async ({path, run}) => {
+          await run(`install`);
+
+          const indexPath = ppath.join(path, `node_modules/no-deps/index.js` as PortablePath);
+          await xfs.writeFilePromise(indexPath, `corrupted`);
+
+          await touchManifest(path);
+          await run(`install`);
+
+          // The package's plan didn't change, so its folder must not
+          // have been re-extracted.
+          await expect(xfs.readFilePromise(indexPath, `utf8`)).resolves.toEqual(`corrupted`);
+        },
+      ),
+    );
+
+    it(`should rewrite packages when --force is set`,
+      makeTemporaryEnv(
+        {
+          dependencies: {
+            [`no-deps`]: `1.0.0`,
+          },
+        },
+        {
+          nodeLinker: `node-modules`,
+        },
+        async ({path, run}) => {
+          await run(`install`);
+
+          const indexPath = ppath.join(path, `node_modules/no-deps/index.js` as PortablePath);
+          await xfs.writeFilePromise(indexPath, `corrupted`);
+
+          await run(`install`, `--force`);
+
+          await expect(xfs.readFilePromise(indexPath, `utf8`)).resolves.not.toEqual(`corrupted`);
+        },
+      ),
+    );
+
+    it(`should rewrite packages when their resolution changes`,
+      makeTemporaryEnv(
+        {
+          dependencies: {
+            [`no-deps`]: `1.0.0`,
+          },
+        },
+        {
+          nodeLinker: `node-modules`,
+        },
+        async ({path, run}) => {
+          await run(`install`);
+
+          const indexPath = ppath.join(path, `node_modules/no-deps/index.js` as PortablePath);
+          await xfs.writeFilePromise(indexPath, `corrupted`);
+
+          await xfs.writeJsonPromise(ppath.join(path, Filename.manifest), {
+            dependencies: {
+              [`no-deps`]: `2.0.0`,
+            },
+          });
+
+          await run(`install`);
+
+          await expect(xfs.readFilePromise(indexPath, `utf8`)).resolves.not.toEqual(`corrupted`);
+          await expect(xfs.readJsonPromise(ppath.join(path, `node_modules/no-deps/package.json` as PortablePath))).resolves.toMatchObject({
+            version: `2.0.0`,
+          });
+        },
+      ),
+    );
+
+    it(`should still prune removed packages`,
+      makeTemporaryEnv(
+        {
+          dependencies: {
+            [`no-deps`]: `1.0.0`,
+            [`has-bin-entries`]: `1.0.0`,
+          },
+        },
+        {
+          nodeLinker: `node-modules`,
+        },
+        async ({path, run}) => {
+          await run(`install`);
+
+          await xfs.writeJsonPromise(ppath.join(path, Filename.manifest), {
+            dependencies: {
+              [`no-deps`]: `1.0.0`,
+            },
+          });
+
+          await run(`install`);
+
+          await expect(xfs.existsPromise(ppath.join(path, `node_modules/has-bin-entries` as PortablePath))).resolves.toEqual(false);
+          await expect(xfs.existsPromise(ppath.join(path, `node_modules/no-deps/index.js` as PortablePath))).resolves.toEqual(true);
+        },
+      ),
+    );
+
+    it(`should re-extract packages whose folder went missing`,
+      makeTemporaryEnv(
+        {
+          dependencies: {
+            [`no-deps`]: `1.0.0`,
+          },
+        },
+        {
+          nodeLinker: `node-modules`,
+        },
+        async ({path, run}) => {
+          await run(`install`);
+
+          await xfs.removePromise(ppath.join(path, `node_modules/no-deps` as PortablePath));
+
+          await touchManifest(path);
+          await run(`install`);
+
+          await expect(xfs.existsPromise(ppath.join(path, `node_modules/no-deps/package.json` as PortablePath))).resolves.toEqual(true);
+        },
+      ),
+    );
+
+    it(`should not skip packages that host nested packages`,
+      makeTemporaryEnv(
+        {
+          dependencies: {
+            [`no-deps`]: `2.0.0`,
+            [`one-fixed-dep`]: `1.0.0`,
+          },
+        },
+        {
+          nodeLinker: `node-modules`,
+        },
+        async ({path, run}) => {
+          await run(`install`);
+
+          // one-fixed-dep needs no-deps@1.0.0, which conflicts with the
+          // hoisted no-deps@2.0.0 and thus nests inside its folder.
+          await expect(xfs.existsPromise(ppath.join(path, `node_modules/one-fixed-dep/node_modules/no-deps` as PortablePath))).resolves.toEqual(true);
+
+          const indexPath = ppath.join(path, `node_modules/one-fixed-dep/index.js` as PortablePath);
+          await xfs.writeFilePromise(indexPath, `corrupted`);
+
+          await touchManifest(path);
+          await run(`install`);
+
+          await expect(xfs.readFilePromise(indexPath, `utf8`)).resolves.not.toEqual(`corrupted`);
+        },
+      ),
+    );
+
+    it(`should record the source of each package in the package map`,
+      makeTemporaryEnv(
+        {
+          dependencies: {
+            [`no-deps`]: `1.0.0`,
+          },
+        },
+        {
+          nodeLinker: `node-modules`,
+        },
+        async ({path, run}) => {
+          await run(`install`);
+
+          const packageMap = await xfs.readJsonPromise(ppath.join(path, `node_modules/.package-map.json` as PortablePath));
+
+          expect(packageMap.packages[`no-deps`].locator).toContain(`no-deps`);
+          expect(packageMap.packages[`no-deps`].checksum).toBeDefined();
+        },
+      ),
+    );
+
+    it(`should leave unchanged packages untouched in hardlink modes`,
+      makeTemporaryEnv(
+        {
+          dependencies: {
+            [`no-deps`]: `1.0.0`,
+          },
+        },
+        {
+          nodeLinker: `node-modules`,
+          nmMode: `hardlinks-local`,
+        },
+        async ({path, run}) => {
+          await run(`install`);
+
+          const indexPath = ppath.join(path, `node_modules/no-deps/index.js` as PortablePath);
+          await xfs.removePromise(indexPath);
+          await xfs.writeFilePromise(indexPath, `corrupted`);
+
+          await touchManifest(path);
+          await run(`install`);
+
+          await expect(xfs.readFilePromise(indexPath, `utf8`)).resolves.toEqual(`corrupted`);
+
+          await run(`install`, `--force`);
+
+          await expect(xfs.readFilePromise(indexPath, `utf8`)).resolves.not.toEqual(`corrupted`);
+        },
+      ),
+    );
+  });
 });


### PR DESCRIPTION
This PR closes most of the gap surfaced by benchmarks in the scenarios where an install runs over existing state (no-op installs and node_modules-present reinstalls), and speeds up cold links along the way.

## Changes

**Up-to-date fast path.** `yarn install` returns early when the previous install is provably still current: fresh install state, unchanged config hash and manifests (mtime-tracked), untouched lockfile (mtime recorded in the install state), linker artifacts still on disk, and — for transient ranges — unchanged content. A new `-f,--force` flag bypasses the check; it defaults to **on in interactive terminals** so a manually damaged project still heals when a user reaches for `yarn install`, and off in CI/scripts. Skipped installs report themselves:

```
➤ · Yarn 6.0.0-rc.19.local
➤ · All dependencies are up-to-date, nothing to do. Run with --force to ignore this check.
```

**Transient ranges are re-derived, not blocked.** Instead of disabling the fast path whenever the project uses local sources, the guard re-derives the exact content hashes the resolvers embed in their locators — tarball bytes, exec script bytes, packed `file:` folders, patch files — and compares them with the recorded resolutions. Registry-backed ranges (including `npm:` aliases) are immutable and never checked. `Reference::Portal` now embeds a hash of its target's manifest so portals participate in the same comparison; existing lockfiles migrate on their next real install. Installs that fail their build or constraints step drop the freshness marker, and the binary version is mixed into the config hash so every Yarn upgrade runs one full install.

**Incremental node_modules linking.** `.package-map.json` now records the locator and archive checksum each location was materialized from. The linker diffs that against the new install plan and leaves matching folders entirely alone — no zip read, no byte-per-byte comparison — instead of re-extracting and diffing every package on every install. Skipping requires the folder to exist, the locator+checksum to match, and no nested packages in either layout; `--force` and `nmMode` transitions disable it.

**Parallel extraction.** `SyncTree::run` processes tree levels on the rayon pool (parents still precede children), per-workspace trees run concurrently, CAS extractions are parallelized behind sharded content locks, and the link step moved behind `block_in_place` so it stops starving its tokio worker.

**Clonefile materialization.** Installs maintain an unpacked store under `<globalFolder>/unpacked`, keyed by locator + checksum, and materialize fresh package folders as copy-on-write clones (one `clonefile` syscall per package on macOS/APFS; probed once, with per-clone fallback to regular extraction). Only fresh folders clone — in-place reconcile keeps folder inodes stable for file watchers. Store entries are immutable, built via temp-dir + rename so parallel installs race safely.

## Benchmarks

Next.js fixture, node-modules linker, vs `main`:

| Scenario | main | this PR |
|---|---|---|
| No-op install | 369ms | **10ms** |
| No-op install (PnP linker) | 165ms | **10ms** |
| Reinstall after manifest touch | 370ms | **135ms** |
| Reinstall after install-state loss | 518ms | **175ms** |
| Link into empty node_modules (store warm) | 1.07s | **361ms** |
| Same, first install on machine (store cold) | 869ms | 977ms (one-time store fill) |

On this repository itself, `yarn --no-force` runs in ~26ms, stays fast across a content-preserving rebuild of `scripts/@clipanion-tools.tgz`, and correctly triggers exactly one full pass when the tarball's content changes.

## Behavior notes

- Repairing manual damage *inside* `node_modules` (deleted files within a package folder) now requires `--force` — which interactive runs pass by default. Wholesale deletions (`node_modules`, a package folder, `.yarn/unplugged`) are still detected and healed by plain installs.
- ~10 acceptance tests that relied on plain installs repairing manual damage now pass `--force` explicitly; 24 new tests cover the fast path (aliases, tarballs, folders, portals, lockfile edits, config changes), incremental linking, and clonefile materialization.
- Skipped installs emit no OTel spans; the hot-install span expectations in the otel test use `--force`.

## Follow-ups (not in this PR)

- `<globalFolder>/unpacked` is append-only; `yarn cache clean` should learn to prune it (same policy could cover the hardlink `index` sibling).
- The PnP unplugged path could reuse the clone helper for its extractions.

Full acceptance suite is at exact parity with `main` (the only failures are the 15 pre-existing venv/lazy-install/typescript-plugin ones, identical on both branches).


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches install correctness (freshness markers, lockfile ordering, portal locators), filesystem linking (parallel CAS, clonefile, assume-up-to-date folders), and default `--force` behavior in interactive terminals.
> 
> **Overview**
> **Install can exit immediately** when `is_install_up_to_date()` passes (install state, config hash including Yarn version, lockfile mtime in state, linker artifacts, transient source re-hashes). `yarn install` adds **`-f,--force`** (default on in TTY) to bypass; failed builds/constraints clear `lockfile_changed_at` so the fast path cannot lie.
> 
> **Incremental `node_modules` linking** persists locator + checksum in `.package-map.json`, skips zip expansion via `SyncItem::Folder { assume_up_to_date }`, and disables incremental work on `--force` or `nmMode` transitions. **Parallel I/O**: `SyncTree::run` and per-workspace trees use rayon; CAS/local dedup use sharded locks; nm link runs under `block_in_place`.
> 
> **Classic nm on macOS** can materialize fresh leaf packages from a global **unpacked store** using **`fs_clonefile`** (with probe + extract fallback). **Portals** gain optional manifest hashes in `Reference::Portal` for resolution and freshness checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f23bec7564c52570884db9773556323b3d7c8172. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->