### PR TITLE
feat: add YARNSW_CACHE_PATH environment variable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5375,6 +5375,7 @@ dependencies = [
  "futures",
  "libc",
  "open",
+ "predicates",
  "regex",
  "reqwest 0.12.28",
  "rkyv",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,6 +119,7 @@ winnow = "0.7"
 url = "2.5.7"
 urlencoding = "2.1.3"
 zerocopy = { version = "0.8.33", features = ["derive"] }
+predicates = { version = "3.1.4", default-features = false, features = ["diff"] }
 
 [workspace.metadata.cargo-shear]
 ignored = ["zpm-semver", "zpm-switch"]

--- a/packages/zpm-switch/Cargo.toml
+++ b/packages/zpm-switch/Cargo.toml
@@ -43,3 +43,4 @@ reqwest = { workspace = true, default-features = false, features = ["rustls-tls"
 
 [dev-dependencies]
 assert_cmd = { workspace = true }
+predicates = { workspace = true, default-features = false, features = ["diff"] }

--- a/packages/zpm-switch/src/cache.rs
+++ b/packages/zpm-switch/src/cache.rs
@@ -47,6 +47,16 @@ impl CacheKey {
 }
 
 pub fn cache_dir() -> Result<Path, Error> {
+    if let Ok(cache_dir) = std::env::var("YARNSW_CACHE_PATH") {
+        let cache_dir = Path::try_from(cache_dir)?;
+
+        if !cache_dir.is_absolute() {
+            return Err(Error::CachePathNotAbsolute(cache_dir));
+        }
+
+        return Ok(cache_dir);
+    }
+
     let cache_dir = Path::home_dir()?
         .ok_or(Error::MissingHomeFolder)?
         .with_join_str(".yarn/switch/cache");

--- a/packages/zpm-switch/src/errors.rs
+++ b/packages/zpm-switch/src/errors.rs
@@ -128,6 +128,9 @@ pub enum Error {
 
     #[error("Failed to write to socket: {0}")]
     SocketWriteError(Arc<std::io::Error>),
+
+    #[error("Cache path must be absolute but got {path}", path = .0.to_print_string())]
+    CachePathNotAbsolute(Path),
 }
 
 impl From<std::str::Utf8Error> for Error {

--- a/packages/zpm-switch/tests/cache.rs
+++ b/packages/zpm-switch/tests/cache.rs
@@ -1,0 +1,40 @@
+use assert_cmd::prelude::*; // Add methods on commands
+use predicates::prelude::*; // Add predicates for use in assertions
+use zpm_utils::Path; // Used for writing assertions
+use std::process::Command; // Run programs
+
+#[test]
+fn list_cache() -> Result<(), Box<dyn std::error::Error>> {
+    let mut cache_path = Path::current_dir()?;
+    cache_path.join_str("./tests/fixtures/cache");
+
+    let mut cmd
+        = Command::cargo_bin("yarn")
+            .expect("Failed to get yarn command");
+    cmd
+            .env("YARNSW_CACHE_PATH", cache_path.as_str())
+            .args(vec!["switch", "cache"]);
+
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("6.0.0-test"))
+        .stdout(predicate::str::contains("b1069c168e09d6e327b9cb88fb86bf52"));
+
+    Ok(())
+}
+
+#[test]
+fn fails_with_relative_cache_path() -> Result<(), Box<dyn std::error::Error>> {
+    let mut cmd
+        = Command::cargo_bin("yarn")
+            .expect("Failed to get yarn command");
+    cmd
+            .env("YARNSW_CACHE_PATH", "tests/fixtures/cache")
+            .args(vec!["switch", "cache"]);
+
+    cmd.assert()
+        .failure()
+        .stdout(predicate::str::contains("Error: Cache path must be absolute but got tests/fixtures/cache"));
+
+    Ok(())
+}

--- a/packages/zpm-switch/tests/fixtures/cache/b1069c168e09d6e327b9cb88fb86bf52/meta.json
+++ b/packages/zpm-switch/tests/fixtures/cache/b1069c168e09d6e327b9cb88fb86bf52/meta.json
@@ -1,0 +1,5 @@
+{
+  "cacheVersion": 2,
+  "version": "6.0.0-test",
+  "platform": "unused-in-this-test"
+}


### PR DESCRIPTION
Fixes #316

Given the number of environment variables that can be used to configured yarn switch it's probably useful to start documenting these somewhere? I'm not sure whether to add an extra webpage or to use one of the existing pages, some guidance would be helpful.